### PR TITLE
Add Threads view to Journalists

### DIFF
--- a/journalist.py
+++ b/journalist.py
@@ -160,7 +160,7 @@ def main(args):
         sender = args.thread
         messages = jdb.select_messages(sender)
         for message in messages:
-            print(f'{message[0]}: {message[1]}')
+            print(f'[{message[0]}]: {message[1]}')
 
     elif args.action == "reply":
         message_id = args.id

--- a/journalist.py
+++ b/journalist.py
@@ -8,9 +8,11 @@ from time import time
 import nacl.secret
 import requests
 from ecdsa import SigningKey
+from hashlib import sha3_256
 
 import commons
 import pki
+import journalist_db
 
 
 def add_ephemeral_keys(journalist_key, journalist_id, journalist_uid):
@@ -84,6 +86,7 @@ def main(args):
     assert (journalist_id >= 0 and journalist_id < commons.JOURNALISTS)
 
     journalist_uid, journalist_sig, journalist_key, journalist_chal_sig, journalist_chal_key = pki.load_and_verify_journalist_keypair(journalist_id)
+    jdb = journalist_db.JournalistDatabase('files/.jdb.sqlite3')
 
     if args.action == "upload_keys":
         journalist_uid = commons.add_journalist(journalist_key, journalist_sig, journalist_chal_key, journalist_chal_sig)
@@ -126,10 +129,11 @@ def main(args):
             else:
                 message_plaintext["attachments"] = []
 
+            sender = sha3_256(message_plaintext['source_encryption_public_key'].encode("ascii")).hexdigest()
             print(f"[+] Successfully decrypted message {message_id}")
             print()
             print(f"\tID: {message_id}")
-            # print(f"\tFrom: {message_plaintext['sender']}")
+            print(f"\tFrom: {sender}")
             print(f"\tDate: {datetime.fromtimestamp(message_plaintext['timestamp'])}")
             for attachment in message_plaintext["attachments"]:
                 print(f"\tAttachment: name={attachment['name']};size={attachment['size']};parts_count={attachment['parts_count']}")
@@ -150,6 +154,13 @@ def main(args):
 
             print(f"\tText: {message_plaintext['message']}")
             print()
+            jdb.insert_message(sender, datetime.fromtimestamp(message_plaintext['timestamp']), message_plaintext['message'])
+
+    elif args.action == "thread":
+        sender = args.thread
+        messages = jdb.select_messages(sender)
+        for message in messages:
+            print(f'{message[0]}: {message[1]}')
 
     elif args.action == "reply":
         message_id = args.id
@@ -168,8 +179,9 @@ def main(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("-j", "--journalist", help="Journalist number", type=int, choices=range(0, commons.JOURNALISTS), metavar=f"[0, {commons.JOURNALISTS - 1}]", required=True)
-    parser.add_argument("-a", "--action", help="Action to perform", default="fetch", choices=["upload_keys", "fetch", "read", "reply", "delete"])
+    parser.add_argument("-a", "--action", help="Action to perform", default="fetch", choices=["upload_keys", "fetch", "read", "reply", "delete", "thread"])
     parser.add_argument("-i", "--id", help="Message id")
+    parser.add_argument("-t", "--thread", help="Thread id")
     parser.add_argument("-m", "--message", help="Plaintext message content for replies")
     args = parser.parse_args()
     main(args)

--- a/journalist_db.py
+++ b/journalist_db.py
@@ -1,0 +1,43 @@
+import os
+import sqlite3
+
+class JournalistDatabase():
+
+    def __init__(self, path):
+        self.path = path
+        self.is_valid = os.path.isfile(self.path)
+        self.con = sqlite3.connect(self.path)
+        if self.is_valid == False:
+            try:
+                self.create()
+            except sqlite3.OperationalError:
+                pass
+
+    def __del__(self):
+        self.con.close()
+
+    def create(self):
+        cur = self.con.cursor()
+        cur.execute("CREATE TABLE messages (sender TEXT NOT NULL, timestamp TEXT NOT NULL, content TEXT NOT NULL);")
+        self.con.commit()
+
+    def select_messages(self, sender):
+        cur = self.con.cursor()
+        cur.execute("SELECT timestamp, content FROM messages WHERE sender = ? ORDER BY timestamp;", (sender,))
+        rows = cur.fetchall()
+        messages = rows if len(rows) > 0 else []
+        self.con.commit()
+        return messages
+
+    def insert_message(self, sender, timestamp, content):
+        cur = self.con.cursor()
+        cur.execute("INSERT INTO messages (sender, timestamp, content) VALUES (?,?,?);", (sender, timestamp, content))
+        self.con.commit()
+        return cur.lastrowid
+
+    """
+    def delete_message(self, message_id):
+        cur = self.con.cursor()
+        cur.execute("DELETE FROM messages WHERE message_id = ?;", message_id)
+        self.con.commit()
+    """

--- a/server.py
+++ b/server.py
@@ -212,7 +212,7 @@ def get_messages_challenge():
     response_dict = {"status": "OK",
                      "count": len(message_server_challenges),
                      "challenge_id": challenge_id,
-                     "message_challenges": message_server_challengesWW}
+                     "message_challenges": message_server_challenges}
     return response_dict, 200
 
 

--- a/source.py
+++ b/source.py
@@ -118,20 +118,20 @@ def main(args):
             print("[-] There are no messages")
             print()
 
-    elif args.passphrase and args.action in ["read", "reply"]:
+    elif args.passphrase and args.action == "read":
         if not args.id:
             print("[-] Please specify a message id using -i")
             return -1
 
         passphrase = bytes.fromhex(args.passphrase)
+        source_key = derive_key(passphrase, "source_key-")
         message_id = args.id
         message = commons.get_message(message_id)
-        source_key = derive_key(passphrase, "source_key-")
         message_plaintext = commons.decrypt_message_ciphertext(source_key,
                                                                message["message_public_key"],
                                                                message["message_ciphertext"])
 
-        if args.action == "read" and message_plaintext:
+        if message_plaintext:
             print(f"[+] Successfully decrypted message {message_id}")
             print()
             print(f"\tID: {message_id}")
@@ -140,11 +140,12 @@ def main(args):
             print(f"\tText: {message_plaintext['message']}")
             print()
 
-        elif args.action == "reply":
-            if not args.message:
-                print("[-] Please specify a text message using -m")
-                return -1
-            send_submission(intermediate_verifying_key, passphrase, args.message, None)
+    elif args.passphrase and args.action == "reply":
+        passphrase = bytes.fromhex(args.passphrase)
+        if not args.message:
+            print("[-] Please specify a text message using -m")
+            return -1
+        send_submission(intermediate_verifying_key, passphrase, args.message, None)
 
     elif args.action == "delete":
         message_id = args.id


### PR DESCRIPTION
This PR:
- fixes a minor typo in the server.py file
- allow sources to reply to a submission even if no journalist has replied (we can so why not?)
- adds threads view to Journalist CLI.

----

For the thread view:
Fetch and Read are still done manually and each phase is a separate CLI command.
This is done to keep each "core" action separated.

In order to use the thread functionality, with a pre-existing Journalist-Server-Source setup do the following:
1. Send a message as a Source:
   `python3 source.py -a submit -m "My first message :)"`
2. Take note of the submission id in the terminal (ex. `[+] New submission passphrase: a833224b4d2e9a093e58977f22703184c07ccbab7429aa8b1ecd6cc296e31122`)
3. Send another message (reply) within the same submission:
   `python3 source.py -a reply -m "My second message, can you read me?" -p a833224b4d2e9a093e58977f22703184c07ccbab7429aa8b1ecd6cc296e31122`
4. From a Journalist, fetch available messages:
   `python3 journalist.py -j 7 -a fetch`
5. For every new message, perform a read:
   `python3 journalist.py -j 7 -a read -i 7def4ae794a81d470000ba79d47850dbf16ad8734a070ee02401d7388d4fe669`
   `python3 journalist.py -j 7 -a read -i a294b12f946f2f3406db38e406ca87369258090e9b335374afd7840234d8c046`
6. Take note of the "**From**" field id
7. Display the thread from that specific sender:
   `python3 journalist.py -j 7 -a thread -t 0e225efd8d312be58fadca97a0347b574e0c38f3f20e6065ef569fdad114cb5a`

Final result:
![image](https://user-images.githubusercontent.com/686894/215124906-f4ec3e96-15b5-438e-bc30-4d0223fe47d8.png)

----

Technical info:
When a Journalist receives a message, take the source long-term public key and performs a SHA3 hash to derive a "source id".  This "source id" is then used to store messages inside a Journalist local sqlite3 database.

NB: this is a basic source designation just to make the PoC work, an actual source designation is out-of-scope of the current PoC.