### PR TITLE
Treat messages and metadata as attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ In `commons.py` there are the following configuration values which are global fo
 |---|---|---|---|
 | `SERVER` | `127.0.0.1:5000` | source, journalist | The URL the Flask server listens on; used by both the journalist and the source clients. |
 | `DIR` | `keys/` | server, source, journalist | The folder where everybody will load the keys from. There is no separation for demo simplicity of course in an actual implementation, everybody will only have their keys and the required public one to ensure the trust chain. |
-| `UPLOADS` | `files/` | server | The folder where the Flask server will store uploaded files
+| `UPLOADS` | `files/` | server | The folder where the Flask server will store uploaded files. |
+| `DOWNLOADS` | `downloads/` | journalist | The folder where submission attachments will be saved. |
 | `JOURNALISTS` | `10` | server, source |  How many journalists do we create and enroll. In general, this is realistic, in current SecureDrop usage it is way less. For demo purposes everybody knows it, in a real scenario it would not be needed. |
 | `ONETIMEKEYS` | `30` | journalist | How many ephemeral keys each journalist create, sign and uploads when required. |
 | `CURVE` | `NIST384p` | server, source, journalist | The curve for all elliptic curve operations. It must be imported first from the python-ecdsa library. Ed25519 and Ed448, although supported by the lib, are not fully implemented. |

--- a/journalist_db.py
+++ b/journalist_db.py
@@ -1,13 +1,14 @@
 import os
 import sqlite3
 
+
 class JournalistDatabase():
 
     def __init__(self, path):
         self.path = path
         self.is_valid = os.path.isfile(self.path)
         self.con = sqlite3.connect(self.path)
-        if self.is_valid == False:
+        if self.is_valid is False:
             try:
                 self.create()
             except sqlite3.OperationalError:


### PR DESCRIPTION
Following @eaon suggestion, this PR treats messages and metadata as attachments in the following way:

From the source side:
 - A random key is generated
 - Message _m_ is encrypted using `nacl.SecretBox`
 - Encrypted message _m_ is uploaded through the `/file` endpoint
 - Source sends the `file_id` and the encryption key to every journalist

Basically instead of sending the message and the metadata duplicated, padded and encrypted for every journalist we just send the retrieval information in an encrypted form. The same happens when communicating in the opposite direction.

Open questions:
 - Does this worsen pattern behavior and helps linking fetching? Ie every journalist reading the same message will fetch the same attachment. However this was the case even before with attachments so I do not see this worsening it; we have to add decoys/countermeasures anyway.


TODO:
Readme changes will come in the next commits.