### PR TITLE
Ephemeral Keys in replies (journalist to source)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ In `commons.py` there are the following configuration values which are global fo
 |---|---|---|---|
 | `SERVER` | `127.0.0.1:5000` | source, journalist | The URL the Flask server listens on; used by both the journalist and the source clients. |
 | `DIR` | `keys/` | server, source, journalist | The folder where everybody will load the keys from. There is no separation for demo simplicity of course in an actual implementation, everybody will only have their keys and the required public one to ensure the trust chain. |
-| `UPLOADS` | `files/` | server | The folder where the Flask server will store uploaded files
+| `UPLOADS` | `files/` | server | The folder where the Flask server will store uploaded files. |
+| `DOWNLOADS` | `downloads/` | journalist | The folder where submission attachments will be saved. |
 | `JOURNALISTS` | `10` | server, source |  How many journalists do we create and enroll. In general, this is realistic, in current SecureDrop usage it is way less. For demo purposes everybody knows it, in a real scenario it would not be needed. |
 | `ONETIMEKEYS` | `30` | journalist | How many ephemeral keys each journalist create, sign and uploads when required. |
 | `CURVE` | `NIST384p` | server, source, journalist | The curve for all elliptic curve operations. It must be imported first from the python-ecdsa library. Ed25519 and Ed448, although supported by the lib, are not fully implemented. |

--- a/journalist.py
+++ b/journalist.py
@@ -61,6 +61,12 @@ def journalist_reply(message, reply, journalist_uid):
         message["source_challenge_public_key"],
         message["source_encryption_public_key"])
 
+    intermediate_verifying_key = pki.verify_root_intermediate()
+
+    journalists = commons.get_journalists(intermediate_verifying_key)
+
+    ephemeral_keys = commons.get_ephemeral_keys(journalists)
+
     # The actual message struct varies depending on the sending party.
     # Still it is client controlled, so in each client we shall watch out a bit.
     message_dict = {"message": reply,
@@ -70,6 +76,7 @@ def journalist_reply(message, reply, journalist_uid):
                     # we could list the journalists involved in the conversation here
                     # if the source choose not to pick everybody
                     "group_members": [],
+                    "ephemeral_keys": ephemeral_keys,
                     "timestamp": int(time())}
 
     file_id, key = commons.upload_message(json.dumps(message_dict))

--- a/journalist_db.py
+++ b/journalist_db.py
@@ -1,13 +1,14 @@
 import os
 import sqlite3
 
+
 class JournalistDatabase():
 
     def __init__(self, path):
         self.path = path
         self.is_valid = os.path.isfile(self.path)
         self.con = sqlite3.connect(self.path)
-        if self.is_valid == False:
+        if self.is_valid is False:
             try:
                 self.create()
             except sqlite3.OperationalError:


### PR DESCRIPTION
_On the source side_:
 - Moved the message fetching and decryption to a function
 - Changed the `send_submission` prototype to accept ephemeral keys array as a argument
 - Depending if submission or reply fetch the ephemeral keys from server or the previous message

_On the journalist side_:
 - Fetch ephemeral keys from the server and attach them in replies


__Limitations__:
 - The keys are still fetched from the serve anyway. To make this effective we should have a pool of journalist accessible only keys
 - Multiple replies might end up reusing the same keys from the previous message, how to handle that? Do we attach multiple with the risk of wasting?
- TODO: verify the signatures of the key attached in message
