### PR TITLE
Disallow sources to access or delete their own submissions

### DIFF
--- a/journalist.py
+++ b/journalist.py
@@ -47,7 +47,9 @@ def load_ephemeral_keys(journalist_key, journalist_id, journalist_uid):
 
 def add_file_tokens(journalist_key, journalist_uid):
     file_tokens = []
-    for _ in range(commons.ONETIMEKEYS):
+    # Every message will use up at least one token, so we'll generate more than commons.ONETIMEKEYS
+    # to allow sources to add multiple attachments without running low on tokens
+    for _ in range(commons.ONETIMEKEYS * 10):
         file_tokens.append((token_hex(32), token_hex(32)))
 
     file_tokens = json.dumps(file_tokens)

--- a/pki.py
+++ b/pki.py
@@ -89,13 +89,17 @@ def generate_key(name):
     return key
 
 
-# Sign a given public key with the pubblid private key
-def sign_key(signing_pivate_key, signed_public_key, signature_name):
-    sig = signing_pivate_key.sign_deterministic(
-        signed_public_key.to_string(),
+def sign(signing_private_key, signed):
+    return signing_private_key.sign_deterministic(
+        signed,
         hashfunc=sha3_256,
         sigencode=sigencode_der
     )
+
+
+# Sign a given public key with the pubblid private key
+def sign_key(signing_private_key, signed_public_key, signature_name):
+    sig = sign(signing_private_key, signed_public_key.to_string())
 
     with open(signature_name, "wb") as f:
         f.write(sig)
@@ -104,12 +108,17 @@ def sign_key(signing_pivate_key, signed_public_key, signature_name):
 
 
 # Verify a signature
+def verify(signing_public_key, signed, sig):
+    signing_public_key.verify(sig, signed, hashfunc=sha3_256, sigdecode=sigdecode_der)
+    return sig
+
+
 def verify_key(signing_public_key, signed_public_key, signature_name, sig=None):
     if not sig:
         with open(signature_name, "rb") as f:
             sig = f.read()
-    signing_public_key.verify(sig, signed_public_key.to_string(), hashfunc=sha3_256, sigdecode=sigdecode_der)
-    return sig
+
+    return verify(signing_public_key, signed_public_key.to_string(), sig)
 
 
 def generate_pki():

--- a/source.py
+++ b/source.py
@@ -134,10 +134,11 @@ def main(args):
 
         if message_plaintext:
             print(f"[+] Successfully decrypted message {message_id}")
-            print(f"[+] file_id: {message_plaintext['file_id']}, key: {message_plaintext['key']}")
+            # sources receive the otherwise secret file_name from journalists
+            print(f"[+] file_name: {message_plaintext['file_name']}, key: {message_plaintext['key']}")
             print()
             key = message_plaintext['key']
-            encrypted_message_content = commons.get_file(message_plaintext['file_id'])
+            encrypted_message_content = commons.get_file(message_plaintext['file_name'])
             message_plaintext = commons.decrypt_message_symmetric(encrypted_message_content, bytes.fromhex(key))
             print(f"\tID: {message_id}")
             print(f"\tFrom: {message_plaintext['sender']}")


### PR DESCRIPTION
Basic testing done, working as expected. Fixes #10.

It turns out the codebase already distinguished between `file_id` and `file_name`, both of which are randomly generated `secrets.token_hex(32)` values. This adapts the use of these variables, making `file_id` knowable by the source, and changes `file_name` to be used to access/delete a particular file.

Journalists create a signed map of `file_id` and `file_name` key/values, which they share. Any long-term journalist signature is verified by the server, adding the respective mappings as members to the `file_token` redis set. This then allows the server to tell sources what they're allowed to learn (`file_id`) when submitting anything, while journalists can infer what they need to learn (`file_name`) when they receive messages or want to reply to a source. In the case of the latter, sources have to be told what they needs to know (`file_name`) by journalists without supplying other details of the public/private `file_id`/`file_name` map.

## Notes

1. I don't know if there was a significant reason for distinguishing between `file_name` for file-system names and `file_id` for database/remote access names, but as far as I can tell there is no need to hide on-disk file names from recipients. Happy to adapt if this is still something we want to continue to do.
2. The base branch for this PR is `messages-as-attachments` (i.e. #8), as protocol symmetry is a key point of this change (even though it could be adapted to just not send replies as file uploads, i.e. the source would not need to learn `file_name`)

