### PR TITLE
Drop python-ecdsa and port all crypto operations to libsodium

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,6 @@ No endpoints require authentication or sessions. The only data store is Redis an
 |`journalist_sig` | *base64(sig<sup>NR</sup>(J<sub>PK</sub>))* |
 |`journalist_fetching_key` | *base64(JC<sub>PK</sub>)* |
 |`journalist_fetching_sig` | *base64(sig<sup>J</sup>(JC<sub>PK</sub>))* |
-|`journalist_uid` | *hex(Hash(J<sub>PK</sub>))* |
 
 #### POST
 Adds *Newsroom* signed *Journalist* to the *Server*.
@@ -517,7 +516,6 @@ curl -X GET "http://127.0.0.1:5000/journalists"
       "journalist_fetching_sig": <journalist_fetching_sig>,
       "journalist_key": <journalist_key>,
       "journalist_sig": <journalist_sig>,
-      "journalist_uid": <journalist_uid>
     },
     ...
   ],
@@ -539,17 +537,17 @@ At this point *Source* must have a verified *NR<sub>PK</sub>* and must verify bo
 |`count` | Number of returned ephemeral keys. It should match the number of *Journalists*. If it does not, a specific *Journalist* bucket might be out of keys. |
 |`ephemeral_key` | *base64(JE<sub>PK</sub>)* |
 |`ephemeral_sig` | *base64(sig<sup>J</sup>(JE<sub>PK</sub>))* |
-|`journalist_uid` | *hex(Hash(J<sub>PK</sub>))* |
+|`journalist_key` | *base64(J<sub>PK</sub>)* |
 
 
 #### POST
 Adds *n* *Journalist* signed ephemeral key agreement keys to Server.
-The keys are stored in a Redis *set* specific per *Journalist*, which key is `journalist:<journalist_uid>`. In the demo implementation, the number of ephemeral keys to generate and upload each time is `commons.ONETIMEKEYS`. 
+The keys are stored in a Redis *set* specific per *Journalist*, which key is `journalist:<hex(public_key)>`. In the demo implementation, the number of ephemeral keys to generate and upload each time is `commons.ONETIMEKEYS`. 
 
 ```
 curl -X POST -H "Content-Type: application/json" "http://127.0.0.1:5000/ephemeral_keys" --data
 {
-  "journalist_uid": <journalist_uid>,
+  "journalist_key": <journalist_key>,
   "ephemeral_keys": [
     {
       "ephemeral_key": <ephemeral_key>,  
@@ -578,7 +576,7 @@ curl -X GET http://127.0.0.1:5000/ephemeral_keys
     {
       "ephemeral_key": <ephemeral_key>,
       "ephemeral_sig": <ephemeral_sig>,
-      "journalist_uid": <journalist_uid>
+      "journalist_key": <journalist_key>
     },
     ...
   ],

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ In `commons.py` there are the following configuration values which are global fo
 | `UPLOADS` | `files/` | server | The folder where the Flask server will store uploaded files
 | `JOURNALISTS` | `10` | server, source |  How many journalists do we create and enroll. In general, this is realistic, in current SecureDrop usage it is way less. For demo purposes everybody knows it, in a real scenario it would not be needed. |
 | `ONETIMEKEYS` | `30` | journalist | How many ephemeral keys each journalist create, sign and uploads when required. |
-| `CURVE` | `NIST384p` | server, source, journalist | The curve for all elliptic curve operations. It must be imported first from the python-ecdsa library. |
 | `MAX_MESSAGES` | `500` | server | How may potential messages the server sends to each party when they try to fetch messages. This basically must be more than the messages in the database, otherwise we need to develop a mechanism to group messages adding some bits of metadata. |
 | `CHUNK` | `512 * 1024` | source | The base size of every parts in which attachment are split/padded to. This is not the actual size on disk, cause that will be a bit more depending on the nacl SecretBox implementation. |
 

--- a/commons.py
+++ b/commons.py
@@ -1,5 +1,5 @@
 import json
-from base64 import b64encode
+from base64 import b64decode, b64encode
 from hashlib import sha3_256
 from os import path, stat
 from secrets import token_bytes
@@ -174,19 +174,11 @@ def fetch_messages_id(fetching_key):
         message_gdh = PublicKey(message["gdh"], Base64Encoder)
         message_client_box = Box(fetching_key, message_gdh)
 
-        print(message['key'])
-        print(b64encode(message_client_box.shared_key()).decode('ascii'))
-
-        if (message['key'] == b64encode(message_client_box.shared_key()).decode('ascii')):
-            print(message["enc"])
-            message_id = message_client_box.decrypt(message["enc"], Base64Encoder).decode('ascii')
-
-    try:
-        message_id = message_client_box.decrypt(message["enc"], Base64Encoder).decode('ascii')
-        messages.append(message_id)
-    except:
-        pass
-
+        try:
+            message_id = message_client_box.decrypt(b64decode(message["enc"])).decode('ascii')
+            messages.append(message_id)
+        except:
+            pass
 
     if len(messages) > 0:
         return messages
@@ -200,11 +192,10 @@ def fetch_messages_content(messages_id):
 
 
 def decrypt_message_ciphertext(private_key, message_public_key, message_ciphertext):
-    private_key = PrivateKey(private_key)
     public_key = PublicKey(message_public_key, Base64Encoder)
     box = Box(private_key, public_key)
     try:
-        message_plaintext = json.loads(box.decrypt(message_ciphertext, Base64Encoder).decode('ascii'))
+        message_plaintext = json.loads(box.decrypt(b64decode(message_ciphertext)).decode('ascii'))
         return message_plaintext
     except Exception:
         return False

--- a/commons.py
+++ b/commons.py
@@ -29,7 +29,7 @@ ONETIMEKEYS = 30
 # How may entries the server sends to each party when they try to fetch messages
 # This basically must be more than the msssages in the database, otherwise we need
 # to develop a mechanism to group messages adding some bits of metadata
-MAX_MESSAGES = 500
+MAX_MESSAGES = 1000
 # The base size of every parts in which attachment are splitted/padded to. This
 # is not the actual size on disk, cause thet will be a bit more depending on
 # the nacl SecretBox implementation
@@ -64,7 +64,7 @@ def get_journalists(intermediate_verifying_key):
                             journalist_verifying_key,
                             None,
                             content["journalist_sig"])
-        pki.verify_key_func(intermediate_verifying_key,
+        pki.verify_key_func(journalist_verifying_key,
                             journalist_fetching_verifying_key,
                             None,
                             content["journalist_fetching_sig"])

--- a/commons.py
+++ b/commons.py
@@ -1,12 +1,14 @@
 import json
-from base64 import b64decode, b64encode
 from hashlib import sha3_256
 from os import path, stat
 from secrets import token_bytes
 
-import nacl.secret
+from nacl.encoding import HexEncoder, Base64Encoder
+from nacl.public import PrivateKey, Box
+from nacl.secret import SecretBox
+from nacl.signing import SigningKey, VerifyKey
+
 import requests
-from ecdsa import ECDH, NIST384p, SigningKey, VerifyingKey
 
 import pki
 
@@ -23,9 +25,6 @@ UPLOADS = "files/"
 JOURNALISTS = 10
 # How many ephemeral keys each journalist create, sign and auploads when required
 ONETIMEKEYS = 30
-# The curve for all elliptic curve operations. It must be imported first from the python-ecdsa
-# library. Ed25519 and Ed448, although supported by the lib, are not fully implemented
-CURVE = NIST384p
 # How may entries the server sends to each party when they try to fetch messages
 # This basically must be more than the msssages in the database, otherwise we need
 # to develop a mechanism to group messages adding some bits of metadata
@@ -37,11 +36,11 @@ CHUNK = 512 * 1024
 
 
 def add_journalist(journalist_key, journalist_sig, journalist_fetching_key, journalist_fetching_sig):
-    journalist_uid = sha3_256(journalist_key.verifying_key.to_string()).hexdigest()
-    journalist_key = b64encode(journalist_key.verifying_key.to_string()).decode("ascii")
-    journalist_sig = b64encode(journalist_sig).decode("ascii")
-    journalist_fetching_key = b64encode(journalist_fetching_key.verifying_key.to_string()).decode("ascii")
-    journalist_fetching_sig = b64encode(journalist_fetching_sig).decode("ascii")
+    journalist_uid = sha3_256(journalist_key.verify_key.encode()).hexdigest()
+    journalist_key = journalist_key.verify_key.encode(Base64Encoder).decode("ascii")
+    journalist_sig = journalist_sig
+    journalist_fetching_key = journalist_fetching_key.verify_key.encode(Base64Encoder).decode("ascii")
+    journalist_fetching_sig = journalist_fetching_sig
 
     response = requests.post(f"http://{SERVER}/journalists", json={
                 "journalist_key": journalist_key,
@@ -59,18 +58,18 @@ def get_journalists(intermediate_verifying_key):
     journalists = response.json()["journalists"]
     assert (len(journalists) == JOURNALISTS)
     for content in journalists:
-        journalist_verifying_key = pki.public_b642key(content["journalist_key"])
-        journalist_fetching_verifying_key = pki.public_b642key(content["journalist_fetching_key"])
+        journalist_verifying_key = VerifyKey(content["journalist_key"], Base64Encoder)
+        journalist_fetching_verifying_key = VerifyKey(content["journalist_fetching_key"], Base64Encoder)
         # pki.verify_key shall give an hard fault is a signature is off
         pki.verify_key(intermediate_verifying_key,
                        journalist_verifying_key,
                        None,
-                       b64decode(content["journalist_sig"])
+                       content["journalist_sig"]
                        )
         pki.verify_key(intermediate_verifying_key,
                        journalist_fetching_verifying_key,
                        None,
-                       b64decode(content["journalist_fetching_sig"])
+                       content["journalist_fetching_sig"]
                        )
     return journalists
 
@@ -91,13 +90,13 @@ def get_ephemeral_keys(journalists):
                 ephemeral_key_dict["journalist_fetching_key"] = journalist["journalist_fetching_key"]
                 # add uids to a set
                 checked_uids.add(journalist_uid)
-                journalist_verifying_key = pki.public_b642key(journalist["journalist_key"])
-        ephemeral_verifying_key = pki.public_b642key(ephemeral_key_dict["ephemeral_key"])
+                journalist_verifying_key = VerifyKey(journalist["journalist_key"], Base64Encoder)
+        ephemeral_verifying_key = VerifyKey(ephemeral_key_dict["ephemeral_key"], Base64Encoder)
         # We rely again on verify_key raising an exception in case of failure
         pki.verify_key(journalist_verifying_key,
                        ephemeral_verifying_key,
                        None,
-                       b64decode(ephemeral_key_dict["ephemeral_sig"]))
+                       ephemeral_key_dict["ephemeral_sig"])
         ephemeral_keys_return.append(ephemeral_key_dict)
     # check that all keys are from different journalists
     assert (len(checked_uids) == JOURNALISTS)
@@ -105,29 +104,17 @@ def get_ephemeral_keys(journalists):
 
 
 def build_message(fetching_public_key, encryption_public_key):
-    fetching_public_key = VerifyingKey.from_string(b64decode(fetching_public_key), curve=CURVE)
-    encryption_public_key = VerifyingKey.from_string(b64decode(encryption_public_key), curve=CURVE)
+    fetching_public_key = PublicKey(fetching_public_key, Base64Encoder)
+    encryption_public_key = PublicKey(encryption_public_key, Base64Encoder)
 
-    ecdh = ECDH(curve=CURVE)
-    # [SOURCE] PERMESSAGE-EPHEMERAL KEY (private)
-    message_key = SigningKey.generate(curve=CURVE)
-    message_public_key = b64encode(message_key.verifying_key.to_string()).decode("ascii")
-    # load the private key to generate the shared secret
-    ecdh.load_private_key(message_key)
-
-    # [JOURNALIST] PERMESSAGE-EPHEMERAL KEY (public)
-    ecdh.load_received_public_key(encryption_public_key)
-    # generate the secret for encrypting the secret with the source_ephemeral+journo_ephemeral
-    # so that we have forward secrecy
-    encryption_shared_secret = ecdh.generate_sharedsecret_bytes()
+    message_secret_key = PrivateKey.generate()
+    message_public_key = (message_secret_key.public_key.encode(Base64Encoder)).decode("ascii")
 
     # encrypt the message, we trust nacl safe defaults
-    box = nacl.secret.SecretBox(encryption_shared_secret[0:32])
+    box = Box(message_secret_key, receiver_public_key)
 
     # generate the message gdh to send the server
-    message_gdh = b64encode(VerifyingKey.from_public_point(
-        pki.get_shared_secret(fetching_public_key, message_key),
-        curve=CURVE).to_string()).decode('ascii')
+    message_gdh = Box(message_secret_key, fetching_public_key).shared_key().encode(Base64Encoder)
 
     return message_public_key, message_gdh, box
 
@@ -185,18 +172,13 @@ def fetch_messages_id(fetching_key):
     potential_messages = fetch()
 
     messages = []
-    ecdh = ECDH(curve=CURVE)
 
     for message in potential_messages:
-
-        ecdh.load_private_key(fetching_key)
-        ecdh.load_received_public_key_bytes(b64decode(message["gdh"]))
-        message_client_shared_secret = ecdh.generate_sharedsecret_bytes()
-
-        box = nacl.secret.SecretBox(message_client_shared_secret[0:32])
+        message_gdh = PublicKey(message["gdh"], Base64Encoder)
+        message_client_box = Box(fetching_key, message_gdh)
 
         try:
-            message_id = box.decrypt(b64decode(message["enc"])).decode('ascii')
+            message_id = box.decrypt(message["enc"], Base64Encoder).decode('ascii')
             messages.append(message_id)
 
         except Exception:
@@ -214,13 +196,11 @@ def fetch_messages_content(messages_id):
 
 
 def decrypt_message_ciphertext(private_key, message_public_key, message_ciphertext):
-    ecdh = ECDH(curve=CURVE)
-    ecdh.load_private_key(private_key)
-    ecdh.load_received_public_key_bytes(b64decode(message_public_key))
-    encryption_shared_secret = ecdh.generate_sharedsecret_bytes()
-    box = nacl.secret.SecretBox(encryption_shared_secret[0:32])
+    private_key = PrivateKey(private_key)
+    public_key = PublicKey(message_public_key, Base64Encoder)
+    box = Box(private_key, public_key)
     try:
-        message_plaintext = json.loads(box.decrypt(b64decode(message_ciphertext)).decode('ascii'))
+        message_plaintext = json.loads(box.decrypt(message_ciphertext, Base64Encoder).decode('ascii'))
         return message_plaintext
     except Exception:
         return False
@@ -247,7 +227,7 @@ def upload_attachment(filename):
             part_len = len(part)
             read_size += part_len
 
-            box = nacl.secret.SecretBox(key)
+            box = SecretBox(key)
             encrypted_part = box.encrypt(part.ljust(CHUNK))
 
             upload_response = send_file(encrypted_part)

--- a/commons.py
+++ b/commons.py
@@ -177,7 +177,7 @@ def fetch_messages_id(fetching_key):
         try:
             message_id = message_client_box.decrypt(b64decode(message["enc"])).decode('ascii')
             messages.append(message_id)
-        except:
+        except Exception:
             pass
 
     if len(messages) > 0:

--- a/demo.sh
+++ b/demo.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+killall flask 2>/dev/null
 sudo systemctl restart redis > /dev/null 2>&1
 
 # start clean

--- a/deploy_keys.py
+++ b/deploy_keys.py
@@ -1,0 +1,15 @@
+import requests
+import commons
+
+with open("keys/root.public", "r") as f:
+    fpf_key = f.read()
+
+with open("keys/intermediate.public", "r") as f:
+    nr_key = f.read()
+
+with open("keys/intermediate.sig", "r") as f:
+    nr_sig = f.read()
+
+res = requests.post(f"http://{commons.SERVER}/keys", json={"fpf_key": fpf_key, "newsroom_key": nr_key, "newsroom_sig": nr_sig})
+
+assert(res.status_code == 200)

--- a/journalist.py
+++ b/journalist.py
@@ -35,10 +35,10 @@ def add_ephemeral_keys(journalist_key, journalist_id):
 # database.
 def load_ephemeral_keys(journalist_key, journalist_id):
     ephemeral_keys = []
-    key_file_list = listdir(f"{commons.DIR}journalists/{journalist_key.verify_key.encode(HexEncoder)}/")
+    key_file_list = listdir(f"{commons.DIR}journalists/{journalist_key.verify_key.encode(HexEncoder).decode('ascii')}/")
     for file_name in key_file_list:
         if file_name.endswith('.key'):
-            with open(f"{commons.DIR}journalists/{journalist_key.verify_key.encode(HexEncoder)}/{file_name}", "r") as f:
+            with open(f"{commons.DIR}journalists/{journalist_key.verify_key.encode(HexEncoder).decode('ascii')}/{file_name}", "r") as f:
                 key = f.read()
             ephemeral_keys.append(PrivateKey(key, Base64Encoder))
     return ephemeral_keys

--- a/journalist.py
+++ b/journalist.py
@@ -7,10 +7,9 @@ from os import listdir, mkdir, path
 from time import time
 
 import requests
-from nacl.encoding import Base64Encoder, HexEncoder
-from nacl.public import Box, PrivateKey, PublicKey
+from nacl.encoding import Base64Encoder
 from nacl.secret import SecretBox
-from nacl.signing import SigningKey, VerifyKey
+from nacl.signing import SigningKey
 
 import commons
 import journalist_db

--- a/journalist.py
+++ b/journalist.py
@@ -8,6 +8,7 @@ from time import time
 
 import requests
 from nacl.encoding import Base64Encoder
+from nacl.public import PrivateKey
 from nacl.secret import SecretBox
 from nacl.signing import SigningKey
 
@@ -41,7 +42,7 @@ def load_ephemeral_keys(journalist_key, journalist_id, journalist_uid):
         if file_name.endswith('.key'):
             with open(f"{commons.DIR}journalists/{journalist_uid}/{file_name}", "r") as f:
                 key = f.read()
-            ephemeral_keys.append(SigningKey(key, Base64Encoder))
+            ephemeral_keys.append(PrivateKey(key, Base64Encoder))
     return ephemeral_keys
 
 

--- a/journalist.py
+++ b/journalist.py
@@ -7,9 +7,8 @@ from os import listdir, mkdir, path
 from time import time
 
 import requests
-
-from nacl.encoding import HexEncoder, Base64Encoder
-from nacl.public import PublicKey, PrivateKey, Box
+from nacl.encoding import Base64Encoder, HexEncoder
+from nacl.public import Box, PrivateKey, PublicKey
 from nacl.secret import SecretBox
 from nacl.signing import SigningKey, VerifyKey
 

--- a/journalist.py
+++ b/journalist.py
@@ -2,12 +2,11 @@ import argparse
 import json
 from base64 import b64encode
 from datetime import datetime
-from hashlib import sha3_256
 from os import listdir, mkdir, path
 from time import time
 
 import requests
-from nacl.encoding import Base64Encoder
+from nacl.encoding import Base64Encoder, HexEncoder
 from nacl.public import PrivateKey
 from nacl.secret import SecretBox
 
@@ -16,16 +15,16 @@ import journalist_db
 import pki
 
 
-def add_ephemeral_keys(journalist_key, journalist_id, journalist_uid):
+def add_ephemeral_keys(journalist_key, journalist_id):
     ephemeral_keys = []
     for key in range(commons.ONETIMEKEYS):
         # Generate an ephemeral key, sign it and load the signature
-        ephemeral_sig, ephemeral_key = pki.generate_ephemeral(journalist_key, journalist_id, journalist_uid)
+        ephemeral_sig, ephemeral_key = pki.generate_ephemeral(journalist_key, journalist_id)
         ephemeral_keys.append({"ephemeral_key": ephemeral_key.public_key.encode(Base64Encoder).decode("ascii"),
                                "ephemeral_sig": ephemeral_sig.signature.decode("ascii")})
 
     # Send both to server, the server veifies the signature and the trust chain prior ro storing/publishing
-    response = requests.post(f"http://{commons.SERVER}/ephemeral_keys", json={"journalist_uid": journalist_uid,
+    response = requests.post(f"http://{commons.SERVER}/ephemeral_keys", json={"journalist_key": journalist_key.verify_key.encode(Base64Encoder),
                                                                               "ephemeral_keys": ephemeral_keys})
 
     return (response.status_code == 200)
@@ -34,12 +33,12 @@ def add_ephemeral_keys(journalist_key, journalist_id, journalist_uid):
 # Load the journalist ephemeral keys from the journalist key dirrectory.
 # On an actual implementation this would more likely be a sqlite (or sqlcipher)
 # database.
-def load_ephemeral_keys(journalist_key, journalist_id, journalist_uid):
+def load_ephemeral_keys(journalist_key, journalist_id):
     ephemeral_keys = []
-    key_file_list = listdir(f"{commons.DIR}journalists/{journalist_uid}/")
+    key_file_list = listdir(f"{commons.DIR}journalists/{journalist_key.verify_key.encode(HexEncoder)}/")
     for file_name in key_file_list:
         if file_name.endswith('.key'):
-            with open(f"{commons.DIR}journalists/{journalist_uid}/{file_name}", "r") as f:
+            with open(f"{commons.DIR}journalists/{journalist_key.verify_key.encode(HexEncoder)}/{file_name}", "r") as f:
                 key = f.read()
             ephemeral_keys.append(PrivateKey(key, Base64Encoder))
     return ephemeral_keys
@@ -56,7 +55,7 @@ def decrypt_message(ephemeral_keys, message):
             return message_plaintext
 
 
-def journalist_reply(message, reply, journalist_uid):
+def journalist_reply(message, reply, journalist_key):
     # This function builds the per-message keys and returns a nacl encrypting box
     message_public_key, message_gdh, box = commons.build_message(
         message["source_fetching_public_key"],
@@ -66,7 +65,7 @@ def journalist_reply(message, reply, journalist_uid):
     # Still it is client controlled, so in each client we shall watch out a bit.
     message_dict = {"message": reply,
                     # do we want to sign messages? how do we attest source authoriship?
-                    "sender": journalist_uid,
+                    "sender": journalist_key.verify_key.encode(HexEncoder).decode('ascii'),
                     # "receiver": "source_id_placeholder",
                     # we could list the journalists involved in the conversation here
                     # if the source choose not to pick everybody
@@ -86,14 +85,14 @@ def main(args):
     journalist_id = args.journalist
     assert (journalist_id >= 0 and journalist_id < commons.JOURNALISTS)
 
-    journalist_uid, journalist_sig, journalist_key, journalist_fetching_sig, journalist_fetching_key = pki.load_and_verify_journalist_keypair(journalist_id)
+    journalist_sig, journalist_key, journalist_fetching_sig, journalist_fetching_key = pki.load_and_verify_journalist_keypair(journalist_id)
     jdb = journalist_db.JournalistDatabase('files/.jdb.sqlite3')
 
     if args.action == "upload_keys":
-        journalist_uid = commons.add_journalist(journalist_key, journalist_sig, journalist_fetching_key, journalist_fetching_sig)
+        commons.add_journalist(journalist_key, journalist_sig, journalist_fetching_key, journalist_fetching_sig)
 
         # Generate and upload a bunch (30) of ephemeral keys
-        add_ephemeral_keys(journalist_key, journalist_id, journalist_uid)
+        add_ephemeral_keys(journalist_key, journalist_id)
 
     elif args.action == "fetch":
         # Check if there are messages
@@ -116,7 +115,7 @@ def main(args):
     elif args.action == "read":
         message_id = args.id
         message = commons.get_message(message_id)
-        ephemeral_keys = load_ephemeral_keys(journalist_key, journalist_id, journalist_uid)
+        ephemeral_keys = load_ephemeral_keys(journalist_key, journalist_id)
         message_plaintext = decrypt_message(ephemeral_keys, message)
 
         if message_plaintext:
@@ -130,7 +129,7 @@ def main(args):
             else:
                 message_plaintext["attachments"] = []
 
-            sender = sha3_256(message_plaintext['source_encryption_public_key'].encode("ascii")).hexdigest()
+            sender = message_plaintext['source_encryption_public_key'].encode('ascii')
             print(f"[+] Successfully decrypted message {message_id}")
             print()
             print(f"\tID: {message_id}")
@@ -166,9 +165,9 @@ def main(args):
     elif args.action == "reply":
         message_id = args.id
         message = commons.get_message(message_id)
-        ephemeral_keys = load_ephemeral_keys(journalist_key, journalist_id, journalist_uid)
+        ephemeral_keys = load_ephemeral_keys(journalist_key, journalist_id)
         message_plaintext = decrypt_message(ephemeral_keys, message)
-        journalist_reply(message_plaintext, args.message, journalist_uid)
+        journalist_reply(message_plaintext, args.message, journalist_key)
 
     elif args.action == "delete":
         message_id = args.id

--- a/journalist.py
+++ b/journalist.py
@@ -10,7 +10,6 @@ import requests
 from nacl.encoding import Base64Encoder
 from nacl.public import PrivateKey
 from nacl.secret import SecretBox
-from nacl.signing import SigningKey
 
 import commons
 import journalist_db
@@ -22,7 +21,7 @@ def add_ephemeral_keys(journalist_key, journalist_id, journalist_uid):
     for key in range(commons.ONETIMEKEYS):
         # Generate an ephemeral key, sign it and load the signature
         ephemeral_sig, ephemeral_key = pki.generate_ephemeral(journalist_key, journalist_id, journalist_uid)
-        ephemeral_keys.append({"ephemeral_key": ephemeral_key.verify_key.encode(Base64Encoder).decode("ascii"),
+        ephemeral_keys.append({"ephemeral_key": ephemeral_key.public_key.encode(Base64Encoder).decode("ascii"),
                                "ephemeral_sig": ephemeral_sig.signature.decode("ascii")})
 
     # Send both to server, the server veifies the signature and the trust chain prior ro storing/publishing

--- a/pki.py
+++ b/pki.py
@@ -143,19 +143,19 @@ def generate_journalists(intermediate_key):
 
 def generate_ephemeral(journalist_key, journalist_id):
     try:
-        mkdir(f"{commons.DIR}/journalists/{journalist_key.verify_key.encode(HexEncoder)}")
+        mkdir(f"{commons.DIR}/journalists/{journalist_key.verify_key.encode(HexEncoder).decode('ascii')}")
     except Exception:
         pass
     key = PrivateKey.generate()
     name = key.public_key.encode(HexEncoder)
 
-    with open(f"{commons.DIR}/journalists/{journalist_key.verify_key.encode(HexEncoder)}/{name}.key", "w") as f:
+    with open(f"{commons.DIR}/journalists/{journalist_key.verify_key.encode(HexEncoder).decode('ascii')}/{name}.key", "w") as f:
         f.write(key.encode(Base64Encoder).decode('ascii'))
 
-    with open(f"{commons.DIR}/journalists/{journalist_key.verify_key.encode(HexEncoder)}/{name}.public", "w") as f:
+    with open(f"{commons.DIR}/journalists/{journalist_key.verify_key.encode(HexEncoder).decode('ascii')}/{name}.public", "w") as f:
         f.write(key.public_key.encode(Base64Encoder).decode('ascii'))
 
-    sig = sign_key(journalist_key, key.public_key, f"{commons.DIR}/journalists/{journalist_key.verify_key.encode(HexEncoder)}/{name}.sig")
+    sig = sign_key(journalist_key, key.public_key, f"{commons.DIR}/journalists/{journalist_key.verify_key.encode(HexEncoder).decode('ascii')}/{name}.sig")
 
     return sig, key
 

--- a/pki.py
+++ b/pki.py
@@ -2,16 +2,13 @@ from base64 import b64decode
 from hashlib import sha3_256
 from os import mkdir, rmdir
 
-from nacl.encoding import HexEncoder, Base64Encoder
+from ecdsa import InvalidCurveError, InvalidSharedSecretError
+from ecdsa.ellipticcurve import INFINITY
+from nacl.encoding import Base64Encoder, HexEncoder
 from nacl.signing import SigningKey, VerifyKey
 from nacl.utils import randombytes_deterministic
 
-
-from ecdsa import (InvalidCurveError, InvalidSharedSecretError)
-from ecdsa.ellipticcurve import INFINITY
-
 import commons
-
 
 # Used to deterministally generate keys based on the passphrase, only on the source side
 # the class is kind of a hack: python-ecdsa wants a os.urandom() kind of interface

--- a/pki.py
+++ b/pki.py
@@ -163,16 +163,16 @@ def generate_ephemeral(journalist_key, journalist_id, journalist_uid):
         mkdir(f"{commons.DIR}/journalists/{journalist_uid}")
     except Exception:
         pass
-    key = SigningKey.generate()
-    name = sha3_256(key.verify_key.encode()).hexdigest()
+    key = PrivateKey.generate()
+    name = sha3_256(key.public_key.encode()).hexdigest()
 
     with open(f"{commons.DIR}/journalists/{journalist_uid}/{name}.key", "w") as f:
-        f.write(key.verify_key.encode(Base64Encoder).decode('ascii'))
+        f.write(key.encode(Base64Encoder).decode('ascii'))
 
     with open(f"{commons.DIR}/journalists/{journalist_uid}/{name}.public", "w") as f:
-        f.write(key.verify_key.encode(Base64Encoder).decode('ascii'))
+        f.write(key.public_key.encode(Base64Encoder).decode('ascii'))
 
-    sig = sign_key(journalist_key, key.verify_key, f"{commons.DIR}/journalists/{journalist_uid}/{name}.sig")
+    sig = sign_key(journalist_key, key.public_key, f"{commons.DIR}/journalists/{journalist_uid}/{name}.sig")
 
     return sig, key
 

--- a/pki.py
+++ b/pki.py
@@ -2,71 +2,56 @@ from base64 import b64decode
 from hashlib import sha3_256
 from os import mkdir, rmdir
 
-from ecdsa import InvalidCurveError, InvalidSharedSecretError
-from ecdsa.ellipticcurve import INFINITY
-from nacl.encoding import Base64Encoder, HexEncoder
+from nacl.encoding import Base64Encoder
+from nacl.public import PrivateKey, PublicKey
 from nacl.signing import SigningKey, VerifyKey
-from nacl.utils import randombytes_deterministic
 
 import commons
 
-# Used to deterministally generate keys based on the passphrase, only on the source side
-# the class is kind of a hack: python-ecdsa wants a os.urandom() kind of interface
-# but nacl.utils does not have an internal state even if seeded.
-# Thus we use a seed to generate enough randoness for all the needed calls. Shall the
-# pre-generated randomness end, an exception is forcefully raised.
-'''class PRNG:
-    def __init__(self, seed):
-        assert (len(seed) == 32)
-        self.total_size = 4096
-        self.seed = seed
-        self.status = 0
-        self.data = randombytes_deterministic(self.total_size, self.seed)
-
-    def deterministic_random(self, size):
-        if self.status + size >= self.total_size:
-            raise RuntimeError("Ran out of buffered random values")
-        return_data = self.data[self.status:self.status+size]
-        self.status += size
-        return return_data
-
-
-def get_shared_secret(remote_pubkey, local_privkey):
-    if not (local_privkey.curve == remote_pubkey.curve):
-        raise InvalidCurveError("Curves for public key and private key is not equal.")
-
-    # shared secret = PUBKEYtheirs * PRIVATEKEYours
-    result = (remote_pubkey.pubkey.point * local_privkey.privkey.secret_multiplier)
-    if result == INFINITY:
-        raise InvalidSharedSecretError("Invalid shared secret (INFINITY).")
-
-    return result
-'''
 
 # Loads a saved python ed25519 key from disk, if signing=False, load just the public-key
-def load_key(name, signing=True):
+def load_key(name, keytype='sig', private=False):
 
-    with open(f"{commons.DIR}/{name}.public", "r") as f:
-        verify_key = VerifyKey(f.read(), Base64Encoder)
-
-    if signing:
-        with open(f"{commons.DIR}/{name}.key", "r") as f:
-            key = SigningKey(f.read(), Base64Encoder)
-        assert (key.verify_key == verify_key)
-        return key
+    if keytype == 'sig':
+        pub = VerifyKey
+        priv = SigningKey
+    elif keytype == 'enc':
+        pub = PublicKey
+        priv = PrivateKey
     else:
-        return verify_key
+        return False
+
+    if private:
+        with open(f"{commons.DIR}/{name}.key", "r") as f:
+            private_key = priv(f.read(), Base64Encoder)
+        # assert (key.verify_key == verify_key)
+        return private_key
+    else:
+        with open(f"{commons.DIR}/{name}.public", "r") as f:
+            public_key = pub(f.read(), Base64Encoder)
+
+        return public_key
 
 
 # Generate a ed25519 keypair and save it to disk
-def generate_key(name):
-    key = SigningKey.generate()
+def generate_key(name, keytype='sig'):
+    if keytype == 'sig':
+        generate_obj = SigningKey
+    elif keytype == 'enc':
+        generate_obj = PrivateKey
+    else:
+        return False
+
+    key = generate_obj.generate()
 
     with open(f"{commons.DIR}/{name}.key", "w") as f:
         f.write(key.encode(encoder=Base64Encoder).decode('ascii'))
 
     with open(f"{commons.DIR}/{name}.public", "w") as f:
-        f.write(key.verify_key.encode(encoder=Base64Encoder).decode('ascii'))
+        if keytype == 'sig':
+            f.write(key.verify_key.encode(encoder=Base64Encoder).decode('ascii'))
+        else:
+            f.write(key.public_key.encode(encoder=Base64Encoder).decode('ascii'))
 
     return key
 
@@ -110,16 +95,16 @@ def generate_pki():
 
 
 def verify_root_intermediate():
-    root_verifying_key = load_key("root", signing=False)
-    intermediate_verifying_key = load_key("intermediate", signing=False)
+    root_verifying_key = load_key("root", keytype='sig', private=False)
+    intermediate_verifying_key = load_key("intermediate", keytype='sig', private=False)
     verify_key_func(root_verifying_key, intermediate_verifying_key, f"{commons.DIR}intermediate.sig")
     return intermediate_verifying_key
 
 
-def load_pki():
+'''def load_pki():
     root_key = load_key("root")
     intermediate_key = load_key("intermediate")
-    verify_key_func(root_key.verif_key, intermediate_key.verify_key, f"{commons.DIR}intermediate.sig")
+    verify_key_func(root_key.verify_key, intermediate_key.verify_key, f"{commons.DIR}intermediate.sig")
     journalist_keys = []
     for j in range(commons.JOURNALISTS):
         journalist_key = load_key(f"{commons.DIR}journalists/journalist_{j}")
@@ -128,19 +113,20 @@ def load_pki():
                    journalist_key.verify_key,
                    f"{commons.DIR}journalists/journalist_{j}.sig")
     return root_key, intermediate_key, journalist_keys
+'''
 
 
 def load_and_verify_journalist_keypair(journalist_id):
     intermediate_verifying_key = verify_root_intermediate()
-    journalist_key = load_key(f"journalists/journalist_{journalist_id}")
+    journalist_key = load_key(f"journalists/journalist_{journalist_id}", keytype='sig', private=True)
     journalist_uid = sha3_256(journalist_key.verify_key.encode()).hexdigest()
     journalist_sig = verify_key_func(intermediate_verifying_key,
-                                journalist_key.verify_key,
-                                f"{commons.DIR}journalists/journalist_{journalist_id}.sig")
-    journalist_fetching_key = load_key(f"journalists/journalist_fetching_{journalist_id}")
+                                     journalist_key.verify_key,
+                                     f"{commons.DIR}journalists/journalist_{journalist_id}.sig")
+    journalist_fetching_key = load_key(f"journalists/journalist_fetching_{journalist_id}", keytype='enc', private=True)
     journalist_fetching_sig = verify_key_func(intermediate_verifying_key,
-                                         journalist_fetching_key.verify_key,
-                                         f"{commons.DIR}journalists/journalist_fetching_{journalist_id}.sig")
+                                              journalist_fetching_key.public_key,
+                                              f"{commons.DIR}journalists/journalist_fetching_{journalist_id}.sig")
 
     return journalist_uid, journalist_sig, journalist_key, journalist_fetching_sig, journalist_fetching_key
 
@@ -149,10 +135,10 @@ def load_and_verify_journalist_verifying_keys():
     intermediate_verifying_key = verify_root_intermediate()
     journalist_verying_keys = []
     for j in range(commons.JOURNALISTS):
-        journalist_verifying_key = load_key(f"journalists/journalist_{j}", signing=False)
+        journalist_verifying_key = load_key(f"journalists/journalist_{j}", private=False)
         verify_key_func(intermediate_verifying_key,
-                   journalist_verifying_key,
-                   f"{commons.DIR}journalists/journalist_{j}.sig")
+                        journalist_verifying_key,
+                        f"{commons.DIR}journalists/journalist_{j}.sig")
         journalist_verying_keys.append(journalist_verifying_key)
     return journalist_verying_keys
 
@@ -162,12 +148,12 @@ def generate_journalists(intermediate_key):
     journalist_fetching_keys = []
     mkdir(f"{commons.DIR}/journalists/")
     for j in range(commons.JOURNALISTS):
-        journalist_key = generate_key(f"journalists/journalist_{j}")
+        journalist_key = generate_key(f"journalists/journalist_{j}", keytype='sig')
         journalist_keys.append(journalist_key)
         sign_key(intermediate_key, journalist_key.verify_key, f"{commons.DIR}journalists/journalist_{j}.sig")
-        journalist_fetching_key = generate_key(f"journalists/journalist_fetching_{j}")
+        journalist_fetching_key = generate_key(f"journalists/journalist_fetching_{j}", keytype='enc')
         journalist_fetching_keys.append(journalist_fetching_key)
-        sign_key(intermediate_key, journalist_fetching_key.verify_key, f"{commons.DIR}journalists/journalist_fetching_{j}.sig")
+        sign_key(intermediate_key, journalist_fetching_key.public_key, f"{commons.DIR}journalists/journalist_fetching_{j}.sig")
 
     return journalist_fetching_keys, journalist_keys
 

--- a/pki.py
+++ b/pki.py
@@ -124,7 +124,7 @@ def load_and_verify_journalist_keypair(journalist_id):
                                      journalist_key.verify_key,
                                      f"{commons.DIR}journalists/journalist_{journalist_id}.sig")
     journalist_fetching_key = load_key(f"journalists/journalist_fetching_{journalist_id}", keytype='enc', private=True)
-    journalist_fetching_sig = verify_key_func(intermediate_verifying_key,
+    journalist_fetching_sig = verify_key_func(journalist_key.verify_key,
                                               journalist_fetching_key.public_key,
                                               f"{commons.DIR}journalists/journalist_fetching_{journalist_id}.sig")
 
@@ -153,7 +153,7 @@ def generate_journalists(intermediate_key):
         sign_key(intermediate_key, journalist_key.verify_key, f"{commons.DIR}journalists/journalist_{j}.sig")
         journalist_fetching_key = generate_key(f"journalists/journalist_fetching_{j}", keytype='enc')
         journalist_fetching_keys.append(journalist_fetching_key)
-        sign_key(intermediate_key, journalist_fetching_key.public_key, f"{commons.DIR}journalists/journalist_fetching_{j}.sig")
+        sign_key(journalist_key, journalist_fetching_key.public_key, f"{commons.DIR}journalists/journalist_fetching_{j}.sig")
 
     return journalist_fetching_keys, journalist_keys
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 redis
 flask
-ecdsa
 pynacl
-gmpy2
 requests

--- a/server.py
+++ b/server.py
@@ -55,7 +55,7 @@ def add_journalist():
                                              None,
                                              content["journalist_sig"])
 
-        journalist_fetching_sig = pki.verify_key_func(intermediate_verifying_key,
+        journalist_fetching_sig = pki.verify_key_func(journalist_verifying_key,
                                                       journalist_fetching_public_key,
                                                       None,
                                                       content["journalist_fetching_sig"])

--- a/server.py
+++ b/server.py
@@ -1,7 +1,7 @@
 import json
 from base64 import b64decode, b64encode
 from os import mkdir, remove
-# from random import uniform
+from random import uniform
 from secrets import token_bytes, token_hex
 
 from flask import Flask, request, send_file
@@ -14,7 +14,7 @@ from redis import Redis
 import commons
 import pki
 
-# from time import sleep
+from time import sleep
 
 # bootstrap keys
 intermediate_verifying_key = pki.verify_root_intermediate()
@@ -198,7 +198,7 @@ def get_fetch():
         )
 
     # TODO: add stronger timing attack mitigations (such as a random delay)
-    # sleep(uniform(0, 3.0))
+    sleep(uniform(0, 2.0))
 
     assert (len(potential_messages) == commons.MAX_MESSAGES)
 

--- a/server.py
+++ b/server.py
@@ -4,7 +4,6 @@ from hashlib import sha3_256
 from os import mkdir, remove
 # from random import uniform
 from secrets import token_bytes, token_hex
-# from time import sleep
 
 from flask import Flask, request, send_file
 from nacl.bindings import crypto_scalarmult
@@ -15,6 +14,8 @@ from redis import Redis
 
 import commons
 import pki
+
+# from time import sleep
 
 # bootstrap keys
 intermediate_verifying_key = pki.verify_root_intermediate()

--- a/server.py
+++ b/server.py
@@ -6,12 +6,11 @@ from random import uniform
 from secrets import token_bytes, token_hex
 from time import sleep
 
-from nacl.encoding import HexEncoder, Base64Encoder
-from nacl.public import PublicKey, PrivateKey, Box
+from flask import Flask, request, send_file
+from nacl.encoding import Base64Encoder, HexEncoder
+from nacl.public import Box, PrivateKey, PublicKey
 from nacl.secret import SecretBox
 from nacl.signing import SigningKey, VerifyKey
-
-from flask import Flask, request, send_file
 from redis import Redis
 
 import commons
@@ -37,7 +36,7 @@ def index():
 @app.route("/journalists", methods=["POST"])
 def add_journalist():
     content = request.json
-    print(content)
+
     try:
         assert ("journalist_key" in content)
         assert ("journalist_sig" in content)

--- a/server.py
+++ b/server.py
@@ -188,23 +188,22 @@ def get_fetch():
         encrypted_message_id = box.encrypt(message_id.encode('ascii'))
 
         potential_messages.append({"gdh": b64encode(message_server_gdh).decode('ascii'),
-                                   "enc": b64encode(encrypted_message_id).decode('ascii'),
-                                   "key": b64encode(box.shared_key()).decode('ascii')})
+                                   "enc": b64encode(encrypted_message_id).decode('ascii')})
 
     # add DECOY potential messages
     # TODO: add shuffling of the response dict
-    # for decoy in range(commons.MAX_MESSAGES - len(potential_messages)):
-    #    potential_messages.append({
-    #                               "gdh": PrivateKey.generate().encode(Base64Encoder).decode('ascii'),
-    #                               # message_id are 32 bytes and encryption overhead is 64 bytes
-    #                               "enc": b64encode(token_bytes(32+72)).decode('ascii')
-    #        }
-    #    )
+    for decoy in range(commons.MAX_MESSAGES - len(potential_messages)):
+        potential_messages.append({
+                                   "gdh": PrivateKey.generate().encode(Base64Encoder).decode('ascii'),
+                                   # message_id are 32 bytes and encryption overhead is 64 bytes
+                                   "enc": b64encode(token_bytes(32+72)).decode('ascii')
+            }
+        )
 
     # TODO: add stronger timing attack mitigations (such as a random delay)
     # sleep(uniform(0, 3.0))
 
-    # assert (len(potential_messages) == commons.MAX_MESSAGES)
+    assert (len(potential_messages) == commons.MAX_MESSAGES)
 
     # padding to hide the number of meesages to be added later
     response_dict = {"status": "OK",

--- a/server.py
+++ b/server.py
@@ -144,7 +144,7 @@ def add_ephemeral_keys():
             ephemeral_key_verifying_key,
             None,
             ephemeral_key_dict["ephemeral_sig"])
-        redis.sadd(f"journalist:{journalist_verifying_key.encode(HexEncoder)}",
+        redis.sadd(f"journalist:{journalist_verifying_key.encode(HexEncoder).decode('ascii')}",
                    json.dumps({"ephemeral_key": ephemeral_key_verifying_key.encode(Base64Encoder).decode("ascii"),
                                "ephemeral_sig": ephemeral_sig}))
 
@@ -158,7 +158,7 @@ def get_ephemeral_keys():
 
     for journalist in journalists:
         journalist_dict = json.loads(journalist.decode("ascii"))
-        ephemeral_key_dict = json.loads(redis.spop(f"journalist:{VerifyKey(journalist_dict['journalist_key'], Base64Encoder).encode(HexEncoder)}").decode("ascii"))
+        ephemeral_key_dict = json.loads(redis.spop(f"journalist:{VerifyKey(journalist_dict['journalist_key'], Base64Encoder).encode(HexEncoder).decode('ascii')}").decode("ascii"))
         ephemeral_key_dict["journalist_key"] = journalist_dict["journalist_key"]
         ephemeral_keys.append(ephemeral_key_dict)
 

--- a/source.py
+++ b/source.py
@@ -1,15 +1,12 @@
 import argparse
 import json
-from base64 import b64encode
 from datetime import datetime
 from hashlib import sha3_256
 from secrets import token_bytes
 from time import time
 
-from nacl.encoding import Base64Encoder, HexEncoder
-from nacl.public import Box, PrivateKey, PublicKey
-from nacl.secret import SecretBox
-from nacl.signing import SigningKey, VerifyKey
+from nacl.encoding import Base64Encoder
+from nacl.public import PrivateKey
 
 import commons
 import pki


### PR DESCRIPTION
See here https://github.com/freedomofpress/securedrop-poc/issues/23.

We might want to test some more before merging, especially functionalities outside the `demo.sh`, such as attachments.