### PR TITLE
(WIP) Add initial 0.3 compatible changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cryptokeys/
 downloads/
 docs/html/
 node_modules/
+securedrop-protocol/target/*

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,12 @@ doxygen:  ## Generate browsable documentation and call/caller graphs (requires D
 	@doxygen
 	@echo "Now open \"$(PWD)/docs/html/index.html\" in your browser."
 
+.PHONY: build-wasm
+build-wasm:  ## Compile securedrop-protocol crate for wasm32-unknown-unknown (browser compat, requires rust toolchain).
+	@which cargo >> /dev/null || { echo "Please install the Rust toolchain"; exit 1; }
+	@rustup target list --installed | grep wasm32-unknown-unknown || { echo "Install wasm32 target using \`rustup target add wasm32-unknown-unknown\`"; exit 1; }
+	RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo build --manifest-path securedrop-protocol/Cargo.toml --target wasm32-unknown-unknown
+
 .PHONY: fix
 fix: docs-fix  ## Apply automatic fixes.
 

--- a/securedrop-protocol/src/journalist.rs
+++ b/securedrop-protocol/src/journalist.rs
@@ -7,7 +7,7 @@ use crate::keys::{
     JournalistEphemeralKEMKeyPair, JournalistEphemeralKeyBundle, JournalistEphemeralPKEKeyPair,
     JournalistEphemeralPublicKeys, JournalistFetchKeyPair, JournalistSigningKeyPair,
 };
-use crate::messages::core::{MessageFetchResponse, MessageIdFetchResponse};
+use crate::messages::core::{MessageChallengeFetchResponse, MessageFetchResponse};
 use crate::messages::setup::{JournalistRefreshRequest, JournalistSetupRequest};
 use crate::primitives::DHPublicKey;
 use crate::sign::VerifyingKey;
@@ -146,7 +146,7 @@ impl JournalistSession {
     pub fn fetch_message_ids<R: RngCore + CryptoRng>(
         &self,
         _rng: &mut R,
-    ) -> MessageIdFetchResponse {
+    ) -> MessageChallengeFetchResponse {
         // TODO: Implement message ID fetching
         unimplemented!()
     }

--- a/securedrop-protocol/src/keys/newsroom.rs
+++ b/securedrop-protocol/src/keys/newsroom.rs
@@ -17,4 +17,3 @@ impl NewsroomKeyPair {
         NewsroomKeyPair { sk, vk }
     }
 }
-

--- a/securedrop-protocol/src/messages/core.rs
+++ b/securedrop-protocol/src/messages/core.rs
@@ -106,14 +106,12 @@ pub type MessageSubmitRequest = MessageBundle;
 /// User (source or journalist) fetches message IDs
 ///
 /// This corresponds to step 7 in the spec.
-/// TODO: "FetchRequest/ChallengeFetchRequest"
-pub struct MessageIdFetchRequest {}
+pub struct MessageChallengeFetchRequest {}
 
 /// Server returns encrypted message IDs
 ///
 /// This corresponds to step 7 in the spec.
-/// TODO: naming as above?
-pub struct MessageIdFetchResponse {
+pub struct MessageChallengeFetchResponse {
     /// Number of message entries returned
     /// TODO: constant size response
     count: usize,

--- a/securedrop-protocol/src/messages/core.rs
+++ b/securedrop-protocol/src/messages/core.rs
@@ -2,8 +2,56 @@ use crate::primitives::{DHPublicKey, PPKPublicKey};
 use crate::{Signature, VerifyingKey};
 use alloc::vec::Vec;
 
-/// TODO: Should be (C, Z, X)
-pub struct MessageBundle {}
+pub struct MessageBundle {
+    /// C
+    pub sealed_envelope: SealedEnvelope,
+    /// (Z, X)
+    pub message_clue: MessageClue,
+}
+
+pub struct SealedEnvelope {
+    /// HPKE AuthPSK Sealed ciphertext
+    pub sealed_message: SealedMessage,
+
+    /// HPKE BaseMode Sealed X-WING encapsulated metadata (contains
+    /// sender pubkey needed to open SealedMessage.
+    /// See https://www.rfc-editor.org/rfc/rfc9180#section-9.9)
+    pub sealed_metadata: SealedMessageMetadata,
+    /// X-WING shared secret encaps, 1120 bytes
+    pub metadata_encaps: Vec<u16>,
+}
+
+/// Sealed metadata bytes
+pub struct SealedMessageMetadata {}
+
+/// Metadata for decrypting ciphertext
+/// TODO: check int sizes
+pub struct MessageMetadata {
+    pub sender_key: DHPublicKey,
+    message_dhakem_secret_encaps: Vec<u8>,
+    message_psk_secret_encaps: Vec<u8>,
+}
+
+/// Ciphertext bytes
+pub struct SealedMessage {}
+
+/// TODO: Plaintext message structure (i.e what keys or hashes of keys are included?)
+/// At minimum:
+/// Sender XWING key (for replies metadata)
+/// Sender MLKEM key (for replies)
+/// Identifiers: newsroom identifier
+/// Fetching key identifier?
+/// DH-AKEM key identifier (maybe not needed bc of how auth mode in hpke works)?
+/// Plaintext
+pub struct Message {}
+
+/// (Z, X)
+pub struct MessageClue {
+    /// DH share
+    pub clue_bytes: Vec<u8>,
+    /// Ephemeral DH pubkey
+    pub clue_pubkey: DHPublicKey,
+}
 
 /// Source fetches keys for the newsroom
 ///
@@ -52,27 +100,25 @@ pub struct SourceJournalistKeyResponse {
 /// User submits a message to the server $(C, Z, X)$
 ///
 /// This corresponds to step 6 for sources and step 9 for journalists in the spec.
-pub struct MessageSubmitRequest {
-    /// Encrypted message ciphertext
-    ciphertext: Vec<u8>,
-    /// Diffie-Hellman share Z
-    dh_share_z: Vec<u8>,
-    /// Diffie-Hellman share X
-    dh_share_x: Vec<u8>,
-}
+/// TODO: could remove this, just kept it for consistency of naming with the other types
+pub type MessageSubmitRequest = MessageBundle;
 
 /// User (source or journalist) fetches message IDs
 ///
 /// This corresponds to step 7 in the spec.
+/// TODO: "FetchRequest/ChallengeFetchRequest"
 pub struct MessageIdFetchRequest {}
 
 /// Server returns encrypted message IDs
 ///
 /// This corresponds to step 7 in the spec.
+/// TODO: naming as above?
 pub struct MessageIdFetchResponse {
     /// Number of message entries returned
+    /// TODO: constant size response
     count: usize,
     /// Array of (Q, cid) pairs where Q is the group DH share and cid is encrypted message ID
+    /// TODO: constant size array
     messages: Vec<(Vec<u8>, Vec<u8>)>,
 }
 
@@ -87,9 +133,5 @@ pub struct MessageFetchRequest {
 /// Server returns the requested message
 ///
 /// This corresponds to step 8 and 10 in the spec.
-pub struct MessageFetchResponse {
-    /// Encrypted message ciphertext
-    ciphertext: Vec<u8>,
-    /// Diffie-Hellman share X (only for source→journalist messages)
-    dh_share_x: Option<Vec<u8>>,
-}
+/// TODO: may remove alias
+pub type MessageFetchResponse = MessageBundle;

--- a/securedrop-protocol/src/server.rs
+++ b/securedrop-protocol/src/server.rs
@@ -13,9 +13,9 @@ use crate::keys::{
     NewsroomKeyPair,
 };
 use crate::messages::core::{
-    MessageFetchRequest, MessageFetchResponse, MessageIdFetchRequest, MessageIdFetchResponse,
-    MessageSubmitRequest, SourceJournalistKeyRequest, SourceJournalistKeyResponse,
-    SourceNewsroomKeyRequest, SourceNewsroomKeyResponse,
+    MessageChallengeFetchRequest, MessageChallengeFetchResponse, MessageFetchRequest,
+    MessageFetchResponse, MessageSubmitRequest, SourceJournalistKeyRequest,
+    SourceJournalistKeyResponse, SourceNewsroomKeyRequest, SourceNewsroomKeyResponse,
 };
 use crate::messages::setup::{
     JournalistRefreshRequest, JournalistRefreshResponse, JournalistSetupRequest,
@@ -230,9 +230,9 @@ impl ServerSession {
     /// Handle message ID fetch request (step 7)
     pub fn handle_message_id_fetch<R: RngCore + CryptoRng>(
         &self,
-        _request: MessageIdFetchRequest,
+        _request: MessageChallengeFetchRequest,
         _rng: &mut R,
-    ) -> MessageIdFetchResponse {
+    ) -> MessageChallengeFetchResponse {
         unimplemented!()
     }
 

--- a/securedrop-protocol/src/source.rs
+++ b/securedrop-protocol/src/source.rs
@@ -6,7 +6,7 @@ use crate::keys::{
     JournalistEnrollmentKeyBundle, JournalistEphemeralPublicKeys, SourceKeyBundle, SourcePassphrase,
 };
 use crate::messages::core::{
-    MessageFetchResponse, MessageIdFetchResponse, SourceJournalistKeyRequest,
+    MessageChallengeFetchResponse, MessageFetchResponse, SourceJournalistKeyRequest,
     SourceJournalistKeyResponse, SourceNewsroomKeyRequest, SourceNewsroomKeyResponse,
 };
 use crate::sign::VerifyingKey;
@@ -132,7 +132,7 @@ impl SourceSession {
     pub fn fetch_message_ids<R: RngCore + CryptoRng>(
         &self,
         _rng: &mut R,
-    ) -> MessageIdFetchResponse {
+    ) -> MessageChallengeFetchResponse {
         unimplemented!()
     }
 


### PR DESCRIPTION
@redshiftzero this is a start towards 0.3 - I have [more key refactoring WIP](https://github.com/freedomofpress/securedrop-protocol/commit/81a7c8dcd9f5088f34ec084e584c5f9c607bf0c3)  but it's not compile-ready or passing ci yet so I'm not including them for now, just need a little more time to fix them up.

So I don't slow you down, I'm submitting this as a pr to your branch now even though it's incomplete;  I'll keep working on the refactor that I previewed in that other branch, and if I'm done before you've had a chance to look at this I'll push commits to this branch, but otherwise I'll just rebase and submit separately afterwards.