### PR TITLE
Update rust-scaffold crate with 0.3 key types + journalist self-signature on fetch and reply keys

### DIFF
--- a/securedrop-protocol/Cargo.lock
+++ b/securedrop-protocol/Cargo.lock
@@ -1132,6 +1132,7 @@ dependencies = [
  "libcrux-curve25519 0.0.3 (git+https://github.com/cryspen/libcrux?rev=54c6624630e47ed599ffc1549101c2b861d51a8c)",
  "libcrux-ed25519",
  "libcrux-kem 0.0.3 (git+https://github.com/cryspen/libcrux?rev=54c6624630e47ed599ffc1549101c2b861d51a8c)",
+ "libcrux-ml-kem 0.0.3 (git+https://github.com/cryspen/libcrux?rev=54c6624630e47ed599ffc1549101c2b861d51a8c)",
  "libcrux-traits 0.0.3 (git+https://github.com/cryspen/libcrux?rev=54c6624630e47ed599ffc1549101c2b861d51a8c)",
  "proptest",
  "rand_chacha",

--- a/securedrop-protocol/Cargo.toml
+++ b/securedrop-protocol/Cargo.toml
@@ -13,6 +13,7 @@ libcrux-curve25519 = { git = "https://github.com/cryspen/libcrux", rev="54c66246
 libcrux-chacha20poly1305 = { git = "https://github.com/cryspen/libcrux", rev="54c6624630e47ed599ffc1549101c2b861d51a8c" }
 libcrux-traits = { git = "https://github.com/cryspen/libcrux", rev="54c6624630e47ed599ffc1549101c2b861d51a8c" }
 libcrux-kem = { git = "https://github.com/cryspen/libcrux", rev="54c6624630e47ed599ffc1549101c2b861d51a8c" }
+libcrux-ml-kem = { git = "https://github.com/cryspen/libcrux", rev="54c6624630e47ed599ffc1549101c2b861d51a8c" }
 hpke-rs = {version = "0.3.0", features = ["libcrux"]}
 rand_core = {version = "0.9"}
 rand_chacha = { version = "0.9", default-features = false }

--- a/securedrop-protocol/src/client.rs
+++ b/securedrop-protocol/src/client.rs
@@ -16,6 +16,7 @@ pub trait StructuredMessage {
 pub(crate) trait ClientPrivate {
     /// Get the fetching private key for message ID decryption
     fn fetching_private_key(&self) -> Result<[u8; 32], Error>;
+    fn message_enc_private_key_dhakem(&self) -> Result<[u8; 32], Error>;
 }
 
 /// Common client functionality for source and journalist clients

--- a/securedrop-protocol/src/client.rs
+++ b/securedrop-protocol/src/client.rs
@@ -94,14 +94,14 @@ pub trait Client {
     fn submit_structured_message<M, R>(
         &self,
         message: M,
-        recipient_ephemeral_keys: (
-            &crate::primitives::x25519::DHPublicKey,
-            &crate::primitives::PPKPublicKey,
+        recipient_message_keys: (
+            &crate::primitives::dh_akem::DhAkemPublicKey,
+            &crate::primitives::mlkem::MLKEM768PublicKey,
         ),
-        recipient_pke_key: &crate::primitives::PPKPublicKey,
+        recipient_metadata_key: &crate::primitives::xwing::XWingPublicKey,
         recipient_fetch_key: &crate::primitives::x25519::DHPublicKey,
-        sender_dh_private_key: &crate::primitives::x25519::DHPrivateKey,
-        sender_dh_public_key: &crate::primitives::x25519::DHPublicKey,
+        sender_dh_private_key: &crate::primitives::dh_akem::DhAkemPrivateKey,
+        sender_dh_public_key: &crate::primitives::dh_akem::DhAkemPublicKey,
         rng: &mut R,
     ) -> Result<Message, Error>
     where
@@ -113,13 +113,15 @@ pub trait Client {
 
         // 2. Perform authenticated encryption
         let ((c1, c2), c_double_prime) = crate::primitives::auth_encrypt(
+            rng,
             sender_dh_private_key,
-            recipient_ephemeral_keys,
+            recipient_message_keys,
             &padded_message,
         )?;
 
         // 3. Encrypt the DH key and ciphertexts
-        let c_prime = crate::primitives::enc(recipient_pke_key, sender_dh_public_key, &c1, &c2)?;
+        let c_prime =
+            crate::primitives::enc(recipient_metadata_key, sender_dh_public_key, &c1, &c2)?;
 
         // 4. Combine ciphertexts
         let ciphertext = [c_prime, c_double_prime].concat();

--- a/securedrop-protocol/src/journalist.rs
+++ b/securedrop-protocol/src/journalist.rs
@@ -38,7 +38,7 @@ pub struct JournalistClient {
     one_time_pubkeys: Vec<JournalistOneTimeKeyBundle>,
     /// TODO: store complete key bundles (private and pubkey)
     /// and use instead of dh_key for encryption
-    one_time_keystore: Vec<JournalistOneTimeKeyBundle>,
+    /// one_time_keystore: TODO
     /// Newsroom's verifying key
     newsroom_verifying_key: Option<VerifyingKey>,
 }

--- a/securedrop-protocol/src/journalist.rs
+++ b/securedrop-protocol/src/journalist.rs
@@ -186,7 +186,7 @@ impl JournalistClient {
     ) -> Result<Message, Error> {
         // Get the journalist's DH private key
         // TODO: not the long-term DH key!
-        let journalist_dhakem_keypair: JournalistEphemeralDHKeyPair = "";
+        let journalist_dhakem_keypair: JournalistEphemeralDHKeyPair = todo!("");
 
         let journalist_dh_private_key = self
             .dh_key
@@ -198,28 +198,30 @@ impl JournalistClient {
         // 1. Create the structured message according to Step 9 format:
         // TODO format needs revising; PQ_KEM_PSK key?
         // msg || S || J_sig,pk || J_fetch,pk || J_dh,pk || σ^NR || NR
-        let journalist_reply_message = JournalistReplyMessage {
-            message,
-            source,
-            journalist_sig_pk: self.signing_key.as_ref().unwrap().vk,
-            journalist_fetch_pk: self.fetching_key.as_ref().unwrap().public_key.clone(),
-            journalist_dh_pk: self.dh_key.as_ref().unwrap().public_key.clone(),
-            newsroom_signature,
-            newsroom_sig_pk: *self.get_newsroom_verifying_key()?,
-        };
+        // Proposed 0.3 format:
+        //
+        // let journalist_reply_message = JournalistReplyMessage {
+        //     message,
+        //     source,
+        //     journalist_sig_pk: self.signing_key.as_ref().unwrap().vk,
+        //     journalist_fetch_pk: self.fetching_key.as_ref().unwrap().public_key.clone(),
+        //     journalist_dh_pk: self.dh_key.as_ref().unwrap().public_key.clone(),
+        //     newsroom_signature,
+        //     newsroom_sig_pk: *self.get_newsroom_verifying_key()?,
+        // };
 
-        // 2. Use the shared method for encryption and message creation
-        self.submit_structured_message(
-            journalist_reply_message,
-            (
-                &source_public_keys.message_dhakem_pk,
-                &source_public_keys.message_pq_psk_pk,
-            ),
-            &source_public_keys.metadata_pk,
-            &source_public_keys.fetch_pk,
-            &journalist_dh_private_key,
-            &self.dh_key.as_ref().unwrap().public_key,
-            rng,
-        )
+        // // 2. Use the shared method for encryption and message creation
+        // self.submit_structured_message(
+        //     journalist_reply_message,
+        //     (
+        //         &source_public_keys.message_dhakem_pk,
+        //         &source_public_keys.message_pq_psk_pk,
+        //     ),
+        //     &source_public_keys.metadata_pk,
+        //     &source_public_keys.fetch_pk,
+        //     &journalist_dh_private_key,
+        //     &self.dh_key.as_ref().unwrap().public_key,
+        //     rng,
+        // )
     }
 }

--- a/securedrop-protocol/src/keys.rs
+++ b/securedrop-protocol/src/keys.rs
@@ -25,7 +25,9 @@ impl FPFKeyPair {
 pub use journalist::{
     JournalistDHKeyPair, JournalistEnrollmentKeyBundle, JournalistEphemeralDHKeyPair,
     JournalistEphemeralKEMKeyPair, JournalistEphemeralPKEKeyPair, JournalistFetchKeyPair,
-    JournalistOneTimeKeyBundle, JournalistOneTimePublicKeys, JournalistSigningKeyPair,
+    JournalistOneTimeKeyBundle, JournalistOneTimeKeypairs,
+    JournalistOneTimeMessageClassicalKeyPair, JournalistOneTimeMessagePQKeyPair,
+    JournalistOneTimeMetadataKeyPair, JournalistOneTimePublicKeys, JournalistSigningKeyPair,
 };
 pub use newsroom::NewsroomKeyPair;
 pub use source::{

--- a/securedrop-protocol/src/keys.rs
+++ b/securedrop-protocol/src/keys.rs
@@ -27,7 +27,8 @@ pub use journalist::{
     JournalistEphemeralKEMKeyPair, JournalistEphemeralPKEKeyPair, JournalistFetchKeyPair,
     JournalistOneTimeKeyBundle, JournalistOneTimeKeypairs,
     JournalistOneTimeMessageClassicalKeyPair, JournalistOneTimeMessagePQKeyPair,
-    JournalistOneTimeMetadataKeyPair, JournalistOneTimePublicKeys, JournalistSigningKeyPair,
+    JournalistOneTimeMetadataKeyPair, JournalistOneTimePublicKeys, JournalistReplyClassicalKeyPair,
+    JournalistSigningKeyPair,
 };
 pub use newsroom::NewsroomKeyPair;
 pub use source::{

--- a/securedrop-protocol/src/keys.rs
+++ b/securedrop-protocol/src/keys.rs
@@ -25,7 +25,7 @@ impl FPFKeyPair {
 pub use journalist::{
     JournalistDHKeyPair, JournalistEnrollmentKeyBundle, JournalistEphemeralDHKeyPair,
     JournalistEphemeralKEMKeyPair, JournalistEphemeralPKEKeyPair, JournalistFetchKeyPair,
-    JournalistOneTimeKeyBundle, JournalistOneTimeKeypairs,
+    JournalistLongtermPublicKeys, JournalistOneTimeKeyBundle, JournalistOneTimeKeypairs,
     JournalistOneTimeMessageClassicalKeyPair, JournalistOneTimeMessagePQKeyPair,
     JournalistOneTimeMetadataKeyPair, JournalistOneTimePublicKeys, JournalistReplyClassicalKeyPair,
     JournalistSigningKeyPair,

--- a/securedrop-protocol/src/keys/journalist.rs
+++ b/securedrop-protocol/src/keys/journalist.rs
@@ -219,7 +219,7 @@ impl JournalistOneTimePublicKeys {
     }
 }
 
-/// One-time key set for a journalist
+/// One-time public key set for a journalist
 #[derive(Debug, Clone)]
 pub struct JournalistOneTimeKeyBundle {
     /// The one-time public keys
@@ -227,6 +227,25 @@ pub struct JournalistOneTimeKeyBundle {
     /// Journalist's signature over the one-time keys
     pub signature: Signature,
 }
+
+/// One-time keystore (public and private) for a journalist
+/// TODO: improve/refactor with OneTimeKeyBundle
+/// TODO: use native hpke-rs types
+#[derive(Debug, Clone)]
+pub struct JournalistOneTimeKeystore {
+    // One-time PQ KEM PSK (message enc)
+    pub(crate) one_time_message_pq_sk: MLKEM768PrivateKey,
+    pubone_time_message_pq_pk: MLKEM768PublicKey,
+    /// One-time DH-AKEM public key (message enc)
+    pub(crate) one_time_message_sk: DhAkemPrivateKey,
+    pub one_time_message_pk: DhAkemPublicKey,
+    /// One-time XWING public key (metadata enc)
+    pub(crate) one_time_metadata_sk: XWingPrivateKey,
+    pub one_time_metadata_pk: XWingPublicKey,
+}
+
+// TODO
+impl JournalistOneTimeKeystore {}
 
 /// Journalist enrollment key bundle for 0.3 spec
 ///

--- a/securedrop-protocol/src/keys/journalist.rs
+++ b/securedrop-protocol/src/keys/journalist.rs
@@ -18,7 +18,7 @@ pub struct JournalistSigningKeyPair {
 
 impl JournalistSigningKeyPair {
     pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> JournalistSigningKeyPair {
-        let sk = SigningKey::new(&mut rng).unwrap();
+        let sk = SigningKey::new(&mut rng).expect("Signing key generation should succeed");
         let vk = sk.vk;
         JournalistSigningKeyPair { vk, sk }
     }

--- a/securedrop-protocol/src/keys/journalist.rs
+++ b/securedrop-protocol/src/keys/journalist.rs
@@ -245,6 +245,36 @@ impl JournalistOneTimeMetadataKeyPair {
     }
 }
 
+/// Journalist medium or long-term DH-AKEM key used for sending replies
+#[derive(Debug, Clone)]
+pub struct JournalistReplyClassicalKeyPair {
+    pub public_key: DhAkemPublicKey,
+    pub(crate) private_key: DhAkemPrivateKey,
+}
+
+impl JournalistReplyClassicalKeyPair {
+    pub fn new(
+        pubkey: DhAkemPublicKey,
+        priv_key: DhAkemPrivateKey,
+    ) -> JournalistReplyClassicalKeyPair {
+        JournalistReplyClassicalKeyPair {
+            public_key: (pubkey),
+            private_key: (priv_key),
+        }
+    }
+
+    /// Generate a new medium/long-term keypair for sending replies
+    pub fn generate<R: RngCore + CryptoRng>(mut rng: R) -> JournalistReplyClassicalKeyPair {
+        let (private_key, public_key) =
+            crate::primitives::dh_akem::generate_dh_akem_keypair(&mut rng)
+                .expect("DH-AKEM key generation failed");
+        JournalistReplyClassicalKeyPair {
+            private_key,
+            public_key,
+        }
+    }
+}
+
 /// One-time public keys for a journalist (without signature)
 ///
 /// This struct contains just the one-time public keys that need to be signed.

--- a/securedrop-protocol/src/keys/source.rs
+++ b/securedrop-protocol/src/keys/source.rs
@@ -172,8 +172,8 @@ impl SourceMessagePQKeyPair {
     pub fn from_bytes(priv_key_bytes: [u8; 64]) -> SourceMessagePQKeyPair {
         let (sk, pk) = mlkem768::generate_key_pair(priv_key_bytes).into_parts();
         // TODO: use hpke-rs types in keys.rs
-        let mlkem_encaps = MLKEM768PublicKey::from_bytes(*pk.as_slice());
-        let mlkem_decaps = MLKEM768PrivateKey::from_bytes(*sk.as_slice());
+        let mlkem_encaps = MLKEM768PublicKey::from_bytes(pk.into());
+        let mlkem_decaps = MLKEM768PrivateKey::from_bytes(sk.into());
 
         SourceMessagePQKeyPair {
             public_key: mlkem_encaps,

--- a/securedrop-protocol/src/keys/source.rs
+++ b/securedrop-protocol/src/keys/source.rs
@@ -34,7 +34,7 @@ pub struct SourcePublicKeys {
 #[derive(Debug, Clone)]
 pub struct SourceKeyBundle {
     pub fetch: SourceFetchKeyPair,
-    pub long_term_dh: SourceMessageClassicalKeyPair,
+    pub message_encrypt_dhakem: SourceMessageClassicalKeyPair,
     pub pq_kem_psk: SourceMessagePQKeyPair,
     pub metadata: SourceMetadataKeyPair,
 }
@@ -232,7 +232,7 @@ impl SourceMetadataKeyPair {
 impl SourceKeyBundle {
     /// Get the source's DH-AKEM  public key
     pub fn dh_public_key(&self) -> &DhAkemPublicKey {
-        &self.long_term_dh.public_key
+        &self.message_encrypt_dhakem.public_key
     }
 
     /// Get the source's metadata public key
@@ -296,7 +296,7 @@ impl SourceKeyBundle {
         // Create key pairs
         Self {
             fetch: SourceFetchKeyPair::new(fetch_result.into()),
-            long_term_dh: SourceMessageClassicalKeyPair::from_bytes(dh_result.into()),
+            message_encrypt_dhakem: SourceMessageClassicalKeyPair::from_bytes(dh_result.into()),
             pq_kem_psk: SourceMessagePQKeyPair::from_bytes(kem_result.into()),
             metadata: SourceMetadataKeyPair::from_bytes(pke_result.into()),
         }

--- a/securedrop-protocol/src/keys/source.rs
+++ b/securedrop-protocol/src/keys/source.rs
@@ -1,3 +1,5 @@
+use libcrux_kem::{Algorithm, key_gen_derand};
+use libcrux_ml_kem::*;
 use rand_core::{CryptoRng, RngCore};
 
 use crate::primitives::{
@@ -8,17 +10,19 @@ use crate::primitives::{
     xwing::{XWingPrivateKey, XWingPublicKey},
 };
 
-/// Source public keys needed for journalist to reply to a source
-///
-/// This contains the ephemeral keys that the source provided during their message submission.
+/// This contains the sender keys for the source, provided during their message submission.
+/// The DH-AKEM public key is provided in the outer metadata, and is needed to
+/// decrypt the inner authenticated ciphertext.
+/// The metadata key, PQ PSK key, and Fetching key are provided so that sources
+/// can receive replies.
 #[derive(Debug, Clone)]
 pub struct SourcePublicKeys {
-    /// Source's ephemeral DH public key
-    pub ephemeral_dh_pk: DHPublicKey,
-    /// Source's ephemeral KEM public key
-    pub ephemeral_kem_pk: PPKPublicKey,
-    /// Source's ephemeral PKE public key
-    pub ephemeral_pke_pk: PPKPublicKey,
+    /// Source's DH-AKEM public key
+    pub message_dhakem_pk: DhAkemPublicKey,
+    /// Source's PQ KEM PSK public key
+    pub message_pq_psk_pk: MLKEM768PublicKey,
+    /// Source's Metadata public key
+    pub metadata_pk: XWingPublicKey,
     /// Source's fetching public key
     pub fetch_pk: DHPublicKey,
 }
@@ -28,9 +32,9 @@ pub struct SourcePublicKeys {
 #[derive(Debug, Clone)]
 pub struct SourceKeyBundle {
     pub fetch: SourceFetchKeyPair,
-    pub long_term_dh: SourceDHKeyPair,
-    pub kem: SourceKEMKeyPair,
-    pub pke: SourcePKEKeyPair,
+    pub long_term_dh: SourceMessageClassicalKeyPair,
+    pub pq_kem_psk: SourceMessagePQKeyPair,
+    pub metadata: SourceMetadataKeyPair,
 }
 
 #[derive(Debug, Clone)]
@@ -155,42 +159,107 @@ impl SourcePKEKeyPair {
 /// Source message encryption PSK (used for PQ secret)
 ///
 /// $S_pq$ in the specification.
+#[derive(Debug, Clone)]
 pub struct SourceMessagePQKeyPair {
     pub public_key: MLKEM768PublicKey,
     pub(crate) private_key: MLKEM768PrivateKey,
 }
 
-/// Source message encryption keypair
+/// Source message encryption keypair (PQ PSK component)
+impl SourceMessagePQKeyPair {
+    /// Given a random seed, construct MLKEM768 encaps and decaps key.
+    /// TODO: ***FOR PROOF OF CONCEPT ONLY!*** Not for production use.
+    pub fn from_bytes(priv_key_bytes: [u8; 64]) -> SourceMessagePQKeyPair {
+        let (sk, pk) = mlkem768::generate_key_pair(priv_key_bytes).into_parts();
+        // TODO: use hpke-rs types in keys.rs
+        let mlkem_encaps = MLKEM768PublicKey::from_bytes(*pk.as_slice());
+        let mlkem_decaps = MLKEM768PrivateKey::from_bytes(*sk.as_slice());
+
+        SourceMessagePQKeyPair {
+            public_key: mlkem_encaps,
+            private_key: mlkem_decaps,
+        }
+    }
+}
+
+/// Source message encryption keypair (classical component)
 ///
-/// $S_pke$ in the specification.
+/// $S_dh$ in the specification.
+#[derive(Debug, Clone)]
 pub struct SourceMessageClassicalKeyPair {
     pub public_key: DhAkemPublicKey,
     pub(crate) private_key: DhAkemPrivateKey,
 }
 
-/// Source metadata keypair
+impl SourceMessageClassicalKeyPair {
+    /// Given a random seed, construct XWING encaps and decaps key.
+    /// TODO: ***FOR PROOF OF CONCEPT ONLY!*** Not for production use.
+    pub fn from_bytes(seed_bytes: [u8; 64]) -> SourceMessageClassicalKeyPair {
+        let alg = Algorithm::X25519;
+        let (sk, pk) =
+            key_gen_derand(alg, &seed_bytes).expect("Failed to generate DH-AKEM keypair");
+        let sk_bytes = sk.encode().try_into().expect("error encoding dh-akem sk");
+        let pk_bytes = pk.encode().try_into().expect("error encoding dh-akem pk");
+
+        let md_encaps = DhAkemPublicKey::from_bytes(pk_bytes);
+        let md_decaps = DhAkemPrivateKey::from_bytes(sk_bytes);
+
+        SourceMessageClassicalKeyPair {
+            public_key: (md_encaps),
+            private_key: (md_decaps),
+        }
+    }
+}
+
+/// Source metadata (hybrid) keypair
 ///
 /// $S_md$ in the specification.
+#[derive(Debug, Clone)]
 pub struct SourceMetadataKeyPair {
     pub public_key: XWingPublicKey,
     pub(crate) private_key: XWingPrivateKey,
 }
 
+impl SourceMetadataKeyPair {
+    /// Given a random seed, construct XWING encaps and decaps key.
+    /// TODO: ***FOR PROOF OF CONCEPT ONLY!*** Not for production use.
+    pub fn from_bytes(seed_bytes: [u8; 64]) -> SourceMetadataKeyPair {
+        let alg = Algorithm::XWingKemDraft06;
+        let (sk, pk) = key_gen_derand(alg, &seed_bytes).expect("Failed to generate XWing keypair");
+        let pk_bytes = pk
+            .encode()
+            .try_into()
+            .expect("Error encoding xwing pk bytes");
+        let sk_bytes = sk
+            .encode()
+            .try_into()
+            .expect("Error encoding xwing sk bytes");
+
+        let md_encaps = XWingPublicKey::from_bytes(pk_bytes);
+        let md_decaps = XWingPrivateKey::from_bytes(sk_bytes);
+
+        SourceMetadataKeyPair {
+            public_key: md_encaps,
+            private_key: md_decaps,
+        }
+    }
+}
+
 /// Generate a passphrase and the corresponding keys (via KDF).
 impl SourceKeyBundle {
-    /// Get the source's DH public key
-    pub fn dh_public_key(&self) -> &DHPublicKey {
+    /// Get the source's DH-AKEM  public key
+    pub fn dh_public_key(&self) -> &DhAkemPublicKey {
         &self.long_term_dh.public_key
     }
 
-    /// Get the source's PKE public key
-    pub fn pke_public_key(&self) -> &PPKPublicKey {
-        &self.pke.public_key
+    /// Get the source's metadata public key
+    pub fn pke_public_key(&self) -> &XWingPublicKey {
+        &self.metadata.public_key
     }
 
     /// Get the source's KEM public key
-    pub fn kem_public_key(&self) -> &PPKPublicKey {
-        &self.kem.public_key
+    pub fn kem_public_key(&self) -> &MLKEM768PublicKey {
+        &self.pq_kem_psk.public_key
     }
 
     /// Get the source's fetch public key
@@ -217,8 +286,8 @@ impl SourceKeyBundle {
     pub fn from_passphrase(passphrase: &[u8]) -> Self {
         use blake2::{Blake2b, Digest};
 
-        // DH key
-        let mut dh_hasher = Blake2b::<blake2::digest::typenum::U32>::new();
+        // DH-AKEM key
+        let mut dh_hasher = Blake2b::<blake2::digest::typenum::U64>::new();
         dh_hasher.update(b"SD_DH_KEY");
         dh_hasher.update(passphrase);
         let dh_result = dh_hasher.finalize();
@@ -229,14 +298,14 @@ impl SourceKeyBundle {
         fetch_hasher.update(passphrase);
         let fetch_result = fetch_hasher.finalize();
 
-        // PKE key
-        let mut pke_hasher = Blake2b::<blake2::digest::typenum::U32>::new();
+        // Metadata Key
+        let mut pke_hasher = Blake2b::<blake2::digest::typenum::U64>::new();
         pke_hasher.update(b"SD_PKE_KEY");
         pke_hasher.update(passphrase);
         let pke_result = pke_hasher.finalize();
 
-        // KEM key
-        let mut kem_hasher = Blake2b::<blake2::digest::typenum::U32>::new();
+        // PQ KEM PSK key
+        let mut kem_hasher = Blake2b::<blake2::digest::typenum::U64>::new();
         kem_hasher.update(b"SD_KEM_KEY");
         kem_hasher.update(passphrase);
         let kem_result = kem_hasher.finalize();
@@ -244,9 +313,9 @@ impl SourceKeyBundle {
         // Create key pairs
         Self {
             fetch: SourceFetchKeyPair::new(fetch_result.into()),
-            long_term_dh: SourceDHKeyPair::new(dh_result.into()),
-            kem: SourceKEMKeyPair::new(kem_result.into()),
-            pke: SourcePKEKeyPair::new(pke_result.into()),
+            long_term_dh: SourceMessageClassicalKeyPair::from_bytes(dh_result.into()),
+            pq_kem_psk: SourceMessagePQKeyPair::from_bytes(kem_result.into()),
+            metadata: SourceMetadataKeyPair::from_bytes(pke_result.into()),
         }
     }
 }

--- a/securedrop-protocol/src/lib.rs
+++ b/securedrop-protocol/src/lib.rs
@@ -37,7 +37,7 @@ pub mod primitives;
 /// TODO: Move to primitives?
 pub mod sign;
 
-pub use sign::{Signature, SigningKey, VerifyingKey};
+pub use sign::{SelfSignature, Signature, SigningKey, VerifyingKey};
 
 /// Server storage
 pub mod storage;

--- a/securedrop-protocol/src/messages/core.rs
+++ b/securedrop-protocol/src/messages/core.rs
@@ -110,12 +110,9 @@ pub struct SourceJournalistKeyResponse {
 /// Message structure for Step 6: Source submits a message
 ///
 /// This represents the message format before padding and encryption:
-/// `msg || S_dh,pk || S_pke,pk || S_kem,pk || S_fetch,pk || J^i_sig,pk || NR`
-///
-/// Updated for 0.3 spec with new key types:
-/// - source_message_pq_pk: MLKEM-768 for message enc PSK (one-time)
-/// - source_message_pk: DH-AKEM for message enc (one-time)
-/// - source_metadata_pk: XWING for metadata enc (one-time)
+/// `source_message_pq_pk || source_message_pk || source_metadata_pk || S_fetch,pk || J^i_sig,pk || NR || msg`
+/// TODO: Decide on actual format
+/// TODO: Just include a hash of the DH-AKEM public key, 0.3 description suggests that
 #[derive(Clone)]
 pub struct SourceMessage {
     /// The actual message content
@@ -137,7 +134,7 @@ pub struct SourceMessage {
 impl SourceMessage {
     /// Serialize the message into bytes for padding and encryption
     ///
-    /// Note: Deviated from spec here to put variable length field last
+    /// Note: Deviated from 0.2 spec here to put variable length field last
     pub fn into_bytes(self) -> Vec<u8> {
         let mut bytes: Vec<u8> = Vec::new();
         bytes.extend_from_slice(&self.source_message_pq_pk.as_bytes()[0..1184]);

--- a/securedrop-protocol/src/messages/core.rs
+++ b/securedrop-protocol/src/messages/core.rs
@@ -3,7 +3,7 @@ use crate::primitives::{
     PPKPublicKey, dh_akem::DhAkemPublicKey, mlkem::MLKEM768PublicKey, x25519::DHPublicKey,
     xwing::XWingPublicKey,
 };
-use crate::{Signature, VerifyingKey};
+use crate::{SelfSignature, Signature, VerifyingKey};
 use alloc::vec::Vec;
 use uuid::Uuid;
 
@@ -88,13 +88,15 @@ pub struct SourceJournalistKeyRequest {}
 /// - ephemeral_dh_pk: MLKEM-768 for message enc PSK (one-time)
 /// - ephemeral_kem_pk: DH-AKEM for message enc (one-time)
 /// - ephemeral_pke_pk: XWING for metadata enc (one-time)
+/// TODO: this may be split into 2 responses, one that contains
+/// static keys and one that contains one-time keys
 pub struct SourceJournalistKeyResponse {
     /// Journalist's signing public key
     pub journalist_sig_pk: VerifyingKey,
     /// Journalist's fetching public key
     pub journalist_fetch_pk: DHPublicKey,
     /// Journalist's long-term DH public key
-    pub journalist_dh_pk: DHPublicKey,
+    pub journalist_dhakem_sending_pk: DhAkemPublicKey,
     /// Newsroom's signature over journalist keys
     pub newsroom_sig: Signature,
     /// MLKEM-768 public key for message enc PSK (one-time)
@@ -103,8 +105,10 @@ pub struct SourceJournalistKeyResponse {
     pub one_time_message_pk: DhAkemPublicKey,
     /// XWING public key for metadata enc (one-time)
     pub one_time_metadata_pk: XWingPublicKey,
-    /// Journalist's signature over ephemeral keys
+    /// Journalist's signature over one-time keys
     pub journalist_ephemeral_sig: Signature,
+    /// Journalist's signature over their long-term keys
+    pub journalist_self_sig: SelfSignature,
 }
 
 /// Message structure for Step 6: Source submits a message

--- a/securedrop-protocol/src/primitives/mlkem.rs
+++ b/securedrop-protocol/src/primitives/mlkem.rs
@@ -39,6 +39,46 @@ impl MLKEM768PrivateKey {
     }
 }
 
+/// Generate MLKEM-768 keypair from external randomness
+/// FOR TEST PURPOSES ONLY
+pub fn deterministic_keygen(
+    randomness: [u8; 32],
+) -> Result<(MLKEM768PrivateKey, MLKEM768PublicKey), anyhow::Error> {
+    use libcrux_kem::{Algorithm, key_gen_derand};
+
+    // Generate MLKEM-768 keypair using libcrux_kem with deterministic randomness
+    let (sk, pk) = key_gen_derand(Algorithm::MlKem768, &randomness)
+        .map_err(|e| anyhow::anyhow!("MLKEM-768 deterministic key generation failed: {:?}", e))?;
+
+    // Convert to our types
+    let private_key_bytes = sk.encode();
+    let public_key_bytes = pk.encode();
+
+    // Validate key sizes (MLKEM-768 should have consistent sizes)
+    if private_key_bytes.len() != MLKEM768_PRIVATE_KEY_LEN
+        || public_key_bytes.len() != MLKEM768_PUBLIC_KEY_LEN
+    {
+        return Err(anyhow::anyhow!(
+            "Unexpected MLKEM-768 key sizes: private={}, public={}",
+            private_key_bytes.len(),
+            public_key_bytes.len()
+        ));
+    }
+
+    let private_key = MLKEM768PrivateKey::from_bytes(
+        private_key_bytes
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("Failed to convert private key bytes"))?,
+    );
+    let public_key = MLKEM768PublicKey::from_bytes(
+        public_key_bytes
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("Failed to convert public key bytes"))?,
+    );
+
+    Ok((private_key, public_key))
+}
+
 /// Generate a new MLKEM-768 keypair using libcrux_kem
 pub fn generate_mlkem768_keypair<R: RngCore + CryptoRng>(
     rng: &mut R,

--- a/securedrop-protocol/src/primitives/mlkem.rs
+++ b/securedrop-protocol/src/primitives/mlkem.rs
@@ -12,7 +12,7 @@ pub const MLKEM768_PRIVATE_KEY_LEN: usize = 2400;
 pub struct MLKEM768PublicKey([u8; MLKEM768_PUBLIC_KEY_LEN]);
 
 /// MLKEM-768 private key.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct MLKEM768PrivateKey([u8; MLKEM768_PRIVATE_KEY_LEN]);
 
 impl MLKEM768PublicKey {

--- a/securedrop-protocol/src/primitives/pad.rs
+++ b/securedrop-protocol/src/primitives/pad.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 /// Fixed-length padded message length.
 ///
 /// Note: I made this up. We should pick something based on actual reasons.
-pub const PADDED_MESSAGE_LEN: usize = 1024;
+pub const PADDED_MESSAGE_LEN: usize = 100000;
 
 /// Pad a message to a fixed length
 pub fn pad_message(message: &[u8]) -> Vec<u8> {

--- a/securedrop-protocol/src/primitives/xwing.rs
+++ b/securedrop-protocol/src/primitives/xwing.rs
@@ -36,6 +36,46 @@ impl XWingPrivateKey {
     }
 }
 
+/// Generate XWING keypair from external randomness
+/// FOR TEST PURPOSES ONLY
+pub fn deterministic_keygen(
+    randomness: [u8; 32],
+) -> Result<(XWingPrivateKey, XWingPublicKey), anyhow::Error> {
+    use libcrux_kem::{Algorithm, key_gen_derand};
+
+    // Generate XWING keypair using libcrux_kem with deterministic randomness
+    let (sk, pk) = key_gen_derand(Algorithm::XWingKemDraft06, &randomness)
+        .map_err(|e| anyhow::anyhow!("XWING deterministic key generation failed: {:?}", e))?;
+
+    // Convert to our types
+    let private_key_bytes = sk.encode();
+    let public_key_bytes = pk.encode();
+
+    // Validate key sizes (XWING should have consistent sizes)
+    if private_key_bytes.len() != XWING_PRIVATE_KEY_LEN
+        || public_key_bytes.len() != XWING_PUBLIC_KEY_LEN
+    {
+        return Err(anyhow::anyhow!(
+            "Unexpected XWING key sizes: private={}, public={}",
+            private_key_bytes.len(),
+            public_key_bytes.len()
+        ));
+    }
+
+    let private_key = XWingPrivateKey::from_bytes(
+        private_key_bytes
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("Failed to convert private key bytes"))?,
+    );
+    let public_key = XWingPublicKey::from_bytes(
+        public_key_bytes
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("Failed to convert public key bytes"))?,
+    );
+
+    Ok((private_key, public_key))
+}
+
 /// Generate a new XWING keypair using libcrux_kem
 pub fn generate_xwing_keypair<R: RngCore + CryptoRng>(
     rng: &mut R,
@@ -78,6 +118,7 @@ pub fn generate_xwing_keypair<R: RngCore + CryptoRng>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
     use rand_chacha::ChaCha20Rng;
     use rand_core::SeedableRng;
 
@@ -105,5 +146,12 @@ mod tests {
 
         assert_eq!(private_key.as_bytes(), reconstructed_private.as_bytes());
         assert_eq!(public_key.as_bytes(), reconstructed_public.as_bytes());
+    }
+
+    #[test]
+    fn test_deterministic_keygen() {
+        proptest!(|(randomness in proptest::array::uniform32(any::<u8>()).prop_filter("exclude zero", |arr| arr != &[0u8; 32]))| {
+            let (private_key, public_key) = deterministic_keygen(randomness.try_into().unwrap()).unwrap();
+        });
     }
 }

--- a/securedrop-protocol/src/primitives/xwing.rs
+++ b/securedrop-protocol/src/primitives/xwing.rs
@@ -9,7 +9,7 @@ pub const XWING_PRIVATE_KEY_LEN: usize = 32;
 pub struct XWingPublicKey([u8; XWING_PUBLIC_KEY_LEN]);
 
 /// XWING private key.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct XWingPrivateKey([u8; XWING_PRIVATE_KEY_LEN]);
 
 impl XWingPublicKey {

--- a/securedrop-protocol/src/sign.rs
+++ b/securedrop-protocol/src/sign.rs
@@ -12,6 +12,16 @@ pub struct SigningKey {
 #[derive(Copy, Clone)]
 pub struct VerifyingKey(LibCruxVerifyingKey);
 
+// TODO (avoid confusion between journalist self-signature and newsroom signature)
+#[derive(Debug, Clone)]
+pub struct SelfSignature(pub Signature);
+
+impl SelfSignature {
+    pub fn as_signature(self) -> Signature {
+        self.0
+    }
+}
+
 /// An Ed25519 signature.
 #[derive(Debug, Clone)]
 pub struct Signature(pub [u8; 64]);

--- a/securedrop-protocol/src/source.rs
+++ b/securedrop-protocol/src/source.rs
@@ -89,6 +89,16 @@ impl ClientPrivate for SourceClient {
             .clone()
             .into_bytes())
     }
+    fn message_enc_private_key_dhakem(&self) -> Result<[u8; 32], Error> {
+        Ok(*self
+            .key_bundle
+            .as_ref()
+            .unwrap()
+            .message_encrypt_dhakem
+            .private_key
+            .clone()
+            .as_bytes())
+    }
 }
 
 impl SourceClient {
@@ -181,7 +191,7 @@ impl SourceClient {
             let source_message = SourceMessage {
                 message: message.clone(),
                 source_message_pq_pk: key_bundle.pq_kem_psk.public_key.clone(),
-                source_message_pk: key_bundle.long_term_dh.public_key.clone(),
+                source_message_pk: key_bundle.message_encrypt_dhakem.public_key.clone(),
                 source_metadata_pk: key_bundle.metadata.public_key.clone(),
                 source_fetch_pk: key_bundle.fetch.public_key.clone(),
                 journalist_sig_pk: journalist_response.journalist_sig_pk,
@@ -197,8 +207,8 @@ impl SourceClient {
                 ),
                 &journalist_response.one_time_metadata_pk,
                 &journalist_response.journalist_fetch_pk,
-                &key_bundle.long_term_dh.private_key,
-                &key_bundle.long_term_dh.public_key,
+                &key_bundle.message_encrypt_dhakem.private_key,
+                &key_bundle.message_encrypt_dhakem.public_key,
                 rng,
             )?;
 
@@ -234,13 +244,13 @@ mod tests {
 
         // DH keys
         assert_eq!(
-            keybundle1.long_term_dh.public_key.as_bytes(),
-            keybundle2.long_term_dh.public_key.as_bytes(),
+            keybundle1.message_encrypt_dhakem.public_key.as_bytes(),
+            keybundle2.message_encrypt_dhakem.public_key.as_bytes(),
             "DH Pubkey should be identical"
         );
         assert_eq!(
-            keybundle1.long_term_dh.private_key.as_bytes(),
-            keybundle2.long_term_dh.private_key.as_bytes(),
+            keybundle1.message_encrypt_dhakem.private_key.as_bytes(),
+            keybundle2.message_encrypt_dhakem.private_key.as_bytes(),
             "DH Private Key should be identical"
         );
 

--- a/securedrop-protocol/src/source.rs
+++ b/securedrop-protocol/src/source.rs
@@ -240,6 +240,7 @@ mod tests {
             assert_eq!(bytes1, bytes2, "{} bytes should be identical", label);
         }
 
+        // TODO: there's a type mismatch here
         let checks = [
             (
                 &keybundle1.long_term_dh.public_key.as_bytes(),
@@ -274,22 +275,8 @@ mod tests {
         ];
 
         // Iterate over each check and call `assert_bytes_eq`
-        for (label, bytes1, bytes2) in checks.iter() {
-            assert_bytes_eq(label, bytes1, bytes2);
+        for (bytes1, bytes2, label) in checks.iter() {
+            assert_bytes_eq(bytes1, bytes2, label);
         }
-
-        // Assert that the key bundles are identical
-        assert_eq!(
-            keybundle1.long_term_dh.public_key.as_bytes(),
-            keybundle2.long_term_dh.public_key.as_bytes(),
-            "KeyBundles should be identical"
-        );
-
-        // Assert that the key bundles are identical
-        assert_eq!(
-            keybundle1.long_term_dh.private_key.as_bytes(),
-            keybundle2.long_term_dh.private_key.as_bytes(),
-            "KeyBundles should be identical"
-        );
     }
 }

--- a/securedrop-protocol/src/source.rs
+++ b/securedrop-protocol/src/source.rs
@@ -236,47 +236,40 @@ mod tests {
         let keybundle1 = session1.key_bundle.expect("Should be keybundle");
         let keybundle2 = session2.key_bundle.expect("Should be keybundle");
 
-        fn assert_bytes_eq(bytes1: &[u8], bytes2: &[u8], label: &str) {
-            assert_eq!(bytes1, bytes2, "{} bytes should be identical", label);
-        }
+        // DH keys
+        assert_eq!(
+            keybundle1.long_term_dh.public_key.as_bytes(),
+            keybundle2.long_term_dh.public_key.as_bytes(),
+            "DH Pubkey should be identical"
+        );
+        assert_eq!(
+            keybundle1.long_term_dh.private_key.as_bytes(),
+            keybundle2.long_term_dh.private_key.as_bytes(),
+            "DH Private Key should be identical"
+        );
 
-        // TODO: there's a type mismatch here
-        let checks = [
-            (
-                &keybundle1.long_term_dh.public_key.as_bytes(),
-                &keybundle2.long_term_dh.public_key.as_bytes(),
-                "DH Pubkey",
-            ),
-            (
-                &keybundle1.long_term_dh.private_key.as_bytes(),
-                &keybundle2.long_term_dh.private_key.as_bytes(),
-                "DH Private Key",
-            ),
-            (
-                &keybundle1.pq_kem_psk.public_key.as_bytes(),
-                &keybundle2.pq_kem_psk.public_key.as_bytes(),
-                "PQ KEM Public Key",
-            ),
-            (
-                &keybundle1.pq_kem_psk.private_key.as_bytes(),
-                &keybundle2.pq_kem_psk.private_key.as_bytes(),
-                "PQ KEM Private Key",
-            ),
-            (
-                &keybundle1.metadata.public_key.as_bytes(),
-                &keybundle2.metadata.public_key.as_bytes(),
-                "Metadata Public Key",
-            ),
-            (
-                &keybundle1.metadata.private_key.as_bytes(),
-                &keybundle2.metadata.private_key.as_bytes(),
-                "Metadata Private Key",
-            ),
-        ];
+        // PQ KEM keys
+        assert_eq!(
+            keybundle1.pq_kem_psk.public_key.as_bytes(),
+            keybundle2.pq_kem_psk.public_key.as_bytes(),
+            "PQ KEM Public Key should be identical"
+        );
+        assert_eq!(
+            keybundle1.pq_kem_psk.private_key.as_bytes(),
+            keybundle2.pq_kem_psk.private_key.as_bytes(),
+            "PQ KEM Private Key should be identical"
+        );
 
-        // Iterate over each check and call `assert_bytes_eq`
-        for (bytes1, bytes2, label) in checks.iter() {
-            assert_bytes_eq(bytes1, bytes2, label);
-        }
+        // Metadata keys
+        assert_eq!(
+            keybundle1.metadata.public_key.as_bytes(),
+            keybundle2.metadata.public_key.as_bytes(),
+            "Metadata Public Key should be identical"
+        );
+        assert_eq!(
+            keybundle1.metadata.private_key.as_bytes(),
+            keybundle2.metadata.private_key.as_bytes(),
+            "Metadata Private Key should be identical"
+        );
     }
 }

--- a/securedrop-protocol/tests/core.rs
+++ b/securedrop-protocol/tests/core.rs
@@ -120,8 +120,11 @@ fn protocol_step_5_source_fetch_keys() {
         .dhakem_reply_key()
         .expect("Journalist should have DH key");
     assert_eq!(
-        journalist_response.journalist_dh_pk.clone().into_bytes(),
-        journalist_dh_key.clone().into_bytes()
+        journalist_response
+            .journalist_dhakem_sending_pk
+            .clone()
+            .as_bytes(),
+        journalist_dh_key.clone().as_bytes()
     );
 
     // Verify that ephemeral keys were consumed (deleted from server storage)

--- a/securedrop-protocol/tests/core.rs
+++ b/securedrop-protocol/tests/core.rs
@@ -117,7 +117,7 @@ fn protocol_step_5_source_fetch_keys() {
 
     // Verify the journalist's DH key matches our expectation
     let journalist_dh_key = journalist_session
-        .dh_key()
+        .dhakem_reply_key()
         .expect("Journalist should have DH key");
     assert_eq!(
         journalist_response.journalist_dh_pk.clone().into_bytes(),

--- a/securedrop-protocol/tests/core.rs
+++ b/securedrop-protocol/tests/core.rs
@@ -25,8 +25,6 @@ fn get_rng() -> ChaCha20Rng {
     ChaCha20Rng::from_seed(seed)
 }
 
-/// TODO
-#[ignore]
 /// Step 5: Source fetches keys and verifies their authenticity
 #[test]
 fn protocol_step_5_source_fetch_keys() {
@@ -158,8 +156,6 @@ fn protocol_step_5_source_fetch_keys() {
     );
 }
 
-/// TODO
-#[ignore]
 /// Step 6: Source submits a message
 #[test]
 fn protocol_step_6_source_submits_message() {

--- a/securedrop-protocol/tests/setup.rs
+++ b/securedrop-protocol/tests/setup.rs
@@ -101,7 +101,7 @@ fn protocol_step_3_1_journalist_enrollment() {
         .expect("Can setup journalist");
 
     // Journalist: Verify the newsroom signature on the enrollment bundle
-    let enrollment_bundle_bytes = enrollment_bundle.into_bytes();
+    let enrollment_bundle_bytes = enrollment_bundle.public_keys.into_bytes();
     let newsroom_vk = server_session
         .get_newsroom_verifying_key()
         .expect("Newsroom keys should be available");
@@ -154,7 +154,7 @@ fn protocol_step_3_2_journalist_ephemeral_keys() {
         .expect("Can setup journalist");
 
     // Journalist: Verify the newsroom signature on the enrollment bundle
-    let enrollment_bundle_bytes = enrollment_bundle.into_bytes();
+    let enrollment_bundle_bytes = enrollment_bundle.public_keys.into_bytes();
     let newsroom_vk = server_session
         .get_newsroom_verifying_key()
         .expect("Newsroom keys should be available");


### PR DESCRIPTION
Ready for review

- Use 0.3 key types
- Use single-shot hpke apis in base and authenc
- Fix hpke base mode algorithm kem selection (XWingDraft06) 
- Support journalist self-signatures over their fetch and reply keys. Update enrollment procedure to include verification of self-signed keys prior to newsroom signing during journalist enrollment
- use rand_core and getrandom as randomness sources  for cross-compatibility

(Note for anyone following along: this is still a toy/poc implementation) 

## Test plan
- [ ] visual review
- [ ] tests passing
- [ ] rust ci passing
- [ ] cross-reference with #92 