### PR TITLE
Rapid fire bench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ downloads/
 docs/html/
 node_modules/
 securedrop-protocol/target/*
+securedrop-protocol/pkg/*

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/html/
 node_modules/
 securedrop-protocol/target/*
 securedrop-protocol/pkg/*
+securedrop-protocol/.selenium-cache

--- a/securedrop-protocol/Cargo.lock
+++ b/securedrop-protocol/Cargo.lock
@@ -853,6 +853,7 @@ dependencies = [
  "getrandom",
  "hashbrown",
  "hpke-rs",
+ "js-sys",
  "libcrux-chacha20poly1305 0.0.3 (git+https://github.com/cryspen/libcrux?rev=54c6624630e47ed599ffc1549101c2b861d51a8c)",
  "libcrux-curve25519 0.0.3 (git+https://github.com/cryspen/libcrux?rev=54c6624630e47ed599ffc1549101c2b861d51a8c)",
  "libcrux-ed25519",
@@ -863,6 +864,8 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_core",
+ "serde",
+ "serde_json",
  "uuid",
  "wasm-bindgen",
 ]

--- a/securedrop-protocol/Cargo.lock
+++ b/securedrop-protocol/Cargo.lock
@@ -861,7 +861,6 @@ dependencies = [
  "libcrux-ml-kem 0.0.3 (git+https://github.com/cryspen/libcrux?rev=54c6624630e47ed599ffc1549101c2b861d51a8c)",
  "libcrux-traits 0.0.3 (git+https://github.com/cryspen/libcrux?rev=54c6624630e47ed599ffc1549101c2b861d51a8c)",
  "proptest",
- "rand",
  "rand_chacha",
  "rand_core",
  "serde",

--- a/securedrop-protocol/Cargo.lock
+++ b/securedrop-protocol/Cargo.lock
@@ -15,31 +15,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
-name = "anstyle"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anyhow"
@@ -99,68 +78,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
-name = "clap"
-version = "4.5.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
-dependencies = [
- "clap_builder",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
-dependencies = [
- "anstyle",
- "clap_lex",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "core-models"
@@ -184,73 +105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,12 +124,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "errno"
@@ -321,16 +169,6 @@ dependencies = [
  "r-efi",
  "wasi",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "half"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
-dependencies = [
- "cfg-if",
- "crunchy",
 ]
 
 [[package]]
@@ -381,12 +219,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hpke-rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,26 +255,6 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_core",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -865,44 +677,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
 name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
-
-[[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -1024,49 +802,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "regex"
-version = "1.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,21 +845,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "securedrop-protocol"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "blake2",
- "criterion",
  "getrandom",
  "hashbrown",
  "hpke-rs",
@@ -1138,6 +863,7 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "uuid",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1203,16 +929,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,16 +980,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
 ]
 
 [[package]]
@@ -1341,25 +1047,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
-dependencies = [
- "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/securedrop-protocol/Cargo.lock
+++ b/securedrop-protocol/Cargo.lock
@@ -265,9 +265,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -994,21 +994,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
 dependencies = [
  "bumpalo",
  "log",
@@ -1020,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1030,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1043,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
 dependencies = [
  "unicode-ident",
 ]

--- a/securedrop-protocol/Cargo.lock
+++ b/securedrop-protocol/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
  "libcrux-ml-kem 0.0.3 (git+https://github.com/cryspen/libcrux?rev=54c6624630e47ed599ffc1549101c2b861d51a8c)",
  "libcrux-traits 0.0.3 (git+https://github.com/cryspen/libcrux?rev=54c6624630e47ed599ffc1549101c2b861d51a8c)",
  "proptest",
+ "rand",
  "rand_chacha",
  "rand_core",
  "uuid",

--- a/securedrop-protocol/Cargo.toml
+++ b/securedrop-protocol/Cargo.toml
@@ -6,29 +6,39 @@ authors = ["redshiftzero <jen@freedom.press>"]
 description = "A wip impl of the securedrop protocol"
 license = "GPL-3.0"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
-libcrux-ed25519 = { git = "https://github.com/cryspen/libcrux", features = ["rand"], rev="54c6624630e47ed599ffc1549101c2b861d51a8c" }
-# using git rev bc X25519 struct was unavailable in latest release on crates
-libcrux-curve25519 = { git = "https://github.com/cryspen/libcrux", rev="54c6624630e47ed599ffc1549101c2b861d51a8c" }
-libcrux-chacha20poly1305 = { git = "https://github.com/cryspen/libcrux", rev="54c6624630e47ed599ffc1549101c2b861d51a8c" }
-libcrux-traits = { git = "https://github.com/cryspen/libcrux", rev="54c6624630e47ed599ffc1549101c2b861d51a8c" }
-libcrux-kem = { git = "https://github.com/cryspen/libcrux", rev="54c6624630e47ed599ffc1549101c2b861d51a8c" }
+# crypto stack
+libcrux-ed25519 = { git = "https://github.com/cryspen/libcrux", features = ["rand"], rev = "54c6624630e47ed599ffc1549101c2b861d51a8c" }
+libcrux-curve25519 = { git = "https://github.com/cryspen/libcrux", rev = "54c6624630e47ed599ffc1549101c2b861d51a8c" }
+libcrux-chacha20poly1305 = { git = "https://github.com/cryspen/libcrux", rev = "54c6624630e47ed599ffc1549101c2b861d51a8c" }
+libcrux-traits = { git = "https://github.com/cryspen/libcrux", rev = "54c6624630e47ed599ffc1549101c2b861d51a8c" }
+libcrux-kem = { git = "https://github.com/cryspen/libcrux", rev = "54c6624630e47ed599ffc1549101c2b861d51a8c" }
 libcrux-ml-kem = { git = "https://github.com/cryspen/libcrux", rev="54c6624630e47ed599ffc1549101c2b861d51a8c" }
-hpke-rs = {version = "0.3.0", features = ["libcrux"]}
-rand_core = {version = "0.9"}
-rand_chacha = { version = "0.9", default-features = false }
-# Needed for wasm compat
-getrandom = {version = "0.3", default-features = false, features = ["wasm_js"]}
+hpke-rs = { version = "0.3.0", features = ["libcrux"] }
+rand_core = { version = "0.9" }
+rand_chacha = {  version = "0.9", default-features = false  }
+getrandom = { version = "0.3", default-features = false, features = ["wasm_js"] }
 anyhow = "1.0"
-hashbrown = {version = "0.14", features = ["raw"]}
+hashbrown = { version = "0.14", features = ["raw"] }
 # In theory, it should be possible to use v4 uuids with getrandom per https://docs.rs/uuid/1.18.1/uuid/#building-for-other-targets, but cargo nono complains vigorously
-uuid = {version = "1.0", default-features = false, features = ["v4", "rng-getrandom", "js"]}
+uuid = { version = "1.0", default-features = false, features = ["v4", "rng-getrandom", "js"] }
 blake2 = "0.10"
+wasm-bindgen = "0.2"
 
 [dev-dependencies]
 proptest = "1.3"
-criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]
-name = "submit"
+name = "manual"
 harness = false
+
+
+[profile.release]
+opt-level = "z"     # smallest code size
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = true

--- a/securedrop-protocol/Cargo.toml
+++ b/securedrop-protocol/Cargo.toml
@@ -27,6 +27,7 @@ hashbrown = { version = "0.14", features = ["raw"] }
 uuid = { version = "1.0", default-features = false, features = ["v4", "rng-getrandom", "js"] }
 blake2 = "0.10"
 wasm-bindgen = "0.2"
+rand_chacha = "0.9.0"
 
 [dev-dependencies]
 proptest = "1.3"

--- a/securedrop-protocol/Cargo.toml
+++ b/securedrop-protocol/Cargo.toml
@@ -30,9 +30,13 @@ blake2 = "0.10"
 # pin an exact version to resolve wasm-bindgen schema compatibility issue
 wasm-bindgen = "0.2.103"
 rand_chacha = "0.9.0"
+js-sys = "0.3"
 
 [dev-dependencies]
 proptest = "1.3"
+getrandom = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [[bench]]
 name = "manual"

--- a/securedrop-protocol/Cargo.toml
+++ b/securedrop-protocol/Cargo.toml
@@ -2,7 +2,7 @@
 name = "securedrop-protocol"
 version = "0.1.0"
 edition = "2024"
-authors = ["redshiftzero <jen@freedom.press>"]
+authors = ["SecureDrop Team <securedrop@freedom.press>"]
 description = "A wip impl of the securedrop protocol"
 license = "GPL-3.0"
 
@@ -26,7 +26,9 @@ hashbrown = { version = "0.14", features = ["raw"] }
 # In theory, it should be possible to use v4 uuids with getrandom per https://docs.rs/uuid/1.18.1/uuid/#building-for-other-targets, but cargo nono complains vigorously
 uuid = { version = "1.0", default-features = false, features = ["v4", "rng-getrandom", "js"] }
 blake2 = "0.10"
-wasm-bindgen = "0.2"
+
+# pin an exact version to resolve wasm-bindgen schema compatibility issue
+wasm-bindgen = "0.2.103"
 rand_chacha = "0.9.0"
 
 [dev-dependencies]

--- a/securedrop-protocol/Cargo.toml
+++ b/securedrop-protocol/Cargo.toml
@@ -19,7 +19,6 @@ libcrux-kem = { git = "https://github.com/cryspen/libcrux", rev = "54c6624630e47
 libcrux-ml-kem = { git = "https://github.com/cryspen/libcrux", rev="54c6624630e47ed599ffc1549101c2b861d51a8c" }
 hpke-rs = { version = "0.3.0", features = ["libcrux"] }
 rand_core = { version = "0.9" }
-rand_chacha = {  version = "0.9", default-features = false  }
 getrandom = { version = "0.3", default-features = false, features = ["wasm_js"] }
 anyhow = "1.0"
 hashbrown = { version = "0.14", features = ["raw"] }
@@ -28,8 +27,8 @@ uuid = { version = "1.0", default-features = false, features = ["v4", "rng-getra
 blake2 = "0.10"
 
 # pin an exact version to resolve wasm-bindgen schema compatibility issue
+rand_chacha = {  version = "0.9.0", default-features = false  }
 wasm-bindgen = "0.2.103"
-rand_chacha = "0.9.0"
 js-sys = "0.3"
 
 [dev-dependencies]

--- a/securedrop-protocol/Makefile
+++ b/securedrop-protocol/Makefile
@@ -5,6 +5,8 @@ SHELL := /usr/bin/env bash
 
 # ===== Config =====
 ITER ?= 100
+KEYBUNDLES ?= 500
+CHALLENGES ?= 3000
 TARGET_DIR ?= target
 WASM_TARGET := wasm32-unknown-unknown
 CRATE_WASM := $(TARGET_DIR)/$(WASM_TARGET)/release/securedrop_protocol.wasm
@@ -12,12 +14,10 @@ PKG_DIR := pkg
 
 RUSTFLAGS := --cfg getrandom_backend="wasm_js"
 
-# Selenium cache lives inside the repo (change if you like)
 SELENIUM_CACHE ?= .selenium-cache
 SELENIUM_TOML  := $(SELENIUM_CACHE)/se-config.toml
 SELENIUM_STAMP := $(SELENIUM_CACHE)/.ready
 
-# ===== Phony targets =====
 .PHONY: all deps rust-target build bench clean clean-cache warm-cache
 
 all: deps build
@@ -27,14 +27,8 @@ deps: node_modules selenium-cache rust-target
 
 node_modules: package.json
 	@if [ -f package-lock.json ]; then npm ci; else npm install; fi
-	@# Ensure Selenium is present (no-op if already installed)
 	@npm ls selenium-webdriver --depth=0 >/dev/null 2>&1 || npm i -D selenium-webdriver
-	@# Optional: pin drivers for offline use (uncomment if desired)
-	# @npm ls chromedriver --depth=0 >/dev/null 2>&1 || npm i -D chromedriver
-	# @npm ls geckodriver  --depth=0 >/dev/null 2>&1 || npm i -D geckodriver
-	@touch node_modules
 
-# Create a project-local Selenium Manager cache and config
 selenium-cache: $(SELENIUM_STAMP)
 
 $(SELENIUM_STAMP):
@@ -59,14 +53,12 @@ build: $(CRATE_WASM)
 $(CRATE_WASM):
 	RUSTFLAGS='$(RUSTFLAGS)' cargo build --target $(WASM_TARGET) --release --target-dir $(TARGET_DIR)
 
-# Run benchmarks with Selenium and a local cache (no /Applications writes on macOS)
 bench: deps build
 	@echo "Running bench with ITER=$(ITER)"
 	SE_CACHE_PATH="$(abspath $(SELENIUM_CACHE))" \
 	SE_FORCE_BROWSER_DOWNLOAD=true \
 	node bench.js -n $(ITER)
 
-# (Optional) pre-warm the cache by launching/closing each browser once
 warm-cache: selenium-cache node_modules
 	SE_CACHE_PATH="$(abspath $(SELENIUM_CACHE))" \
 	SE_FORCE_BROWSER_DOWNLOAD=true \

--- a/securedrop-protocol/Makefile
+++ b/securedrop-protocol/Makefile
@@ -57,7 +57,7 @@ bench: deps build
 	@echo "Running bench with ITER=$(ITER)"
 	SE_CACHE_PATH="$(abspath $(SELENIUM_CACHE))" \
 	SE_FORCE_BROWSER_DOWNLOAD=true \
-	node bench.js -n $(ITER)
+	node bench.js -n $(ITER) --flavors firefox,chrome --mode profile
 
 warm-cache: selenium-cache node_modules
 	SE_CACHE_PATH="$(abspath $(SELENIUM_CACHE))" \

--- a/securedrop-protocol/Makefile
+++ b/securedrop-protocol/Makefile
@@ -1,0 +1,55 @@
+# Makefile
+
+SHELL := /usr/bin/env bash
+.SHELLFLAGS := -eu -o pipefail -c
+
+# ===== Config =====
+ITER ?= 100
+TARGET_DIR ?= target
+WASM_TARGET := wasm32-unknown-unknown
+CRATE_WASM := $(TARGET_DIR)/$(WASM_TARGET)/release/securedrop_protocol.wasm
+PKG_DIR := pkg
+
+RUSTFLAGS := --cfg getrandom_backend="wasm_js"
+
+# ===== Phony targets =====
+.PHONY: all deps browsers rust-target build bench clean
+
+all: deps build
+
+deps: node_modules browsers rust-target
+	@echo "Deps ok."
+
+node_modules: package.json
+	@if [ -f package-lock.json ]; then npm ci; else npm install; fi
+	@# Touch marker so `make` knows it's up-to-date
+	@touch node_modules
+
+browsers: node_modules
+	npx playwright install chromium firefox
+	@touch browsers
+
+rust-target:
+	rustup target add $(WASM_TARGET)
+	@if ! command -v wasm-bindgen >/dev/null 2>&1; then \
+	  echo "Installing wasm-bindgen-cli..."; \
+	  cargo install wasm-bindgen-cli; \
+	fi
+	@echo "Rust target and wasm-bindgen ready."
+
+build: $(CRATE_WASM)
+	@mkdir -p $(PKG_DIR)
+	wasm-bindgen --target web --out-dir $(PKG_DIR) $(CRATE_WASM)
+	@echo "WASM + bindings in $(PKG_DIR)/"
+
+$(CRATE_WASM):
+	RUSTFLAGS='$(RUSTFLAGS)' cargo build --target $(WASM_TARGET) --release --target-dir $(TARGET_DIR)
+
+bench: deps build
+	@echo "Running bench with ITER=$(ITER)"
+	node bench.js -n $(ITER)
+
+clean:
+	cargo clean --target-dir $(TARGET_DIR)
+	rm -rf $(PKG_DIR) node_modules browsers
+

--- a/securedrop-protocol/Makefile
+++ b/securedrop-protocol/Makefile
@@ -1,4 +1,4 @@
-# Makefile
+# Makefile (Selenium version)
 
 SHELL := /usr/bin/env bash
 .SHELLFLAGS := -eu -o pipefail -c
@@ -12,22 +12,36 @@ PKG_DIR := pkg
 
 RUSTFLAGS := --cfg getrandom_backend="wasm_js"
 
+# Selenium cache lives inside the repo (change if you like)
+SELENIUM_CACHE ?= .selenium-cache
+SELENIUM_TOML  := $(SELENIUM_CACHE)/se-config.toml
+SELENIUM_STAMP := $(SELENIUM_CACHE)/.ready
+
 # ===== Phony targets =====
-.PHONY: all deps browsers rust-target build bench clean
+.PHONY: all deps rust-target build bench clean clean-cache warm-cache
 
 all: deps build
 
-deps: node_modules browsers rust-target
+deps: node_modules selenium-cache rust-target
 	@echo "Deps ok."
 
 node_modules: package.json
 	@if [ -f package-lock.json ]; then npm ci; else npm install; fi
-	@# Touch marker so `make` knows it's up-to-date
+	@# Ensure Selenium is present (no-op if already installed)
+	@npm ls selenium-webdriver --depth=0 >/dev/null 2>&1 || npm i -D selenium-webdriver
+	@# Optional: pin drivers for offline use (uncomment if desired)
+	# @npm ls chromedriver --depth=0 >/dev/null 2>&1 || npm i -D chromedriver
+	# @npm ls geckodriver  --depth=0 >/dev/null 2>&1 || npm i -D geckodriver
 	@touch node_modules
 
-browsers: node_modules
-	npx playwright install chromium firefox
-	@touch browsers
+# Create a project-local Selenium Manager cache and config
+selenium-cache: $(SELENIUM_STAMP)
+
+$(SELENIUM_STAMP):
+	@mkdir -p "$(SELENIUM_CACHE)"
+	@echo 'cache-path = "$(abspath $(SELENIUM_CACHE))"' > "$(SELENIUM_TOML)"
+	@echo 'force-browser-download = true'            >> "$(SELENIUM_TOML)"
+	@touch "$(SELENIUM_STAMP)"
 
 rust-target:
 	rustup target add $(WASM_TARGET)
@@ -45,11 +59,23 @@ build: $(CRATE_WASM)
 $(CRATE_WASM):
 	RUSTFLAGS='$(RUSTFLAGS)' cargo build --target $(WASM_TARGET) --release --target-dir $(TARGET_DIR)
 
+# Run benchmarks with Selenium and a local cache (no /Applications writes on macOS)
 bench: deps build
 	@echo "Running bench with ITER=$(ITER)"
+	SE_CACHE_PATH="$(abspath $(SELENIUM_CACHE))" \
+	SE_FORCE_BROWSER_DOWNLOAD=true \
 	node bench.js -n $(ITER)
+
+# (Optional) pre-warm the cache by launching/closing each browser once
+warm-cache: selenium-cache node_modules
+	SE_CACHE_PATH="$(abspath $(SELENIUM_CACHE))" \
+	SE_FORCE_BROWSER_DOWNLOAD=true \
+	node -e 'const {Builder}=require("selenium-webdriver");(async()=>{for(const b of["chrome","firefox"]){try{const d=await new Builder().forBrowser(b).build();await d.quit();}catch(e){console.error("warm-cache:",b,e.message)}}})();'
 
 clean:
 	cargo clean --target-dir $(TARGET_DIR)
-	rm -rf $(PKG_DIR) node_modules browsers
+	rm -rf $(PKG_DIR) node_modules
+
+clean-cache:
+	rm -rf "$(SELENIUM_CACHE)"
 

--- a/securedrop-protocol/bench.js
+++ b/securedrop-protocol/bench.js
@@ -1,69 +1,73 @@
 #!/usr/bin/env node
-/* bench.js
+/* bench.js — native + Selenium Firefox/Chrome flavors, finds best performers.
  *
  * Usage:
- *   node bench.js -n 500                   # native + chromium + firefox
+ *   node bench.js -n 500
  *   node bench.js --browser chromium -n 250
  *   node bench.js --browser all --native off -n 100
+ *   node bench.js --flavors bundled,firefox,chrome -n 200
  */
 
-const { chromium, firefox } = require('playwright');
 const http = require('http');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
+// --- Selenium imports ---
+const { Builder, Capabilities } = require('selenium-webdriver');
+const chrome  = require('selenium-webdriver/chrome');
+const firefox = require('selenium-webdriver/firefox');
+
+// -------- CLI --------
 function parseArgs(argv) {
   let iterations = 100;
-  let browserSel = 'all';          // chromium|firefox|all|none
+  let browserSel = 'all';          // chromium|firefox|all|none (none disables browsers)
   let nativeSel = 'on';            // on|off
+  let flavorsArg = 'all';          // all or comma list among: bundled,chrome,chrome-beta,chrome-dev,firefox,firefox-beta,firefox-nightly
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i];
     if ((a === '-n' || a === '--iterations') && i + 1 < argv.length) {
       iterations = parseInt(argv[++i], 10);
       if (!Number.isFinite(iterations) || iterations <= 0) {
-        console.error(`Invalid iterations: ${argv[i]}`);
-        process.exit(1);
+        console.error(`Invalid iterations: ${argv[i]}`); process.exit(1);
       }
     } else if (a === '--browser' && i + 1 < argv.length) {
       browserSel = argv[++i];
       if (!['chromium', 'firefox', 'all', 'none'].includes(browserSel)) {
-        console.error(`Unknown browser: ${browserSel}`);
-        process.exit(1);
+        console.error(`Unknown --browser: ${browserSel}`); process.exit(1);
       }
     } else if (a === '--native' && i + 1 < argv.length) {
       nativeSel = argv[++i];
       if (!['on', 'off'].includes(nativeSel)) {
-        console.error(`--native must be on|off`);
-        process.exit(1);
+        console.error(`--native must be on|off`); process.exit(1);
       }
+    } else if (a === '--flavors' && i + 1 < argv.length) {
+      flavorsArg = argv[++i];
     } else {
       console.error(`Unknown arg: ${a}`);
-      console.error('Usage: node bench.js [--browser chromium|firefox|all|none] [--native on|off] [-n|--iterations N]');
+      console.error('Usage: node bench.js [--browser chromium|firefox|all|none] [--native on|off] [--flavors all|comma,list] [-n N]');
       process.exit(1);
     }
   }
-  return { iterations, browserSel, nativeSel };
+  return { iterations, browserSel, nativeSel, flavorsArg };
 }
 
+// -------- Server (COOP/COEP) --------
 function startServer(root) {
   return new Promise(resolve => {
     const server = http.createServer((req, res) => {
       const reqPath = req.url === '/' ? '/www/index.html' : req.url;
       const filePath = path.join(root, reqPath);
 
-      // COOP/COEP for precise timers (high-res performance.now(), SAB, etc.)
+      // COOP/COEP: precise timers & SAB-capable
       res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
       res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
       res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
       res.setHeader('Timing-Allow-Origin', '*');
 
       fs.readFile(filePath, (err, data) => {
-        if (err) {
-          res.statusCode = 404;
-          res.end('Not found');
-          return;
-        }
+        if (err) { res.statusCode = 404; res.end('Not found'); return; }
         const ext = path.extname(filePath).toLowerCase();
         const types = {
           '.html': 'text/html; charset=utf-8',
@@ -71,7 +75,7 @@ function startServer(root) {
           '.mjs':  'application/javascript; charset=utf-8',
           '.wasm': 'application/wasm',
           '.json': 'application/json; charset=utf-8',
-          '.css':  'text/css; charset=utf-8'
+          '.css':  'text/css; charset=utf-8',
         };
         res.setHeader('Content-Type', types[ext] || 'application/octet-stream');
         res.end(data);
@@ -80,8 +84,9 @@ function startServer(root) {
   });
 }
 
+// -------- Native runner --------
 function parseNativeOutput(text) {
-  // Expect blocks like:
+  // Expects:
   // bench: encrypt
   // iterations: 1000
   // total: 123.456 ms
@@ -118,165 +123,318 @@ function runNative(iterations) {
     }
     const parsed = parseNativeOutput(proc.stdout.toString());
     const key = (m === 'submit') ? 'submit_bench' : `${m}_bench`;
-
-    let rec = parsed[m];
-    if (!rec) {
-      // fallback: single-run stdout with different label
-      const firstKey = Object.keys(parsed)[0];
-      if (firstKey) rec = parsed[firstKey];
-    }
-    if (!rec) {
-      console.error(`[native ${m}] could not parse output:\n${proc.stdout.toString()}`);
-      process.exit(1);
-    }
-    // Ensure iterations populated; show in the table.
+    let rec = parsed[m] || parsed[Object.keys(parsed)[0]];
+    if (!rec) { console.error(`[native ${m}] could not parse output`); process.exit(1); }
     if (!rec.iterations) rec.iterations = iterations;
-
     results[key] = rec;
   }
   return results;
 }
 
-async function runBrowser(browserType, iterations) {
-  const server = await startServer(process.cwd());
-  const port = server.address().port;
-  const url = `http://localhost:${port}/www/index.html`;
-
-  const browser = await browserType.launch(); // headless by default
-  const page = await browser.newPage();
-  await page.goto(url, { waitUntil: 'load' });
-
-  const coi = await page.evaluate(() => globalThis.crossOriginIsolated === true);
-  if (!coi) {
-    console.warn(`[${browserType.name()}] Warning: crossOriginIsolated is false; timers may be coarse.`);
-  }
-
-  await page.waitForFunction(() =>
-    typeof window.decrypt_bench === 'function' &&
-    typeof window.encrypt_bench === 'function' &&
-    typeof window.fetch_bench   === 'function' &&
-    typeof window.submit_bench  === 'function'
-  );
-
-  async function time(fnName) {
-    // Small warm-up to JIT & cache (doesn't count).
-    await page.evaluate((name) => { window; }, fnName);
-
-    // Timed run
-    const res = await page.evaluate(({ name, iters }) => {
-      const start = performance.now();
-      window[name](iters);
-      const totalMs = performance.now() - start;
-      const avgUs = (totalMs * 1000) / iters;
-      return { totalMs, avgUs };
-    }, { name: fnName, iters: iterations });
-
-    return { ...res, iterations };
-  }
-
-  const results = {};
-  for (const fn of ['encrypt_bench', 'decrypt_bench', 'fetch_bench', 'submit_bench']) {
-    results[fn] = await time(fn);
-  }
-
-  await browser.close();
-  server.close();
-  return results;
+// -------- Selenium helpers --------
+function makeTmpDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 }
 
-function toFixedSafe(num, digits) {
-  if (!Number.isFinite(num)) return String(num);
-  return num.toFixed(digits);
+// Map our "flavors" to Selenium "browserVersion" labels.
+// Chrome/Chromium: stable|beta|dev|canary
+// Firefox: stable (default)|beta|nightly
+function mapFlavorToVersion(family, label) {
+  if (family === 'chromium') {
+    if (label === 'bundled' || label === 'chrome') return 'stable';
+    if (label === 'chrome-beta') return 'beta';
+    if (label === 'chrome-dev')  return 'dev';
+    return null;
+  } else {
+    if (label === 'bundled' || label === 'firefox') return 'stable';
+    if (label === 'firefox-beta')    return 'beta';
+    if (label === 'firefox-nightly') return 'nightly';
+    return null;
+  }
 }
 
-function makeTable(rows, headers) {
-  // rows: array of arrays (strings); headers: array of strings
+async function buildDriver(family, versionLabel, profileDir) {
+  if (family === 'chromium') {
+    const opts = new chrome.Options();
+    opts.addArguments(
+      '--headless=new',
+      '--disable-gpu',
+      '--no-first-run',
+      '--no-default-browser-check',
+      '--disable-extensions',
+      `--user-data-dir=${profileDir}`,
+      '--remote-debugging-port=0',
+      // needed when running as root / in CI containers
+      '--no-sandbox',
+      '--disable-dev-shm-usage',
+      // wasm perf toggles
+      '--enable-features=WebAssemblySimd'
+    );
+    let caps = new Capabilities().setBrowserName('chrome');
+    if (versionLabel) caps = caps.set('browserVersion', versionLabel); // stable|beta|dev|canary
+    return await new Builder().withCapabilities(caps).setChromeOptions(opts).build();
+  }
+
+  // Firefox: fresh temp profile dir + headless via CLI arg (works on all versions)
+  const ffProfileDir = profileDir || makeTmpDir('bench-firefox-');
+  const opts = new firefox.Options();
+  opts.addArguments('-headless'); // avoid .headless() chaining issues on some builds
+  opts.setProfile(ffProfileDir);
+  opts.setPreference('javascript.options.wasm', true);
+  opts.setPreference('javascript.options.wasm_simd', true);
+  opts.setPreference('javascript.options.wasm_relaxed_simd', true);
+  opts.setPreference('javascript.options.wasm_threads', true);
+
+  let caps = new Capabilities().setBrowserName('firefox');
+  if (versionLabel) caps = caps.set('browserVersion', versionLabel);   // stable|beta|nightly
+  const driver = await new Builder().withCapabilities(caps).setFirefoxOptions(opts).build();
+
+  // Keep profile for cleanup
+  driver.__ffProfileDir = ffProfileDir;
+  return driver;
+}
+
+async function ensureExports(driver) {
+  await driver.wait(async () => {
+    return await driver.executeScript(`
+      return ['encrypt_bench','decrypt_bench','fetch_bench','submit_bench']
+        .every(n => typeof window[n] === 'function');
+    `);
+  }, 30000);
+}
+
+async function runOne(driver, iterations, name) {
+  // Warm-up
+  await driver.executeScript(`window;`, name);
+  const res = await driver.executeScript(`
+    const name = arguments[0], iters = arguments[1];
+    const t0 = performance.now();
+    window[name](iters);
+    const totalMs = performance.now() - t0;
+    return { totalMs, avgUs: (totalMs * 1000) / iters };
+  `, name, iterations);
+  return { ...res, iterations };
+}
+
+async function runFlavor(flavor, iterations, url) {
+  const versionLabel = mapFlavorToVersion(flavor.family, flavor.label);
+  const tmpProfile =
+    (flavor.family === 'chromium')
+      ? makeTmpDir(`bench-chrome-${flavor.label}-`)
+      : makeTmpDir(`bench-firefox-${flavor.label}-`);
+
+  let driver;
+  try {
+    driver = await buildDriver(flavor.family, versionLabel, tmpProfile);
+    await driver.get(url);
+
+    const caps = await driver.getCapabilities();
+    const version = caps.get('browserVersion') || 'unknown';
+
+    const coi = await driver.executeScript('return !!globalThis.crossOriginIsolated;');
+    if (!coi) {
+      console.warn(`[${flavor.family}:${flavor.label}] crossOriginIsolated=false; timers may be coarse.`);
+    }
+
+    await ensureExports(driver);
+
+    const results = {};
+    for (const name of ['encrypt_bench', 'decrypt_bench', 'fetch_bench', 'submit_bench']) {
+      results[name] = await runOne(driver, iterations, name);
+    }
+
+    return { flavor, version, coi, results };
+  } finally {
+    if (driver) await driver.quit();
+    // Clean up temp profiles
+    try { fs.rmSync(tmpProfile, { recursive: true, force: true }); } catch {}
+    if (driver && driver.__ffProfileDir && driver.__ffProfileDir !== tmpProfile) {
+      try { fs.rmSync(driver.__ffProfileDir, { recursive: true, force: true }); } catch {}
+    }
+  }
+}
+
+// -------- Tables / printing --------
+function padRight(s, n) { s = String(s); return s + ' '.repeat(Math.max(0, n - s.length)); }
+function padLeft(s, n)  { s = String(s); return ' '.repeat(Math.max(0, n - s.length)) + s; }
+
+function makeTable(rows, headers, aligns = []) {
   const cols = headers.length;
-  const widths = new Array(cols).fill(0);
+  const widths = Array(cols).fill(0);
   for (let c = 0; c < cols; c++) {
     widths[c] = Math.max(headers[c].length, ...rows.map(r => String(r[c]).length));
   }
-  const pad = (s, w) => String(s).padEnd(w, ' ');
-  const line = (ch) => ch.repeat(widths.reduce((a, b) => a + b, 0) + (3 * (cols - 1)));
-
-  let out = '';
-  out += headers.map((h, i) => pad(h, widths[i])).join(' | ') + '\n';
-  out += line('-') + '\n';
-  for (const r of rows) {
-    out += r.map((cell, i) => pad(cell, widths[i])).join(' | ') + '\n';
-  }
-  return out;
+  const cell = (s, i) => (aligns[i] === 'right' ? padLeft(s, widths[i]) : padRight(s, widths[i]));
+  console.log(headers.map((h, i) => cell(h, i)).join('  '));
+  console.log('-'.repeat(widths.reduce((a, b) => a + b, 0) + 2 * (cols - 1)));
+  for (const r of rows) console.log(r.map((v, i) => cell(String(v), i)).join('  '));
 }
 
-function printSection(title) {
-  console.log(`\n=== ${title} ===`);
-}
-
-function buildRows(results, nativeRef) {
-  // results: map op -> {totalMs, avgUs, iterations}
-  // nativeRef: same shape (or null). Slowdown = avgUs / native.avgUs
-  const order = ['encrypt_bench', 'decrypt_bench', 'fetch_bench', 'submit_bench'];
-  const prettyName = {
+function buildRowsForFlavor(rec, native) {
+  const opNames = {
     encrypt_bench: 'encrypt',
     decrypt_bench: 'decrypt',
     fetch_bench:   'fetch',
     submit_bench:  'submit',
   };
-
   const rows = [];
-  for (const op of order) {
-    const r = results[op];
-    if (!r) continue;
-    const iter = r.iterations ?? '';
-    const totalMs = toFixedSafe(r.totalMs, 2);
-    const avgUs   = toFixedSafe(r.avgUs, 2);
-    let slowdown = '';
-    if (nativeRef && nativeRef[op] && Number.isFinite(nativeRef[op].avgUs) && nativeRef[op].avgUs > 0) {
-      slowdown = 'x' + toFixedSafe(r.avgUs / nativeRef[op].avgUs, 2);
-    } else if (!nativeRef) {
-      slowdown = 'x1.00';
-    }
+  for (const op of Object.keys(opNames)) {
+    const m = rec.results[op];
+    const slowNative = (native && native[op]) ? (m.avgUs / native[op].avgUs) : NaN;
     rows.push([
-      prettyName[op],
-      iter,
-      totalMs,
-      avgUs,
-      slowdown || '—',
+      opNames[op],
+      m.iterations,
+      m.totalMs.toFixed(2),
+      m.avgUs.toFixed(2),
+      Number.isFinite(slowNative) ? ('x' + slowNative.toFixed(2)) : '—',
     ]);
   }
   return rows;
 }
 
-(async () => {
-  const { iterations, browserSel, nativeSel } = parseArgs(process.argv);
+function summarizeFlavors(flavors, native) {
+  const ops = ['encrypt_bench', 'decrypt_bench', 'fetch_bench', 'submit_bench'];
+  const best = {};
+  for (const op of ops) {
+    let min = Infinity, who = null;
+    for (const r of flavors) {
+      const val = r.results[op].avgUs;
+      if (val < min) { min = val; who = r; }
+    }
+    best[op] = { min, who };
+  }
 
+  const rows = [];
+  for (const r of flavors) {
+    const label = `${r.flavor.family}:${r.flavor.label} (${r.version})`;
+    const enc = r.results['encrypt_bench'], dec = r.results['decrypt_bench'];
+    const fch = r.results['fetch_bench'],   sub = r.results['submit_bench'];
+
+    const sEncBest = enc.avgUs / best['encrypt_bench'].min;
+    const sDecBest = dec.avgUs / best['decrypt_bench'].min;
+    const sFchBest = fch.avgUs / best['fetch_bench'].min;
+    const sSubBest = sub.avgUs / best['submit_bench'].min;
+
+    const slowVsNative = (op) => (native && native[op]) ? (r.results[op].avgUs / native[op].avgUs) : NaN;
+
+    rows.push([
+      label,
+      enc.avgUs.toFixed(2), dec.avgUs.toFixed(2), fch.avgUs.toFixed(2), sub.avgUs.toFixed(2),
+      'x' + sEncBest.toFixed(2), 'x' + sDecBest.toFixed(2), 'x' + sFchBest.toFixed(2), 'x' + sSubBest.toFixed(2),
+      Number.isFinite(slowVsNative('encrypt_bench')) ? ('x' + slowVsNative('encrypt_bench').toFixed(2)) : '—',
+      Number.isFinite(slowVsNative('decrypt_bench')) ? ('x' + slowVsNative('decrypt_bench').toFixed(2)) : '—',
+      Number.isFinite(slowVsNative('fetch_bench'))   ? ('x' + slowVsNative('fetch_bench').toFixed(2))   : '—',
+      Number.isFinite(slowVsNative('submit_bench'))  ? ('x' + slowVsNative('submit_bench').toFixed(2))  : '—',
+    ]);
+  }
+
+  return {
+    rows,
+    headers: [
+      'flavor',
+      'enc µs', 'dec µs', 'fch µs', 'sub µs',
+      '×best enc', '×best dec', '×best fch', '×best sub',
+      '×native enc', '×native dec', '×native fch', '×native sub',
+    ],
+    aligns: ['left','right','right','right','right','right','right','right','right','right','right','right','right'],
+    best,
+  };
+}
+
+// -------- Main --------
+(async () => {
+  const { iterations, browserSel, nativeSel, flavorsArg } = parseArgs(process.argv);
+
+  // Native
   let native = null;
   if (nativeSel === 'on') {
     native = runNative(iterations);
-    printSection('Native (cargo bench)');
-    const rows = buildRows(native, null); // slowdown x1.00 shown
-    const table = makeTable(rows, ['op', 'iters', 'total (ms)', 'avg (µs/iter)', 'slowdown']);
-    process.stdout.write(table);
+    console.log(`\n=== Native (cargo bench) — iterations: ${iterations} ===`);
+    makeTable(
+      [
+        ['encrypt', native.encrypt_bench.iterations, native.encrypt_bench.totalMs.toFixed(2), native.encrypt_bench.avgUs.toFixed(2), 'x1.00'],
+        ['decrypt', native.decrypt_bench.iterations, native.decrypt_bench.totalMs.toFixed(2), native.decrypt_bench.avgUs.toFixed(2), 'x1.00'],
+        ['fetch',   native.fetch_bench.iterations,   native.fetch_bench.totalMs.toFixed(2),   native.fetch_bench.avgUs.toFixed(2),   'x1.00'],
+        ['submit',  native.submit_bench.iterations,  native.submit_bench.totalMs.toFixed(2),  native.submit_bench.avgUs.toFixed(2),  'x1.00'],
+      ],
+      ['op', 'iters', 'total (ms)', 'avg (µs/iter)', 'slowdown'],
+      ['left','right','right','right','right']
+    );
   }
 
+  if (browserSel === 'none') {
+    console.log('\n(Browsers disabled with --browser none)');
+    return;
+  }
+
+  // Which families to test
   const wantChromium = (browserSel === 'chromium' || browserSel === 'all');
   const wantFirefox  = (browserSel === 'firefox'  || browserSel === 'all');
 
+  // Which flavors to test
+  const allFlavors = [];
+  const requested = (flavorsArg === 'all')
+    ? ['bundled','chrome','chrome-beta','chrome-dev','firefox','firefox-beta','firefox-nightly']
+    : flavorsArg.split(',').map(s => s.trim()).filter(Boolean);
+
   if (wantChromium) {
-    const res = await runBrowser(chromium, iterations);
-    printSection(`Chromium (${iterations} iterations)`);
-    const rows = buildRows(res, native);
-    const table = makeTable(rows, ['op', 'iters', 'total (ms)', 'avg (µs/iter)', 'slowdown vs native']);
-    process.stdout.write(table);
+    const chromes = ['bundled','chrome','chrome-beta','chrome-dev'];
+    for (const label of chromes) if (requested.includes('all') || requested.includes(label)) {
+      allFlavors.push({ family: 'chromium', label });
+    }
+  }
+  if (wantFirefox) {
+    const foxes = ['bundled','firefox','firefox-beta','firefox-nightly'];
+    for (const label of foxes) if (requested.includes('all') || requested.includes(label)) {
+      allFlavors.push({ family: 'firefox', label });
+    }
   }
 
-  if (wantFirefox) {
-    const res = await runBrowser(firefox, iterations);
-    printSection(`Firefox (${iterations} iterations)`);
-    const rows = buildRows(res, native);
-    const table = makeTable(rows, ['op', 'iters', 'total (ms)', 'avg (µs/iter)', 'slowdown vs native']);
-    process.stdout.write(table);
+  // Serve once for all runs
+  const server = await startServer(process.cwd());
+  const port = server.address().port;
+  const url = `http://localhost:${port}/www/index.html`;
+
+  // Run all flavors
+  const results = [];
+  for (const flavor of allFlavors) {
+    try {
+      const rec = await runFlavor(flavor, iterations, url);
+      results.push(rec);
+
+      // Per-flavor table
+      const title = `${flavor.family}:${flavor.label} (${rec.version}) — iterations: ${iterations}`;
+      console.log(`\n=== ${title} ===`);
+      makeTable(
+        buildRowsForFlavor(rec, native),
+        ['op', 'iters', 'total (ms)', 'avg (µs/iter)', 'slowdown vs native'],
+        ['left','right','right','right','right']
+      );
+    } catch (e) {
+      console.error(`\n[ERROR] Failed ${flavor.family}:${flavor.label}:`, e && e.message ? e.message : e);
+    }
   }
+
+  server.close();
+
+  if (results.length === 0) {
+    console.log('\nNo browser results.');
+    return;
+  }
+
+  // Summary across flavors
+  const summary = summarizeFlavors(results, native);
+  console.log(`\n=== Summary: all flavors (iterations: ${iterations}) ===`);
+  makeTable(summary.rows, summary.headers, summary.aligns);
+
+  // Highlight best per op
+  console.log('\nFastest per op:');
+  for (const [op, { who, min }] of Object.entries(summary.best)) {
+    const tag = `${who.flavor.family}:${who.flavor.label} (${who.version})`;
+    const pretty = {encrypt_bench:'encrypt',decrypt_bench:'decrypt',fetch_bench:'fetch',submit_bench:'submit'}[op];
+    console.log(`  ${pretty}: ${tag} — ${min.toFixed(2)} µs/iter`);
+  }
+
 })().catch(err => {
   console.error(err);
   process.exit(1);

--- a/securedrop-protocol/bench.js
+++ b/securedrop-protocol/bench.js
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+/* bench.js
+ *
+ * Usage:
+ *   node bench.js -n 500                   # native + chromium + firefox
+ *   node bench.js --browser chromium -n 250
+ *   node bench.js --browser all --native off -n 100
+ */
+
+const { chromium, firefox } = require('playwright');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+function parseArgs(argv) {
+  let iterations = 100;
+  let browserSel = 'all';          // chromium|firefox|all|none
+  let nativeSel = 'on';            // on|off
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if ((a === '-n' || a === '--iterations') && i + 1 < argv.length) {
+      iterations = parseInt(argv[++i], 10);
+      if (!Number.isFinite(iterations) || iterations <= 0) {
+        console.error(`Invalid iterations: ${argv[i]}`);
+        process.exit(1);
+      }
+    } else if (a === '--browser' && i + 1 < argv.length) {
+      browserSel = argv[++i];
+      if (!['chromium', 'firefox', 'all', 'none'].includes(browserSel)) {
+        console.error(`Unknown browser: ${browserSel}`);
+        process.exit(1);
+      }
+    } else if (a === '--native' && i + 1 < argv.length) {
+      nativeSel = argv[++i];
+      if (!['on', 'off'].includes(nativeSel)) {
+        console.error(`--native must be on|off`);
+        process.exit(1);
+      }
+    } else {
+      console.error(`Unknown arg: ${a}`);
+      console.error('Usage: node bench.js [--browser chromium|firefox|all|none] [--native on|off] [-n|--iterations N]');
+      process.exit(1);
+    }
+  }
+  return { iterations, browserSel, nativeSel };
+}
+
+function startServer(root) {
+  return new Promise(resolve => {
+    const server = http.createServer((req, res) => {
+      const reqPath = req.url === '/' ? '/www/index.html' : req.url;
+      const filePath = path.join(root, reqPath);
+
+      // COOP/COEP for precise timers (high-res performance.now(), SAB, etc.)
+      res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+      res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+      res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
+      res.setHeader('Timing-Allow-Origin', '*');
+
+      fs.readFile(filePath, (err, data) => {
+        if (err) {
+          res.statusCode = 404;
+          res.end('Not found');
+          return;
+        }
+        const ext = path.extname(filePath).toLowerCase();
+        const types = {
+          '.html': 'text/html; charset=utf-8',
+          '.js':   'application/javascript; charset=utf-8',
+          '.mjs':  'application/javascript; charset=utf-8',
+          '.wasm': 'application/wasm',
+          '.json': 'application/json; charset=utf-8',
+          '.css':  'text/css; charset=utf-8'
+        };
+        res.setHeader('Content-Type', types[ext] || 'application/octet-stream');
+        res.end(data);
+      });
+    }).listen(0, () => resolve(server));
+  });
+}
+
+function parseNativeOutput(text) {
+  // Expect blocks like:
+  // bench: encrypt
+  // iterations: 1000
+  // total: 123.456 ms
+  // avg:   123.456 µs/iter
+  const lines = text.split(/\r?\n/);
+  const out = {};
+  let current = null;
+  for (const line of lines) {
+    const b = line.match(/^bench:\s*(\w+)/);
+    if (b) { current = b[1]; if (!out[current]) out[current] = {}; continue; }
+    if (!current) continue;
+    const m1 = line.match(/^iterations:\s*(\d+)/);
+    if (m1) { out[current].iterations = parseInt(m1[1], 10); continue; }
+    const m2 = line.match(/^total:\s*([\d.]+)\s*ms/);
+    if (m2) { out[current].totalMs = parseFloat(m2[1]); continue; }
+    const m3 = line.match(/^avg:\s*([\d.]+)\s*µs\/iter/);
+    if (m3) { out[current].avgUs = parseFloat(m3[1]); continue; }
+  }
+  return out;
+}
+
+function runNative(iterations) {
+  const modes = ['encrypt', 'decrypt', 'fetch', 'submit'];
+  const results = {};
+  for (const m of modes) {
+    const proc = spawnSync(
+      'cargo',
+      ['bench', '--bench', 'manual', '--', m, '-n', String(iterations)],
+      { stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+    if (proc.status !== 0) {
+      console.error(`[native ${m}] failed:\n${proc.stderr.toString()}\n${proc.stdout.toString()}`);
+      process.exit(proc.status || 1);
+    }
+    const parsed = parseNativeOutput(proc.stdout.toString());
+    const key = (m === 'submit') ? 'submit_bench' : `${m}_bench`;
+
+    let rec = parsed[m];
+    if (!rec) {
+      // fallback: single-run stdout with different label
+      const firstKey = Object.keys(parsed)[0];
+      if (firstKey) rec = parsed[firstKey];
+    }
+    if (!rec) {
+      console.error(`[native ${m}] could not parse output:\n${proc.stdout.toString()}`);
+      process.exit(1);
+    }
+    // Ensure iterations populated; show in the table.
+    if (!rec.iterations) rec.iterations = iterations;
+
+    results[key] = rec;
+  }
+  return results;
+}
+
+async function runBrowser(browserType, iterations) {
+  const server = await startServer(process.cwd());
+  const port = server.address().port;
+  const url = `http://localhost:${port}/www/index.html`;
+
+  const browser = await browserType.launch(); // headless by default
+  const page = await browser.newPage();
+  await page.goto(url, { waitUntil: 'load' });
+
+  const coi = await page.evaluate(() => globalThis.crossOriginIsolated === true);
+  if (!coi) {
+    console.warn(`[${browserType.name()}] Warning: crossOriginIsolated is false; timers may be coarse.`);
+  }
+
+  await page.waitForFunction(() =>
+    typeof window.decrypt_bench === 'function' &&
+    typeof window.encrypt_bench === 'function' &&
+    typeof window.fetch_bench   === 'function' &&
+    typeof window.submit_bench  === 'function'
+  );
+
+  async function time(fnName) {
+    // Small warm-up to JIT & cache (doesn't count).
+    await page.evaluate((name) => { window; }, fnName);
+
+    // Timed run
+    const res = await page.evaluate(({ name, iters }) => {
+      const start = performance.now();
+      window[name](iters);
+      const totalMs = performance.now() - start;
+      const avgUs = (totalMs * 1000) / iters;
+      return { totalMs, avgUs };
+    }, { name: fnName, iters: iterations });
+
+    return { ...res, iterations };
+  }
+
+  const results = {};
+  for (const fn of ['encrypt_bench', 'decrypt_bench', 'fetch_bench', 'submit_bench']) {
+    results[fn] = await time(fn);
+  }
+
+  await browser.close();
+  server.close();
+  return results;
+}
+
+function toFixedSafe(num, digits) {
+  if (!Number.isFinite(num)) return String(num);
+  return num.toFixed(digits);
+}
+
+function makeTable(rows, headers) {
+  // rows: array of arrays (strings); headers: array of strings
+  const cols = headers.length;
+  const widths = new Array(cols).fill(0);
+  for (let c = 0; c < cols; c++) {
+    widths[c] = Math.max(headers[c].length, ...rows.map(r => String(r[c]).length));
+  }
+  const pad = (s, w) => String(s).padEnd(w, ' ');
+  const line = (ch) => ch.repeat(widths.reduce((a, b) => a + b, 0) + (3 * (cols - 1)));
+
+  let out = '';
+  out += headers.map((h, i) => pad(h, widths[i])).join(' | ') + '\n';
+  out += line('-') + '\n';
+  for (const r of rows) {
+    out += r.map((cell, i) => pad(cell, widths[i])).join(' | ') + '\n';
+  }
+  return out;
+}
+
+function printSection(title) {
+  console.log(`\n=== ${title} ===`);
+}
+
+function buildRows(results, nativeRef) {
+  // results: map op -> {totalMs, avgUs, iterations}
+  // nativeRef: same shape (or null). Slowdown = avgUs / native.avgUs
+  const order = ['encrypt_bench', 'decrypt_bench', 'fetch_bench', 'submit_bench'];
+  const prettyName = {
+    encrypt_bench: 'encrypt',
+    decrypt_bench: 'decrypt',
+    fetch_bench:   'fetch',
+    submit_bench:  'submit',
+  };
+
+  const rows = [];
+  for (const op of order) {
+    const r = results[op];
+    if (!r) continue;
+    const iter = r.iterations ?? '';
+    const totalMs = toFixedSafe(r.totalMs, 2);
+    const avgUs   = toFixedSafe(r.avgUs, 2);
+    let slowdown = '';
+    if (nativeRef && nativeRef[op] && Number.isFinite(nativeRef[op].avgUs) && nativeRef[op].avgUs > 0) {
+      slowdown = 'x' + toFixedSafe(r.avgUs / nativeRef[op].avgUs, 2);
+    } else if (!nativeRef) {
+      slowdown = 'x1.00';
+    }
+    rows.push([
+      prettyName[op],
+      iter,
+      totalMs,
+      avgUs,
+      slowdown || '—',
+    ]);
+  }
+  return rows;
+}
+
+(async () => {
+  const { iterations, browserSel, nativeSel } = parseArgs(process.argv);
+
+  let native = null;
+  if (nativeSel === 'on') {
+    native = runNative(iterations);
+    printSection('Native (cargo bench)');
+    const rows = buildRows(native, null); // slowdown x1.00 shown
+    const table = makeTable(rows, ['op', 'iters', 'total (ms)', 'avg (µs/iter)', 'slowdown']);
+    process.stdout.write(table);
+  }
+
+  const wantChromium = (browserSel === 'chromium' || browserSel === 'all');
+  const wantFirefox  = (browserSel === 'firefox'  || browserSel === 'all');
+
+  if (wantChromium) {
+    const res = await runBrowser(chromium, iterations);
+    printSection(`Chromium (${iterations} iterations)`);
+    const rows = buildRows(res, native);
+    const table = makeTable(rows, ['op', 'iters', 'total (ms)', 'avg (µs/iter)', 'slowdown vs native']);
+    process.stdout.write(table);
+  }
+
+  if (wantFirefox) {
+    const res = await runBrowser(firefox, iterations);
+    printSection(`Firefox (${iterations} iterations)`);
+    const rows = buildRows(res, native);
+    const table = makeTable(rows, ['op', 'iters', 'total (ms)', 'avg (µs/iter)', 'slowdown vs native']);
+    process.stdout.write(table);
+  }
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/securedrop-protocol/bench.js
+++ b/securedrop-protocol/bench.js
@@ -197,10 +197,6 @@ async function buildDriver(family, versionLabel, profileDir) {
   const opts = new firefox.Options();
   opts.addArguments('-headless');
   opts.setProfile(profileDir);
-  opts.setPreference('javascript.options.wasm', true);
-  opts.setPreference('javascript.options.wasm_simd', true);
-  opts.setPreference('javascript.options.wasm_relaxed_simd', true);
-  opts.setPreference('javascript.options.wasm_threads', true);
 
   let caps = new Capabilities().setBrowserName('firefox');
   if (versionLabel) caps = caps.set('browserVersion', versionLabel);
@@ -279,7 +275,6 @@ function statsFromUs(samplesUs) {
 }
 
 async function runNative(iterations, k, j, rngOn) {
-  // Lock params for native; pass exactly what web harness gets.
   const plans = [
     { bench: 'encrypt',            args: ['encrypt', '-n', String(iterations), '-k', String(k), ...(rngOn ? ['--include-rng'] : [])],
       expect: { iterations, keybundles: k, challenges: null } },
@@ -374,7 +369,7 @@ function makeTable(headers, rows) {
   // Native (optional)
   let native = null;
   if (cfg.native === 'on') {
-    logInfo('Running native (cargo bench, JSON)...');
+    logInfo('Running native...');
     try {
       native = await runNative(cfg.iterations, cfg.k, cfg.j, cfg.rng === 'on');
 

--- a/securedrop-protocol/benches/encrypt_decrypt.rs
+++ b/securedrop-protocol/benches/encrypt_decrypt.rs
@@ -1,0 +1,321 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+use hpke_rs::{HpkeKeyPair, HpkePrivateKey, HpkePublicKey};
+use libcrux_curve25519::hacl::scalarmult;
+use rand::RngCore;
+use rand::rngs::StdRng;
+use rand_core::CryptoRng;
+use rand_core::SeedableRng;
+use securedrop_protocol::primitives::dh_akem::generate_dh_akem_keypair;
+use securedrop_protocol::primitives::mlkem::generate_mlkem768_keypair;
+use securedrop_protocol::primitives::x25519::generate_random_scalar;
+use securedrop_protocol::primitives::xwing::generate_xwing_keypair;
+use std::vec::Vec;
+
+const HPKE_PSK_ID: &[u8] = b"PSK_INFO_ID_TAG"; // Spec requires a tag
+const HPKE_INFO: &[u8] = b"";
+const HPKE_AAD: &[u8] = b"";
+
+// Key lengths
+const LEN_DHKEM_ENCAPS_KEY: usize = libcrux_curve25519::EK_LEN;
+const LEN_DHKEM_DECAPS_KEY: usize = libcrux_curve25519::DK_LEN;
+const LEN_DHKEM_SHAREDSECRET_ENCAPS: usize = libcrux_curve25519::SS_LEN;
+const LEN_DHKEM_SHARED_SECRET: usize = libcrux_curve25519::SS_LEN;
+const LEN_DH_ITEM: usize = LEN_DHKEM_DECAPS_KEY;
+
+// https://openquantumsafe.org/liboqs/algorithms/kem/ml-kem.html
+// todo, source from crates instead of hardcoding
+const LEN_MLKEM_ENCAPS_KEY: usize = 1184;
+const LEN_MLKEM_DECAPS_KEY: usize = 2400;
+const LEN_MLKEM_SHAREDSECRET_ENCAPS: usize = 1088;
+const LEN_MLKEM_SHAREDSECRET: usize = 32;
+const LEN_MLKEM_RAND_SEED_SIZE: usize = 64;
+
+// https://www.ietf.org/archive/id/draft-connolly-cfrg-xwing-kem-01.html#name-encoding-and-sizes
+const LEN_XWING_ENCAPS_KEY: usize = 1216;
+const LEN_XWING_DECAPS_KEY: usize = 2464;
+const LEN_XWING_SHAREDSECRET_ENCAPS: usize = 1120;
+const LEN_XWING_SHAREDSECRET: usize = 32;
+const LEN_XWING_RAND_SEED_SIZE: usize = 96;
+
+#[derive(Debug)]
+pub struct Envelope {
+    cmessage: Vec<u8>,
+    cmetadata: Vec<u8>,
+    metadata_encap: Vec<u8>,
+    mgdh_pubkey: Vec<u8>,
+    mgdh: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub struct Plaintext {
+    msg: Vec<u8>,
+    sender_key: Vec<u8>,
+    recipient_reply_key_classical_msg: Option<Vec<u8>>, // DH-AKEM
+    recipient_reply_key_pq_psk_msg: Option<Vec<u8>>,    // ML-KEM768
+    recipient_reply_key_hybrid_md: Option<Vec<u8>>,     // XWING
+}
+
+pub struct Metadata {}
+
+pub trait User {
+    // msg enc classical
+    fn get_dhakem_sk(&self) -> &[u8];
+    fn get_dhakem_pk(&self) -> &[u8];
+
+    // msg enc pq psk
+    fn get_pq_kem_psk_pk(&self) -> &[u8];
+    fn get_pq_kem_psk_sk(&self) -> &[u8];
+
+    // md enc hybrid
+    fn get_hybrid_md_pk(&self) -> &[u8];
+    fn get_hybrid_md_sk(&self) -> &[u8];
+
+    // fetch classical
+    fn get_fetch_sk(&self) -> &[u8];
+    fn get_fetch_pk(&self) -> &[u8];
+}
+
+pub fn hpke_keypair_from_bytes(sk_bytes: &[u8], pk_bytes: &[u8]) -> HpkeKeyPair {
+    HpkeKeyPair::from((sk_bytes, pk_bytes))
+}
+
+pub fn hpke_pubkey_from_bytes(pk_bytes: &[u8]) -> HpkePublicKey {
+    HpkePublicKey::from(pk_bytes)
+}
+
+pub fn encrypt<R: RngCore + CryptoRng>(
+    rng: &mut R,
+    sender: &dyn User,
+    plaintext: &[u8],
+    recipient: &dyn User,
+) -> Envelope {
+    use hpke_rs::hpke_types::AeadAlgorithm::ChaCha20Poly1305;
+    use hpke_rs::hpke_types::KdfAlgorithm::HkdfSha256;
+    use hpke_rs::hpke_types::KemAlgorithm::{DhKem25519, XWingDraft06};
+    use hpke_rs::{Hpke, Mode};
+
+    let hpke_authenc = Hpke::new(Mode::AuthPsk, DhKem25519, HkdfSha256, ChaCha20Poly1305);
+
+    let recipient_hpke_pubkey_msg = hpke_pubkey_from_bytes(recipient.get_dhakem_pk());
+
+    let sender_hpke_keypair =
+        hpke_keypair_from_bytes(sender.get_dhakem_sk(), sender.get_dhakem_pk());
+
+    // HPKE AuthPSK message enc - TODO type
+    let (enc, ct) = hpke_authenc.seal(
+        &recipient_hpke_pubkey_msg,
+        b"", // info
+        b"", // aad
+        plaintext,
+        Some(b"PQ_KEM_SS"),                      // PSK TODO PQ KEM
+        Some(b"PSK_INFO_ID_TAG"),                // Fixed PSK ID
+        Some(sender_hpke_keypair.private_key()), // sender private key
+    );
+
+    // mgdh
+    let eph_sk: [u8; LEN_DH_ITEM] =
+        generate_random_scalar(rng).expect("DH keygen (ephemeral fetch) failed!");
+    let mut eph_pk: [u8; LEN_DH_ITEM] = [0u8; LEN_DH_ITEM];
+    libcrux_curve25519::secret_to_public(&eph_pk, &eph_sk); // todo
+    let mut out_scalarmult = [0u8; LEN_DH_ITEM];
+    let shared_mgdh = scalarmult(
+        &mut out_scalarmult,
+        &eph_sk.to_bytes(),
+        recipient.get_fetch_pk(),
+    );
+
+    Envelope {
+        cmessage: ct,
+        cmetadata: vec![], // TODO
+        metadata_encap: enc,
+        mgdh_pubkey: eph_pk.as_bytes().to_vec(),
+        mgdh: shared_mgdh,
+    }
+}
+
+pub fn decrypt(receiver: &dyn User, envelope: &Envelope) -> Plaintext {
+    use hpke_rs::hpke_types::AeadAlgorithm::ChaCha20Poly1305;
+    use hpke_rs::hpke_types::KdfAlgorithm::HkdfSha256;
+    use hpke_rs::hpke_types::KemAlgorithm::{DhKem25519, XWingDraft06};
+    use hpke_rs::{Hpke, Mode};
+
+    let hpke_authenc = Hpke::new(Mode::AuthPsk, DhKem25519, HkdfSha256, ChaCha20Poly1305);
+
+    let hpke_keypair_receiver =
+        hpke_keypair_from_bytes(receiver.get_dhakem_sk(), receiver.get_dhakem_pk());
+
+    // TODO from metadata
+    let hpke_pubkey_sender = hpke_pubkey_from_bytes();
+
+    let pt = hpke_authenc
+        .open(
+            &envelope.metadata_encap,
+            hpke_keypair_receiver.private_key(),
+            b"",
+            b"",
+            &envelope.cmessage,
+            Some(b"sharedsecret"),
+            Some(b"PSK_INFO_ID_TAG"),
+            Some(&envelope.mgdh_pubkey), // no, not this key! TODO key parsed from metadata
+        )
+        .expect("Decryption failed");
+
+    // TODO
+    Plaintext {
+        msg: pt,
+        sender_key: envelope.mgdh_pubkey.clone(), // no, not this key!
+        recipient_reply_key_classical_msg: None,
+        recipient_reply_key_pq_psk_msg: None,
+        recipient_reply_key_hybrid_md: None,
+    }
+}
+
+pub struct Source {
+    sk_dh: [u8; LEN_DHKEM_DECAPS_KEY],
+    pk_dh: [u8; LEN_DHKEM_ENCAPS_KEY],
+    sk_pqkem_psk: [u8; LEN_MLKEM_DECAPS_KEY],
+    pk_pqkem_psk: [u8; LEN_MLKEM_ENCAPS_KEY],
+    sk_md: [u8; LEN_XWING_DECAPS_KEY],
+    pk_md: [u8; LEN_XWING_ENCAPS_KEY],
+    sk_fetch: [u8; LEN_DH_ITEM],
+    pk_fetch: [u8; LEN_DH_ITEM],
+}
+
+impl Source {
+    pub fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+        let sk_dh: [u8; LEN_DHKEM_DECAPS_KEY] =
+            generate_random_scalar(rng).expect("DH keygen (ephemeral fetch) failed!");
+        let mut pubkey: [u8; LEN_DH_ITEM] = [0u8; LEN_DH_ITEM];
+        let pk_dh = libcrux_curve25519::secret_to_public(&sk_dh, &mut pubkey);
+        let sk_fetch: [u8; LEN_DHKEM_DECAPS_KEY] =
+            generate_random_scalar(rng).expect("DH keygen (ephemeral fetch) failed!");
+        let pk_fetch = libcrux_curve25519::secret_to_public(&sk_dh, &mut pubkey);
+        Self {
+            sk_dh,
+            pk_dh,
+            sk_pqkem_psk: sk_msg,
+            pk_pqkem_psk: pk_msg,
+            sk_md,
+            pk_md,
+            sk_fetch,
+            pk_fetch,
+        }
+    }
+}
+
+impl User for Source {
+    fn get_dhakem_sk(&self) -> &[u8] {
+        &self.sk_dh
+    }
+    fn get_dhakem_pk(&self) -> &[u8] {
+        &self.pk_dh
+    }
+    fn get_fetch_sk(&self) -> &[u8] {
+        &self.sk_fetch
+    }
+    fn get_fetch_pk(&self) -> &[u8] {
+        &self.pk_fetch
+    }
+    fn get_hybrid_md_pk(&self) -> &[u8] {
+        &self.pk_md
+    }
+    fn get_hybrid_md_sk(&self) -> &[u8] {
+        &self.sk_md
+    }
+    fn get_pq_kem_psk_pk(&self) -> &[u8] {
+        &self.sk_pqkem_psk
+    }
+    fn get_pq_kem_psk_sk(&self) -> &[u8] {
+        &self.sk_pqkem_psk
+    }
+}
+
+pub struct Journalist {
+    sk_dh: [u8; LEN_DHKEM_DECAPS_KEY],
+    pk_dh: [u8; LEN_DHKEM_ENCAPS_KEY],
+    sk_pqkem_psk: [u8; LEN_MLKEM_DECAPS_KEY],
+    pk_pqkem_psk: [u8; LEN_MLKEM_ENCAPS_KEY],
+    sk_md: [u8; LEN_XWING_DECAPS_KEY],
+    pk_md: [u8; LEN_XWING_ENCAPS_KEY],
+    sk_fetch: [u8; LEN_DH_ITEM],
+    pk_fetch: [u8; LEN_DH_ITEM],
+}
+
+impl Journalist {
+    pub fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+        unimplemented!() // TODO!
+    }
+}
+
+impl User for Journalist {
+    fn get_dhakem_sk(&self) -> &[u8] {
+        &self.sk_dh
+    }
+    fn get_dhakem_pk(&self) -> &[u8] {
+        &self.pk_dh
+    }
+    fn get_fetch_sk(&self) -> &[u8] {
+        &self.sk_fetch
+    }
+    fn get_fetch_pk(&self) -> &[u8] {
+        &self.pk_fetch
+    }
+    fn get_hybrid_md_pk(&self) -> &[u8] {
+        &self.pk_md
+    }
+    fn get_hybrid_md_sk(&self) -> &[u8] {
+        &self.sk_md
+    }
+    fn get_pq_kem_psk_pk(&self) -> &[u8] {
+        &self.sk_pqkem_psk
+    }
+    fn get_pq_kem_psk_sk(&self) -> &[u8] {
+        &self.sk_pqkem_psk
+    }
+}
+
+pub fn setup() -> (Source, Journalist, Vec<u8>, Envelope) {
+    let source = Source::new(&mut StdRng::seed_from_u64(666));
+    let journalist = Journalist::new(&mut StdRng::seed_from_u64(666));
+    let plaintext = b"super secret msg".to_vec();
+    let envelope = encrypt(&source, &plaintext, &journalist);
+    (source, journalist, plaintext, envelope)
+}
+
+pub fn bench_encrypt(c: &mut Criterion) {
+    let (source, journalist, plaintext, _) = setup();
+
+    c.benchmark_group("encrypt").bench_function(
+        BenchmarkId::new("source_to_journalist", ""),
+        |b| {
+            b.iter(|| {
+                encrypt(
+                    &mut StdRng::seed_from_u64(666),
+                    &source,
+                    &plaintext,
+                    &journalist,
+                )
+            });
+        },
+    );
+}
+
+pub fn bench_decrypt(c: &mut Criterion) {
+    let (source, journalist, _, envelope) = setup();
+
+    c.benchmark_group("decrypt").bench_function(
+        BenchmarkId::new("journalist_from_source", ""),
+        |b| {
+            b.iter(|| decrypt(&journalist, &envelope));
+        },
+    );
+}
+
+pub fn bench_fetch(c: &mut Criterion) {
+    unimplemented!()
+}
+
+criterion_group!(benches, bench_encrypt, bench_decrypt);
+// criterion_group!(benches, bench_encrypt, bench_decrypt, bench_fetch);
+criterion_main!(benches);

--- a/securedrop-protocol/benches/encrypt_decrypt.rs
+++ b/securedrop-protocol/benches/encrypt_decrypt.rs
@@ -552,9 +552,9 @@ impl User for Journalist {
     }
 }
 
-//////////////////////////////////
-/// add tests ////////////////////
-//////////////////////////////////
+
+// Begin unit tests
+ 
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -600,9 +600,7 @@ mod tests {
     }
 }
 
-//////////////////////////////////
-/// Begin Benchmark functions  ///
-//////////////////////////////////
+// Begin benchmark functions
 
 pub fn setup() -> (Source, Journalist, Vec<u8>, Envelope) {
     let source = Source::new(&mut StdRng::seed_from_u64(666));

--- a/securedrop-protocol/benches/manual.rs
+++ b/securedrop-protocol/benches/manual.rs
@@ -1,0 +1,115 @@
+use std::env;
+use std::time::{Duration, Instant};
+
+// Pull in your wasm-bindgen wrappers' backing functions via the module.
+use securedrop_protocol::bench::{
+    bench_decrypt, bench_encrypt, bench_fetch, bench_submit_message,
+};
+
+fn main() {
+    // Usage: cargo bench --bench manual -- <which> -n <iterations>
+    // Examples:
+    //   cargo bench --bench manual -- submit -n 1000
+    //   cargo bench --bench manual -- encrypt -n 500
+    //   cargo bench --bench manual -- decrypt -n 200
+    //   cargo bench --bench manual -- fetch -n 50
+
+    let mut which: Option<String> = None;
+    let mut iterations: usize = 1000; // default
+
+    let mut args = env::args().skip(1); // skip program name
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            // Cargo may pass this even with harness=false; ignore it.
+            "--bench" => continue,
+
+            // Your bench options:
+            "-n" | "--iterations" => {
+                let v = args.next().unwrap_or_else(|| {
+                    eprintln!("Missing value for {arg}");
+                    help_and_exit()
+                });
+                iterations = v.parse().unwrap_or_else(|_| {
+                    eprintln!("Invalid number for iterations: {v}");
+                    help_and_exit()
+                });
+            }
+
+            // Subcommand (the actual benchmark to run)
+            "submit" | "encrypt" | "decrypt" | "fetch" => {
+                if which.is_none() {
+                    which = Some(arg);
+                } else {
+                    // If more than one non-flag is supplied, that's ambiguous.
+                    eprintln!("Unexpected extra argument: {arg}");
+                    help_and_exit();
+                }
+            }
+
+            // Silently ignore any other cargo-injected or unknown flags (e.g., -Zfoo)
+            _ if arg.starts_with('-') => continue,
+
+            // Anything else is not recognized
+            _ => {
+                eprintln!("Unknown argument: {arg}");
+                help_and_exit();
+            }
+        }
+    }
+
+    let which = which.unwrap_or_else(|| help_and_exit());
+
+    // pick the function
+    let run = match which.as_str() {
+        "submit"  => bench_submit_message as fn(usize),
+        "encrypt" => bench_encrypt        as fn(usize),
+        "decrypt" => bench_decrypt        as fn(usize),
+        "fetch"   => bench_fetch          as fn(usize),
+        _ => {
+            eprintln!("Unknown bench: {which}");
+            help_and_exit();
+        }
+    };
+
+    // time it
+    let start = Instant::now();
+    run(iterations);
+    let total = start.elapsed();
+
+    // print total + average
+    let avg = div_duration(total, iterations as u32);
+    println!("bench: {which}");
+    println!("iterations: {iterations}");
+    println!("total: {} ms", to_millis(total));
+    println!("avg:   {} µs/iter", to_micros(avg));
+}
+
+fn help_and_exit() -> ! {
+    eprintln!(
+        "Usage: cargo bench --bench manual -- <submit|encrypt|decrypt|fetch> [-n <iterations>]\n\
+         Default iterations: 1000\n\
+         Examples:\n  \
+         cargo bench --bench manual -- submit -n 1000\n  \
+         cargo bench --bench manual -- encrypt -n 500\n  \
+         cargo bench --bench manual -- decrypt -n 200\n  \
+         cargo bench --bench manual -- fetch -n 50"
+    );
+    std::process::exit(1);
+}
+
+fn div_duration(d: Duration, by: u32) -> Duration {
+    if by == 0 { return Duration::from_nanos(0); }
+    // Convert to nanoseconds as f64 for precise division, then back.
+    let nanos = d.as_secs_f64() * 1e9;
+    let each = nanos / (by as f64);
+    Duration::from_nanos(each.max(0.0) as u64)
+}
+
+fn to_millis(d: Duration) -> String {
+    // Keep a few decimals for readability
+    format!("{:.3}", d.as_secs_f64() * 1_000.0)
+}
+
+fn to_micros(d: Duration) -> String {
+    format!("{:.3}", d.as_secs_f64() * 1_000_000.0)
+}

--- a/securedrop-protocol/benches/manual.rs
+++ b/securedrop-protocol/benches/manual.rs
@@ -91,6 +91,7 @@ fn main() {
     let avg = div_duration(total, iterations as u32);
     println!("bench: {which}");
     println!("iterations: {iterations}");
+    println!("keybundles/journo (trial decrypt): {num_keybundles}");
     println!("total: {} ms", to_millis(total));
     println!("avg:   {} µs/iter", to_micros(avg));
 }

--- a/securedrop-protocol/package-lock.json
+++ b/securedrop-protocol/package-lock.json
@@ -1,0 +1,62 @@
+{
+  "name": "securedrop-protol-bench",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "securedrop-protol-bench",
+      "version": "0.1.0",
+      "devDependencies": {
+        "playwright": "^1.41.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/securedrop-protocol/package-lock.json
+++ b/securedrop-protocol/package-lock.json
@@ -7,9 +7,24 @@
     "": {
       "name": "securedrop-protol-bench",
       "version": "0.1.0",
+      "dependencies": {
+        "selenium-webdriver": "^4.35.0"
+      },
       "devDependencies": {
         "playwright": "^1.41.1"
       }
+    },
+    "node_modules/@bazel/runfiles": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@bazel/runfiles/-/runfiles-6.3.1.tgz",
+      "integrity": "sha512-1uLNT5NZsUVIGS4syuHwTzZ8HycMPyr6POA3FCE4GbMtc4rhoJk8aZKtNIRthJYfL+iioppi+rTfH3olMPr9nA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -25,6 +40,51 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/playwright": {
       "version": "1.55.0",
@@ -56,6 +116,109 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/selenium-webdriver": {
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.35.0.tgz",
+      "integrity": "sha512-Baaeiuyu7BIIsSYf0SI7Mi55gsNmdI00KM0Hcofw1RnAY+0QEVpdh5yAxueDxgTZS8vcbGZFU0NJ6Qc1riIrLg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/SeleniumHQ"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/selenium"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bazel/runfiles": "^6.3.1",
+        "jszip": "^3.10.1",
+        "tmp": "^0.2.3",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/securedrop-protocol/package-lock.json
+++ b/securedrop-protocol/package-lock.json
@@ -8,10 +8,18 @@
       "name": "securedrop-protol-bench",
       "version": "0.1.0",
       "dependencies": {
-        "selenium-webdriver": "^4.35.0"
-      },
-      "devDependencies": {
-        "playwright": "^1.41.1"
+        "chalk": "^5.6.2",
+        "cli-table3": "^0.6.5",
+        "csv-writer": "^1.6.0",
+        "execa": "^9.6.0",
+        "express": "^5.1.0",
+        "kleur": "^4.1.5",
+        "mime": "^4.1.0",
+        "selenium-webdriver": "^4.35.0",
+        "serve-static": "^2.2.0",
+        "simple-statistics": "^7.8.8",
+        "yargs": "^18.0.0",
+        "zod": "^4.1.11"
       }
     },
     "node_modules/@bazel/runfiles": {
@@ -20,25 +28,698 @@
       "integrity": "sha512-1uLNT5NZsUVIGS4syuHwTzZ8HycMPyr6POA3FCE4GbMtc4rhoJk8aZKtNIRthJYfL+iioppi+rTfH3olMPr9nA==",
       "license": "Apache-2.0"
     },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-disposition/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
       "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csv-writer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
+      "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.0.tgz",
+      "integrity": "sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/immediate": {
@@ -53,11 +734,77 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
     },
     "node_modules/jszip": {
       "version": "3.10.1",
@@ -71,6 +818,15 @@
         "setimmediate": "^1.0.5"
       }
     },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -80,42 +836,207 @@
         "immediate": "~3.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+      "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "license": "MIT",
+      "bin": {
+        "mime": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
     },
-    "node_modules/playwright": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
-      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.55.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/playwright-core": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
-      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/process-nextick-args": {
@@ -123,6 +1044,74 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.7.0",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
@@ -139,10 +1128,32 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/selenium-webdriver": {
@@ -170,11 +1181,177 @@
         "node": ">= 20.0.0"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-statistics": {
+      "version": "7.8.8",
+      "resolved": "https://registry.npmjs.org/simple-statistics/-/simple-statistics-7.8.8.tgz",
+      "integrity": "sha512-CUtP0+uZbcbsFpqEyvNDYjJCl+612fNgjT8GaVuvMG7tBuJg8gXGpsP5M7X658zy0IcepWOZ6nPBu1Qb9ezA1w==",
+      "license": "ISC",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -183,6 +1360,44 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tmp": {
@@ -194,11 +1409,152 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.3",
@@ -219,6 +1575,112 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/securedrop-protocol/package.json
+++ b/securedrop-protocol/package.json
@@ -4,6 +4,17 @@
   "private": true,
   "description": "Benchmark securedrop-protocol in headless browsers using Playwright",
   "dependencies": {
-    "selenium-webdriver": "^4.35.0"
+    "chalk": "^5.6.2",
+    "cli-table3": "^0.6.5",
+    "csv-writer": "^1.6.0",
+    "execa": "^9.6.0",
+    "express": "^5.1.0",
+    "kleur": "^4.1.5",
+    "mime": "^4.1.0",
+    "selenium-webdriver": "^4.35.0",
+    "serve-static": "^2.2.0",
+    "simple-statistics": "^7.8.8",
+    "yargs": "^18.0.0",
+    "zod": "^4.1.11"
   }
 }

--- a/securedrop-protocol/package.json
+++ b/securedrop-protocol/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "securedrop-protol-bench",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Benchmark securedrop-protocol in headless browsers using Playwright",
+  "devDependencies": {
+    "playwright": "^1.41.1"
+  }
+}
+

--- a/securedrop-protocol/package.json
+++ b/securedrop-protocol/package.json
@@ -3,8 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "Benchmark securedrop-protocol in headless browsers using Playwright",
-  "devDependencies": {
-    "playwright": "^1.41.1"
+  "dependencies": {
+    "selenium-webdriver": "^4.35.0"
   }
 }
-

--- a/securedrop-protocol/src/bench/encrypt_decrypt.rs
+++ b/securedrop-protocol/src/bench/encrypt_decrypt.rs
@@ -109,22 +109,30 @@ impl Envelope {
     pub fn size_hint(&self) -> usize {
         self.cmessage.len() + self.cmetadata.len()
     }
-    pub fn cmessage_len(&self)->usize { self.cmessage.len() }
-    pub fn cmetadata_len(&self)->usize { self.cmetadata.len() }
+    pub fn cmessage_len(&self) -> usize {
+        self.cmessage.len()
+    }
+    pub fn cmetadata_len(&self) -> usize {
+        self.cmetadata.len()
+    }
 }
 
 impl ServerMessageStore {
     pub fn new(message_id: [u8; 16], envelope: Envelope) -> Self {
-        Self { message_id, envelope }
+        Self {
+            message_id,
+            envelope,
+        }
     }
 
     pub fn message_id(&self) -> [u8; 16] {
         self.message_id
     }
 
-    pub fn envelope(&self) -> &Envelope { &self.envelope }
+    pub fn envelope(&self) -> &Envelope {
+        &self.envelope
+    }
 }
-
 
 // Plaintext metadata
 pub struct Metadata {
@@ -247,7 +255,7 @@ pub fn encrypt<R: RngCore + CryptoRng>(
     sender: &dyn User,
     plaintext: &[u8],
     recipient: &dyn User,
-    recipient_bundle_index: Option<usize>
+    recipient_bundle_index: Option<usize>,
 ) -> Envelope {
     use hpke_rs::hpke_types::AeadAlgorithm::ChaCha20Poly1305;
     use hpke_rs::hpke_types::KdfAlgorithm::HkdfSha256;
@@ -749,7 +757,13 @@ pub fn bench_encrypt(
     plaintext: &[u8],
 ) -> Envelope {
     let mut rng = ChaCha20Rng::from_seed(seed32);
-    encrypt(&mut rng, sender, plaintext, recipient, Some(recipient_bundle_index))
+    encrypt(
+        &mut rng,
+        sender,
+        plaintext,
+        recipient,
+        Some(recipient_bundle_index),
+    )
 }
 
 pub fn bench_decrypt(recipient: &dyn User, envelope: &Envelope) -> Plaintext {

--- a/securedrop-protocol/src/bench/mod.rs
+++ b/securedrop-protocol/src/bench/mod.rs
@@ -1,6 +1,6 @@
-pub mod submit;
 pub mod encrypt_decrypt;
+pub mod submit;
 
 // Re-export functions so they can be called as `bench::bench_*`
+pub use encrypt_decrypt::{bench_decrypt, bench_encrypt, bench_fetch};
 pub use submit::bench_submit_message;
-pub use encrypt_decrypt::{bench_encrypt, bench_decrypt, bench_fetch};

--- a/securedrop-protocol/src/bench/mod.rs
+++ b/securedrop-protocol/src/bench/mod.rs
@@ -1,0 +1,6 @@
+pub mod submit;
+pub mod encrypt_decrypt;
+
+// Re-export functions so they can be called as `bench::bench_*`
+pub use submit::bench_submit_message;
+pub use encrypt_decrypt::{bench_encrypt, bench_decrypt, bench_fetch};

--- a/securedrop-protocol/src/bench/mod.rs
+++ b/securedrop-protocol/src/bench/mod.rs
@@ -1,6 +1,3 @@
 pub mod encrypt_decrypt;
-pub mod submit;
 
-// Re-export functions so they can be called as `bench::bench_*`
 pub use encrypt_decrypt::{bench_decrypt, bench_encrypt, bench_fetch};
-pub use submit::bench_submit_message;

--- a/securedrop-protocol/src/bench/submit.rs
+++ b/securedrop-protocol/src/bench/submit.rs
@@ -81,22 +81,6 @@ pub fn bench_submit_message(iterations: usize, _: usize) {
         let test_message = vec![0u8; 512]; // Test message content
         let mut rng = StdRng::seed_from_u64(666);
 
-    for index in 0..n {
-        group.bench_with_input(
-            BenchmarkId::new("submit", format!("message_{}", index)),
-            &index,
-            |b, _| {
-                b.iter(|| {
-                    let (source, journalist_key_responses) = setup_test_environment();
-
-                    let test_message = vec![0u8; 512]; // Test message content
-                    let mut rng = ChaCha20Rng::seed_from_u64(666);
-                    source
-                        .submit_message(test_message, &journalist_key_responses, &mut rng)
-                        .expect("Message submission should succeed");
-                })
-            },
-        );
         source
             .submit_message(test_message, &journalist_key_responses, &mut rng)
             .expect(&format!(
@@ -104,5 +88,4 @@ pub fn bench_submit_message(iterations: usize, _: usize) {
                 index
             ));
     }
-}
 }

--- a/securedrop-protocol/src/bench/submit.rs
+++ b/securedrop-protocol/src/bench/submit.rs
@@ -1,7 +1,5 @@
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
-use rand::{SeedableRng, rngs::StdRng};
 use alloc::{format, vec, vec::Vec};
 
 use crate::{
@@ -75,7 +73,9 @@ fn setup_test_environment() -> (SourceClient, Vec<SourceJournalistKeyResponse>) 
     (source, journalist_key_responses)
 }
 
-pub fn bench_submit_message(iterations: usize) {
+// For now the usize param is unused, but eventually it can specify
+// num keybundles, as it does in the other benchmarks
+pub fn bench_submit_message(iterations: usize, _: usize) {
     for index in 0..iterations {
         let (source, journalist_key_responses) = setup_test_environment();
         let test_message = vec![0u8; 512]; // Test message content
@@ -99,8 +99,10 @@ pub fn bench_submit_message(iterations: usize) {
         );
         source
             .submit_message(test_message, &journalist_key_responses, &mut rng)
-            .expect(&format!("Message submission should succeed at iteration {}", index));
+            .expect(&format!(
+                "Message submission should succeed at iteration {}",
+                index
+            ));
     }
 }
 }
-

--- a/securedrop-protocol/src/bench/submit.rs
+++ b/securedrop-protocol/src/bench/submit.rs
@@ -1,8 +1,10 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
+use rand::{SeedableRng, rngs::StdRng};
+use alloc::{format, vec, vec::Vec};
 
-use securedrop_protocol::{
+use crate::{
     journalist::JournalistClient, keys::FPFKeyPair, messages::core::SourceJournalistKeyResponse,
     server::Server, source::SourceClient,
 };
@@ -73,9 +75,11 @@ fn setup_test_environment() -> (SourceClient, Vec<SourceJournalistKeyResponse>) 
     (source, journalist_key_responses)
 }
 
-pub fn bench_submit_message(c: &mut Criterion) {
-    let mut group = c.benchmark_group("submit_message");
-    let n = 1; // I reduced this for faster benchmarking, we still use a group consisting of 100 measurements
+pub fn bench_submit_message(iterations: usize) {
+    for index in 0..iterations {
+        let (source, journalist_key_responses) = setup_test_environment();
+        let test_message = vec![0u8; 512]; // Test message content
+        let mut rng = StdRng::seed_from_u64(666);
 
     for index in 0..n {
         group.bench_with_input(
@@ -93,9 +97,10 @@ pub fn bench_submit_message(c: &mut Criterion) {
                 })
             },
         );
+        source
+            .submit_message(test_message, &journalist_key_responses, &mut rng)
+            .expect(&format!("Message submission should succeed at iteration {}", index));
     }
-    group.finish();
+}
 }
 
-criterion_group!(benches, bench_submit_message);
-criterion_main!(benches);

--- a/securedrop-protocol/src/keys/journalist.rs
+++ b/securedrop-protocol/src/keys/journalist.rs
@@ -347,7 +347,7 @@ impl JournalistLongtermPublicKeys {
     pub fn into_bytes(self) -> [u8; 64] {
         let mut bytes = [0u8; 64];
 
-        // DH fetching public key (1184 bytes)
+        // DH fetching public key (32 bytes)
         bytes[0..32].copy_from_slice(&self.fetch_key.into_bytes());
 
         // DH-AKEM reply public key (32 bytes)

--- a/securedrop-protocol/src/lib.rs
+++ b/securedrop-protocol/src/lib.rs
@@ -41,3 +41,27 @@ pub use sign::{SelfSignature, Signature, SigningKey, VerifyingKey};
 
 /// Server storage
 pub mod storage;
+
+pub mod bench;
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn bench_submit_message(iterations: u32) {
+    bench::bench_submit_message(iterations as usize);
+}
+
+#[wasm_bindgen]
+pub fn bench_encrypt(iterations: u32) {
+    bench::bench_encrypt(iterations as usize);
+}
+
+#[wasm_bindgen]
+pub fn bench_decrypt(iterations: u32) {
+    bench::bench_decrypt(iterations as usize);
+}
+
+#[wasm_bindgen]
+pub fn bench_fetch(iterations: u32) {
+    bench::bench_fetch(iterations as usize);
+}

--- a/securedrop-protocol/src/lib.rs
+++ b/securedrop-protocol/src/lib.rs
@@ -1,70 +1,198 @@
 #![no_std]
 
-//! A draft implementation of the SecureDrop protocol.
-//!
-//! WARNING: This was implemented only for benchmarking and research purposes
-//! and is not ready for production use.
-
 extern crate alloc;
 
-/// The keys used in the SecureDrop protocol.
 pub mod keys;
-
-/// Common client functionality.
-pub mod client;
-pub use client::Client;
-
-/// Protocol messages used in the setup and core messaging protocol.
+pub mod client;  pub use client::Client;
 pub mod messages;
-
-/// Server-side protocol implementation.
 pub mod server;
-
-/// Source-side protocol implementation.
 pub mod source;
-
-/// Journalist-side protocol implementation.
 pub mod journalist;
-
-/// Setup steps in the protocol.
 pub mod setup;
-
-/// Primitives for DH, PPK.
 pub mod primitives;
 
-/// Primitives for signing.
-///
-/// TODO: Move to primitives?
+// Primitives for signing
 pub mod sign;
+pub use sign::{Signature, SelfSignature, SigningKey, VerifyingKey};
 
-pub use sign::{SelfSignature, Signature, SigningKey, VerifyingKey};
-
-/// Server storage
 pub mod storage;
 
 pub mod bench;
 
+use alloc::{boxed::Box, vec::Vec};
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
 use wasm_bindgen::prelude::*;
+use js_sys::{Array, Uint8Array};
 
-// For now we don't use the u32 param here, but when we update
-// the submit benchmark we can add parameterized keybundle size
-// as we have in the other benches.
+use bench::encrypt_decrypt::{
+    compute_fetch_challenges,
+    Envelope,
+    FetchResponse,
+    Journalist,
+    Plaintext,
+    ServerMessageStore,
+    Source,
+    User,
+};
+use bench::{bench_decrypt, bench_encrypt, bench_fetch};
+
+#[inline]
+fn rng_from_seed(seed32: [u8; 32]) -> ChaCha20Rng {
+    ChaCha20Rng::from_seed(seed32)
+}
+
+/* ========= Opaque wrappers ========= */
+
 #[wasm_bindgen]
-pub fn bench_submit_message(iterations: u32, unused: u32) {
-    bench::bench_submit_message(iterations as usize, unused as usize);
+pub struct WSource {
+    inner: Source,
 }
 
 #[wasm_bindgen]
-pub fn bench_encrypt(iterations: u32, num_keybundles: u32) {
-    bench::bench_encrypt(iterations as usize, num_keybundles as usize);
+impl WSource {
+    /// Construct a Source (actor setup randomness is outside timed paths).
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WSource {
+        let mut seed = [0u8; 32];
+        getrandom::fill(&mut seed).expect("getrandom failed");
+        let mut rng = rng_from_seed(seed);
+        WSource { inner: Source::new(&mut rng) }
+    }
 }
 
 #[wasm_bindgen]
-pub fn bench_decrypt(iterations: u32, num_keybundles: u32) {
-    bench::bench_decrypt(iterations as usize, num_keybundles as usize);
+pub struct WJournalist {
+    inner: Journalist,
 }
 
 #[wasm_bindgen]
-pub fn bench_fetch(iterations: u32, num_keybundles: u32) {
-    bench::bench_fetch(iterations as usize, num_keybundles as usize);
+impl WJournalist {
+    /// Construct a Journalist with `num_keybundles` short-lived bundles.
+    #[wasm_bindgen(constructor)]
+    pub fn new(num_keybundles: usize) -> WJournalist {
+        let mut seed = [0u8; 32];
+        getrandom::fill(&mut seed).expect("getrandom failed");
+        let mut rng = rng_from_seed(seed);
+        WJournalist { inner: Journalist::new(&mut rng, num_keybundles) }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn keybundles(&self) -> usize {
+        self.inner.get_all_keys().len()
+    }
+}
+
+#[wasm_bindgen]
+pub struct WEnvelope {
+    inner: Envelope,
+}
+
+impl From<Envelope> for WEnvelope {
+    fn from(inner: Envelope) -> Self { WEnvelope { inner } }
+}
+
+#[wasm_bindgen]
+impl WEnvelope {
+    /// Size hint to mirror the Rust bench’s “sink” usage.
+    pub fn size_hint(&self) -> usize {
+        self.inner.cmessage_len() + self.inner.cmetadata_len()
+    }
+}
+
+#[wasm_bindgen]
+pub struct WFetchResponse {
+    inner: FetchResponse,
+}
+impl From<FetchResponse> for WFetchResponse {
+    fn from(inner: FetchResponse) -> Self { WFetchResponse { inner } }
+}
+
+#[wasm_bindgen]
+pub struct WStoreEntry {
+    inner: ServerMessageStore,
+}
+
+#[wasm_bindgen]
+impl WStoreEntry {
+    /// Build a server store entry from a 16-byte message_id and a WEnvelope.
+    #[wasm_bindgen(constructor)]
+    pub fn new(message_id_16: &[u8], envelope: &WEnvelope) -> WStoreEntry {
+        assert_eq!(message_id_16.len(), 16, "message_id must be 16 bytes");
+        let mut id = [0u8; 16];
+        id.copy_from_slice(message_id_16);
+        WStoreEntry { inner: ServerMessageStore::new(id, envelope.inner.clone()) }
+    }
+}
+
+/* ========= Single-shot ops (what you time in JS) ========= */
+
+/// One encrypt. You time only this call in JS.
+/// `seed32` must be exactly 32 bytes.
+#[wasm_bindgen]
+pub fn encrypt_once(
+    seed32: &[u8],
+    sender: &WSource,
+    recipient: &WJournalist,
+    recipient_bundle_index: usize,
+    plaintext: &[u8],
+) -> WEnvelope {
+    assert_eq!(seed32.len(), 32, "seed32 must be 32 bytes");
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(seed32);
+    let env = bench_encrypt(
+        seed,
+        &sender.inner,
+        &recipient.inner,
+        recipient_bundle_index,
+        plaintext,
+    );
+    env.into()
+}
+
+/// One decrypt. You time only this call in JS.
+/// Returns plaintext bytes.
+#[wasm_bindgen]
+pub fn decrypt_once(recipient: &WJournalist, envelope: &WEnvelope) -> Vec<u8> {
+    // add `impl Plaintext { pub fn into_bytes(self)->Vec<u8> { self.msg } }` in bench module if missing
+    let pt: Plaintext = bench_decrypt(&recipient.inner, &envelope.inner);
+    pt.into_bytes()
+}
+
+/// Build challenges for fetch (usually not timed).
+#[wasm_bindgen]
+pub fn compute_fetch_challenges_once(
+    seed32: &[u8],
+    entries: Box<[WStoreEntry]>,
+    total_responses: usize,
+) -> Box<[WFetchResponse]> {
+    assert_eq!(seed32.len(), 32);
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(seed32);
+    let mut rng = rng_from_seed(seed);
+
+    let store: Vec<ServerMessageStore> = entries.into_vec().into_iter().map(|w| w.inner).collect();
+    compute_fetch_challenges(&mut rng, &store, total_responses)
+        .into_iter()
+        .map(WFetchResponse::from)
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
+}
+
+#[wasm_bindgen]
+pub fn fetch_once(
+    recipient: &WJournalist,
+    challenges: Box<[WFetchResponse]>,
+) -> Array {
+    let inner: Vec<FetchResponse> = challenges.into_vec().into_iter().map(|w| w.inner).collect();
+    let ids: Vec<Vec<u8>> = bench_fetch(&recipient.inner, inner);
+
+    // Build Array<Uint8Array>
+    let out = Array::new();
+    for id in ids {
+        // Each message_id is 16 bytes
+        let u8arr = Uint8Array::from(id.as_slice());
+        out.push(&u8arr.into());
+    }
+    out
 }

--- a/securedrop-protocol/src/lib.rs
+++ b/securedrop-protocol/src/lib.rs
@@ -2,38 +2,33 @@
 
 extern crate alloc;
 
+pub mod client;
 pub mod keys;
-pub mod client;  pub use client::Client;
-pub mod messages;
-pub mod server;
-pub mod source;
+pub use client::Client;
 pub mod journalist;
-pub mod setup;
+pub mod messages;
 pub mod primitives;
+pub mod server;
+pub mod setup;
+pub mod source;
 
 // Primitives for signing
 pub mod sign;
-pub use sign::{Signature, SelfSignature, SigningKey, VerifyingKey};
+pub use sign::{SelfSignature, Signature, SigningKey, VerifyingKey};
 
 pub mod storage;
 
 pub mod bench;
 
 use alloc::{boxed::Box, vec::Vec};
+use js_sys::{Array, Uint8Array};
 use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
 use wasm_bindgen::prelude::*;
-use js_sys::{Array, Uint8Array};
 
 use bench::encrypt_decrypt::{
+    Envelope, FetchResponse, Journalist, Plaintext, ServerMessageStore, Source, User,
     compute_fetch_challenges,
-    Envelope,
-    FetchResponse,
-    Journalist,
-    Plaintext,
-    ServerMessageStore,
-    Source,
-    User,
 };
 use bench::{bench_decrypt, bench_encrypt, bench_fetch};
 
@@ -57,7 +52,9 @@ impl WSource {
         let mut seed = [0u8; 32];
         getrandom::fill(&mut seed).expect("getrandom failed");
         let mut rng = rng_from_seed(seed);
-        WSource { inner: Source::new(&mut rng) }
+        WSource {
+            inner: Source::new(&mut rng),
+        }
     }
 }
 
@@ -74,7 +71,9 @@ impl WJournalist {
         let mut seed = [0u8; 32];
         getrandom::fill(&mut seed).expect("getrandom failed");
         let mut rng = rng_from_seed(seed);
-        WJournalist { inner: Journalist::new(&mut rng, num_keybundles) }
+        WJournalist {
+            inner: Journalist::new(&mut rng, num_keybundles),
+        }
     }
 
     #[wasm_bindgen(getter)]
@@ -89,7 +88,9 @@ pub struct WEnvelope {
 }
 
 impl From<Envelope> for WEnvelope {
-    fn from(inner: Envelope) -> Self { WEnvelope { inner } }
+    fn from(inner: Envelope) -> Self {
+        WEnvelope { inner }
+    }
 }
 
 #[wasm_bindgen]
@@ -105,7 +106,9 @@ pub struct WFetchResponse {
     inner: FetchResponse,
 }
 impl From<FetchResponse> for WFetchResponse {
-    fn from(inner: FetchResponse) -> Self { WFetchResponse { inner } }
+    fn from(inner: FetchResponse) -> Self {
+        WFetchResponse { inner }
+    }
 }
 
 #[wasm_bindgen]
@@ -121,7 +124,9 @@ impl WStoreEntry {
         assert_eq!(message_id_16.len(), 16, "message_id must be 16 bytes");
         let mut id = [0u8; 16];
         id.copy_from_slice(message_id_16);
-        WStoreEntry { inner: ServerMessageStore::new(id, envelope.inner.clone()) }
+        WStoreEntry {
+            inner: ServerMessageStore::new(id, envelope.inner.clone()),
+        }
     }
 }
 
@@ -176,10 +181,7 @@ pub fn compute_fetch_challenges_once(
 }
 
 #[wasm_bindgen]
-pub fn fetch_once(
-    recipient: &WJournalist,
-    challenges: Box<[WFetchResponse]>,
-) -> Array {
+pub fn fetch_once(recipient: &WJournalist, challenges: Box<[WFetchResponse]>) -> Array {
     let inner: Vec<FetchResponse> = challenges.into_vec().into_iter().map(|w| w.inner).collect();
     let ids: Vec<Vec<u8>> = bench_fetch(&recipient.inner, inner);
 

--- a/securedrop-protocol/src/lib.rs
+++ b/securedrop-protocol/src/lib.rs
@@ -125,9 +125,6 @@ impl WStoreEntry {
     }
 }
 
-/* ========= Single-shot ops (what you time in JS) ========= */
-
-/// One encrypt. You time only this call in JS.
 /// `seed32` must be exactly 32 bytes.
 #[wasm_bindgen]
 pub fn encrypt_once(
@@ -150,7 +147,6 @@ pub fn encrypt_once(
     env.into()
 }
 
-/// One decrypt. You time only this call in JS.
 /// Returns plaintext bytes.
 #[wasm_bindgen]
 pub fn decrypt_once(recipient: &WJournalist, envelope: &WEnvelope) -> Vec<u8> {
@@ -159,7 +155,7 @@ pub fn decrypt_once(recipient: &WJournalist, envelope: &WEnvelope) -> Vec<u8> {
     pt.into_bytes()
 }
 
-/// Build challenges for fetch (usually not timed).
+/// Build challenges for fetch
 #[wasm_bindgen]
 pub fn compute_fetch_challenges_once(
     seed32: &[u8],

--- a/securedrop-protocol/src/lib.rs
+++ b/securedrop-protocol/src/lib.rs
@@ -46,22 +46,25 @@ pub mod bench;
 
 use wasm_bindgen::prelude::*;
 
+// For now we don't use the u32 param here, but when we update
+// the submit benchmark we can add parameterized keybundle size
+// as we have in the other benches.
 #[wasm_bindgen]
-pub fn bench_submit_message(iterations: u32) {
-    bench::bench_submit_message(iterations as usize);
+pub fn bench_submit_message(iterations: u32, unused: u32) {
+    bench::bench_submit_message(iterations as usize, unused as usize);
 }
 
 #[wasm_bindgen]
-pub fn bench_encrypt(iterations: u32) {
-    bench::bench_encrypt(iterations as usize);
+pub fn bench_encrypt(iterations: u32, num_keybundles: u32) {
+    bench::bench_encrypt(iterations as usize, num_keybundles as usize);
 }
 
 #[wasm_bindgen]
-pub fn bench_decrypt(iterations: u32) {
-    bench::bench_decrypt(iterations as usize);
+pub fn bench_decrypt(iterations: u32, num_keybundles: u32) {
+    bench::bench_decrypt(iterations as usize, num_keybundles as usize);
 }
 
 #[wasm_bindgen]
-pub fn bench_fetch(iterations: u32) {
-    bench::bench_fetch(iterations as usize);
+pub fn bench_fetch(iterations: u32, num_keybundles: u32) {
+    bench::bench_fetch(iterations as usize, num_keybundles as usize);
 }

--- a/securedrop-protocol/www/index.html
+++ b/securedrop-protocol/www/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>securedrop-protocol wasm harness</title>
+</head>
+<body>
+<script type="module">
+  import init, {
+    bench_decrypt,
+    bench_encrypt,
+    bench_fetch,
+    bench_submit_message,
+  } from '../pkg/securedrop_protocol.js';
+
+  async function run() {
+    try {
+      const wasmUrl = new URL('../pkg/securedrop_protocol_bg.wasm', import.meta.url);
+      await init(wasmUrl);
+
+      window.decrypt_bench = bench_decrypt;
+      window.encrypt_bench = bench_encrypt;
+      window.fetch_bench   = bench_fetch;
+      window.submit_bench  = bench_submit_message;
+
+      console.log('WASM benches ready');
+    } catch (e) {
+      console.error('Failed to init wasm:', e);
+    }
+  }
+  run();
+</script>
+</body>
+</html>

--- a/securedrop-protocol/www/index.html
+++ b/securedrop-protocol/www/index.html
@@ -6,253 +6,195 @@
   <style>
     body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; padding: 16px; }
     pre { white-space: pre-wrap; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; }
   </style>
 </head>
 <body>
-  <h1>securedrop-protocol wasm harness</h1>
-  <p>
-    Use query params:<br>
-    <code>?bench=encrypt|decrypt|fetch|all&amp;n=1000&amp;k=500&amp;j=3000&amp;raw=json|csv&amp;include_rng=1&amp;quiet=1</code>
-  </p>
   <pre id="out"></pre>
 
 <script type="module">
   import init, {
-    // opaque types
-    WSource,
-    WJournalist,
-    WEnvelope,
-    WStoreEntry,
-
-    // single-shot ops
-    encrypt_once,
-    decrypt_once,
-    compute_fetch_challenges_once,
-    fetch_once,
+    WSource, WJournalist, WEnvelope, WStoreEntry,
+    encrypt_once, decrypt_once, compute_fetch_challenges_once, fetch_once,
   } from '../pkg/securedrop_protocol.js';
 
-  // ---------- util ----------
-
-  const outEl = document.getElementById('out');
-  const log = (...args) => { console.log(...args); outEl.textContent += args.join(' ') + '\n'; };
-  const print = (s) => { outEl.textContent += s + '\n'; };
-
-  // crypto-safe u32
-  function randU32() {
-    const buf = new Uint32Array(1);
-    crypto.getRandomValues(buf);
-    return buf[0];
+  function bytesEq(a, b) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+    return true;
   }
 
-  // crypto seed (32 bytes)
-  function seed32() {
-    const u = new Uint8Array(32);
-    crypto.getRandomValues(u);
-    return u;
-  }
-
-  // get query param with default
+  // -------- params (no aliases) --------
   const params = new URLSearchParams(location.search);
-  const which = (params.get('bench') || 'all').toLowerCase(); // encrypt|decrypt|fetch|all
+  const allowed = new Set(['encrypt','decrypt_journalist','decrypt_source','fetch','all']);
+  const which = (params.get('bench') || 'all').toLowerCase();
+  if (!allowed.has(which)) throw new Error(`Unknown bench: ${which}`);
+
   const iterations = +(params.get('n') || 10);
   const keybundles  = +(params.get('k') || 500);
   const challenges  = +(params.get('j') || 3000);
-  const raw = (params.get('raw') || 'none').toLowerCase();   // none|json|csv
+  const raw = (params.get('raw') || 'json').toLowerCase();  // json | csv
   const includeRng = params.get('include_rng') === '1';
-  const quiet = params.get('quiet') === '1';
+  const label = params.get('label') || null;
 
-  function nowMs() { return performance.now(); }
+  // -------- env --------
+  const outEl = document.getElementById('out');
+  const print = (s) => { outEl.textContent += s + '\n'; };
 
-  function summarize(samplesMs) {
-    const n = samplesMs.length;
-    const total = samplesMs.reduce((a,b)=>a+b, 0);
-    const avg = n ? total / n : 0;
-    const sorted = [...samplesMs].sort((a,b)=>a-b);
-    const pick = (q) => {
-      if (!sorted.length) return 0;
-      const idx = Math.min(sorted.length-1, Math.round(q * (sorted.length - 1)));
-      return sorted[idx];
-    };
-    const min = sorted[0] ?? 0;
-    const max = sorted[sorted.length-1] ?? 0;
-    return { total_ms: total, avg_ms: avg, min_ms: min, p50_ms: pick(0.50), p90_ms: pick(0.90), p99_ms: pick(0.99), max_ms: max };
-  }
+  function randU32() { const b = new Uint32Array(1); crypto.getRandomValues(b); return b[0]; }
+  function seed32()  { const u = new Uint8Array(32); crypto.getRandomValues(u); return u; }
+  function nowUs()   { return performance.now() * 1000; } // microseconds (float)
+  function tickUs(fn) { const t0 = nowUs(); const r = fn(); return [Math.round(nowUs() - t0), r]; }
 
-  function output(benchName, iterations, keybundles, challenges, samplesMs) {
-    const summary = summarize(samplesMs);
-
-    if (raw === 'json') {
-      const payload = {
-        bench: benchName,
-        iterations,
-        keybundles,
-        challenges: challenges ?? null,
-        ...summary,
-        samples_ms: samplesMs,
-      };
-      // one line JSON
-      print(JSON.stringify(payload));
-      return;
-    }
-
-    if (raw === 'csv') {
-      // print samples, one per line
-      for (const v of samplesMs) print(String(v));
-      if (!quiet) {
-        console.error(
-          `# bench=${benchName} iterations=${iterations} keybundles=${keybundles} challenges=${challenges ?? 'null'} ` +
-          `total_ms=${summary.total_ms.toFixed(3)} avg_ms=${summary.avg_ms.toFixed(3)} ` +
-          `min_ms=${summary.min_ms.toFixed(3)} p50_ms=${summary.p50_ms.toFixed(3)} ` +
-          `p90_ms=${summary.p90_ms.toFixed(3)} p99_ms=${summary.p99_ms.toFixed(3)} max_ms=${summary.max_ms.toFixed(3)}`
-        );
-      }
-      return;
-    }
-
-    // pretty
-    if (!quiet) {
-      print(`bench: ${benchName}`);
-      print(`iterations: ${iterations}`);
-      print(`keybundles/journo: ${keybundles}`);
-      if (challenges != null) print(`challenges/iter: ${challenges}`);
-      print(`total: ${summary.total_ms.toFixed(3)} ms`);
-      print(`avg:   ${summary.avg_ms.toFixed(3)} ms/iter`);
-      print(
-        `min:   ${summary.min_ms.toFixed(3)} ms  ` +
-        `p50: ${summary.p50_ms.toFixed(3)}  p90: ${summary.p90_ms.toFixed(3)}  ` +
-        `p99: ${summary.p99_ms.toFixed(3)}  max: ${summary.max_ms.toFixed(3)} ms`
-      );
-    }
-  }
-
-  // ---------- benches (mirror manual.rs semantics) ----------
-
-  async function benchEncryptLoop(iterations, numKeybundles, includeRngInEncrypt) {
+  // -------- benches (return array of integer µs) --------
+  async function benchEncryptLoop(n, k, includeRngInEncrypt) {
     const samples = [];
-
-    for (let i = 0; i < iterations; i++) {
-      // fresh context per iter
+    for (let i = 0; i < n; i++) {
       const sender = new WSource();
-      const recipient = new WJournalist(numKeybundles);
+      const recipient = new WJournalist(k);
       const msg = new TextEncoder().encode('super secret msg');
-
-      const bundleIx = numKeybundles === 0 ? 0 : (randU32() % numKeybundles);
+      //const bundleIx = k === 0 ? 0 : (randU32() % k);
+      const bundleIx = 10;
 
       if (includeRngInEncrypt) {
-        const t0 = nowMs();
-        const seed = seed32(); // counted
-        const env = encrypt_once(seed, sender, recipient, bundleIx, msg);
-        const dt = nowMs() - t0;
+        const [dt] = tickUs(() => {
+          const seed = seed32();
+          const env = encrypt_once(seed, sender, recipient, bundleIx, msg);
+          void env;
+        });
         samples.push(dt);
-        // consume result
-        void env; // (opaque WEnvelope)
       } else {
-        const seed = seed32(); // NOT counted
-        const t0 = nowMs();
-        const env = encrypt_once(seed, sender, recipient, bundleIx, msg);
-        const dt = nowMs() - t0;
+        const seed = seed32();
+        const [dt] = tickUs(() => {
+          const env = encrypt_once(seed, sender, recipient, bundleIx, msg);
+          void env;
+        });
         samples.push(dt);
-        void env;
       }
     }
-
     return samples;
   }
 
-  async function benchDecryptLoop(iterations, numKeybundles) {
+  async function benchDecryptLoop(n, k) {
     const samples = [];
-
-    for (let i = 0; i < iterations; i++) {
-      // fresh context per iter
+    for (let i = 0; i < n; i++) {
       const sender = new WSource();
-      const recipient = new WJournalist(numKeybundles);
+      const recipient = new WJournalist(k);
       const msg = new TextEncoder().encode('super secret msg');
-
-      // prepare envelope (not timed)
       const seed = seed32();
-      const bundleIx = numKeybundles === 0 ? 0 : (randU32() % numKeybundles);
+      const bundleIx = k === 0 ? 0 : (randU32() % k);
       const env = encrypt_once(seed, sender, recipient, bundleIx, msg);
 
-      // time only decrypt
-      const t0 = nowMs();
-      const pt = decrypt_once(recipient, env);
-      const dt = nowMs() - t0;
-      samples.push(dt);
-
-      // consume
+      const [dt, pt] = tickUs(() => decrypt_once(recipient, env));
+      if (!bytesEq(pt, msg)) {
+        throw new Error(
+          `Decryption mismatch at iter ${i}: ` +
+          `expected len=${msg.length} (${toHex(msg).slice(0,64)}...), ` +
+          `got len=${pt.length} (${toHex(pt).slice(0,64)}...)`
+        );
+      }
       void pt;
+      samples.push(dt);
     }
-
     return samples;
-    }
+  }
 
-  async function benchFetchLoop(iterations, numKeybundles, challengesPerIter) {
+  async function benchFetchLoop(n, k, challengesPerIter) {
     const samples = [];
-
-    for (let i = 0; i < iterations; i++) {
-      // fresh context per iter
-      const journalist = new WJournalist(numKeybundles);
+    for (let i = 0; i < n; i++) {
+      const journalist = new WJournalist(k);
       const source = new WSource();
 
-      // build store (prep). mirror: store_size = min(challengesPerIter, 100)
       const storeSize = Math.min(challengesPerIter, 100);
       const storeEntries = [];
       for (let j = 0; j < storeSize; j++) {
         const seed = seed32();
-        const bundleIx = numKeybundles === 0 ? 0 : (randU32() % numKeybundles);
+        const bundleIx = k === 0 ? 0 : (randU32() % k);
         const msg = new TextEncoder().encode(`iter${i}-msg${j}`);
         const env = encrypt_once(seed, source, journalist, bundleIx, msg);
 
         const messageId = new Uint8Array(16);
-        messageId.fill(j & 0xff); // same pattern as Rust
-        const entry = new WStoreEntry(messageId, env);
-        storeEntries.push(entry);
+        messageId.fill(j & 0xff);
+        storeEntries.push(new WStoreEntry(messageId, env));
       }
 
-      // compute challenges (not timed)
       const challSeed = seed32();
-      const challenges = compute_fetch_challenges_once(challSeed, storeEntries, challengesPerIter);
+      const chals = compute_fetch_challenges_once(challSeed, storeEntries, challengesPerIter);
 
-      // time only the solver
-      const t0 = nowMs();
-      const ids = fetch_once(journalist, challenges);
-      const dt = nowMs() - t0;
-      samples.push(dt);
-
-      // consume
+      const [dt, ids] = tickUs(() => fetch_once(journalist, chals));
       void ids;
+      samples.push(dt);
     }
-
     return samples;
   }
 
-  // ---------- run ----------
+  // -------- emitters (no stats) --------
+  function makePayload(bench, iters, k, j, samplesUs, extra = {}) {
+    return {
+      bench,                 // encrypt | decrypt_journalist | decrypt_source | fetch
+      label: extra.label ?? null,
+      iterations: iters,
+      keybundles: k,
+      challenges: j ?? null,
+      samples_us: samplesUs, // integer µs per iteration
+    };
+  }
 
+  function emit(payload) {
+    if (raw === 'json') {
+      print(JSON.stringify(payload));
+    } else if (raw === 'csv') {
+      for (const v of payload.samples_us) print(String(v)); // µs per line
+    }
+  }
+
+  // -------- globals for Selenium --------
+  window.benchResults = [];             // array of payloads (with samples_us)
+  window.benchResultsByName = Object.create(null); // keyed by bench
+  window.benchReady = false;
+  window.waitForBenches = () =>
+    new Promise((resolve) => {
+      if (window.benchReady) return resolve(window.benchResults);
+      const iv = setInterval(() => {
+        if (window.benchReady) { clearInterval(iv); resolve(window.benchResults); }
+      }, 50);
+    });
+
+  // -------- run --------
   (async function run() {
     try {
       const wasmUrl = new URL('../pkg/securedrop_protocol_bg.wasm', import.meta.url);
       await init(wasmUrl);
 
-      print('WASM benches ready');
+      const toRun = (which === 'all')
+        ? ['encrypt','decrypt_journalist','decrypt_source','fetch']
+        : [which];
 
-      if (which === 'encrypt' || which === 'all') {
-        const e = await benchEncryptLoop(iterations, keybundles, includeRng);
-        output('encrypt', iterations, keybundles, null, e);
+      for (const name of toRun) {
+        if (name === 'encrypt') {
+          const samples = await benchEncryptLoop(iterations, keybundles, includeRng);
+          const p = makePayload('encrypt', iterations, keybundles, null, samples, { label });
+          window.benchResults.push(p); window.benchResultsByName[p.bench] = p; emit(p);
+        } else if (name === 'decrypt_journalist') {
+          const samples = await benchDecryptLoop(iterations, keybundles);
+          const p = makePayload('decrypt_journalist', iterations, keybundles, null, samples, { label });
+          window.benchResults.push(p); window.benchResultsByName[p.bench] = p; emit(p);
+        } else if (name === 'decrypt_source') {
+          const samples = await benchDecryptLoop(iterations, 1);
+          const p = makePayload('decrypt_source', iterations, 1, null, samples, { label });
+          window.benchResults.push(p); window.benchResultsByName[p.bench] = p; emit(p);
+        } else if (name === 'fetch') {
+          const samples = await benchFetchLoop(iterations, keybundles, challenges);
+          const p = makePayload('fetch', iterations, keybundles, challenges, samples, { label });
+          window.benchResults.push(p); window.benchResultsByName[p.bench] = p; emit(p);
+        }
       }
 
-      if (which === 'decrypt' || which === 'all') {
-        const d = await benchDecryptLoop(iterations, keybundles);
-        output('decrypt', iterations, keybundles, null, d);
-      }
-
-      if (which === 'fetch' || which === 'all') {
-        const f = await benchFetchLoop(iterations, keybundles, challenges);
-        output('fetch', iterations, keybundles, challenges, f);
-      }
-
+      window.benchReady = true;
     } catch (e) {
-      console.error('Failed to init/run wasm benches:', e);
-      print('Error: ' + (e && e.stack || e));
+      // emit a single JSON error line, keep harness quiet otherwise
+      print(JSON.stringify({ error: String(e && e.message || e) }));
+      window.benchReady = true;
     }
   })();
 </script>

--- a/securedrop-protocol/www/index.html
+++ b/securedrop-protocol/www/index.html
@@ -3,32 +3,258 @@
 <head>
   <meta charset="utf-8" />
   <title>securedrop-protocol wasm harness</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; padding: 16px; }
+    pre { white-space: pre-wrap; }
+  </style>
 </head>
 <body>
+  <h1>securedrop-protocol wasm harness</h1>
+  <p>
+    Use query params:<br>
+    <code>?bench=encrypt|decrypt|fetch|all&amp;n=1000&amp;k=500&amp;j=3000&amp;raw=json|csv&amp;include_rng=1&amp;quiet=1</code>
+  </p>
+  <pre id="out"></pre>
+
 <script type="module">
   import init, {
-    bench_decrypt,
-    bench_encrypt,
-    bench_fetch,
-    bench_submit_message,
+    // opaque types
+    WSource,
+    WJournalist,
+    WEnvelope,
+    WStoreEntry,
+
+    // single-shot ops
+    encrypt_once,
+    decrypt_once,
+    compute_fetch_challenges_once,
+    fetch_once,
   } from '../pkg/securedrop_protocol.js';
 
-  async function run() {
+  // ---------- util ----------
+
+  const outEl = document.getElementById('out');
+  const log = (...args) => { console.log(...args); outEl.textContent += args.join(' ') + '\n'; };
+  const print = (s) => { outEl.textContent += s + '\n'; };
+
+  // crypto-safe u32
+  function randU32() {
+    const buf = new Uint32Array(1);
+    crypto.getRandomValues(buf);
+    return buf[0];
+  }
+
+  // crypto seed (32 bytes)
+  function seed32() {
+    const u = new Uint8Array(32);
+    crypto.getRandomValues(u);
+    return u;
+  }
+
+  // get query param with default
+  const params = new URLSearchParams(location.search);
+  const which = (params.get('bench') || 'all').toLowerCase(); // encrypt|decrypt|fetch|all
+  const iterations = +(params.get('n') || 10);
+  const keybundles  = +(params.get('k') || 500);
+  const challenges  = +(params.get('j') || 3000);
+  const raw = (params.get('raw') || 'none').toLowerCase();   // none|json|csv
+  const includeRng = params.get('include_rng') === '1';
+  const quiet = params.get('quiet') === '1';
+
+  function nowMs() { return performance.now(); }
+
+  function summarize(samplesMs) {
+    const n = samplesMs.length;
+    const total = samplesMs.reduce((a,b)=>a+b, 0);
+    const avg = n ? total / n : 0;
+    const sorted = [...samplesMs].sort((a,b)=>a-b);
+    const pick = (q) => {
+      if (!sorted.length) return 0;
+      const idx = Math.min(sorted.length-1, Math.round(q * (sorted.length - 1)));
+      return sorted[idx];
+    };
+    const min = sorted[0] ?? 0;
+    const max = sorted[sorted.length-1] ?? 0;
+    return { total_ms: total, avg_ms: avg, min_ms: min, p50_ms: pick(0.50), p90_ms: pick(0.90), p99_ms: pick(0.99), max_ms: max };
+  }
+
+  function output(benchName, iterations, keybundles, challenges, samplesMs) {
+    const summary = summarize(samplesMs);
+
+    if (raw === 'json') {
+      const payload = {
+        bench: benchName,
+        iterations,
+        keybundles,
+        challenges: challenges ?? null,
+        ...summary,
+        samples_ms: samplesMs,
+      };
+      // one line JSON
+      print(JSON.stringify(payload));
+      return;
+    }
+
+    if (raw === 'csv') {
+      // print samples, one per line
+      for (const v of samplesMs) print(String(v));
+      if (!quiet) {
+        console.error(
+          `# bench=${benchName} iterations=${iterations} keybundles=${keybundles} challenges=${challenges ?? 'null'} ` +
+          `total_ms=${summary.total_ms.toFixed(3)} avg_ms=${summary.avg_ms.toFixed(3)} ` +
+          `min_ms=${summary.min_ms.toFixed(3)} p50_ms=${summary.p50_ms.toFixed(3)} ` +
+          `p90_ms=${summary.p90_ms.toFixed(3)} p99_ms=${summary.p99_ms.toFixed(3)} max_ms=${summary.max_ms.toFixed(3)}`
+        );
+      }
+      return;
+    }
+
+    // pretty
+    if (!quiet) {
+      print(`bench: ${benchName}`);
+      print(`iterations: ${iterations}`);
+      print(`keybundles/journo: ${keybundles}`);
+      if (challenges != null) print(`challenges/iter: ${challenges}`);
+      print(`total: ${summary.total_ms.toFixed(3)} ms`);
+      print(`avg:   ${summary.avg_ms.toFixed(3)} ms/iter`);
+      print(
+        `min:   ${summary.min_ms.toFixed(3)} ms  ` +
+        `p50: ${summary.p50_ms.toFixed(3)}  p90: ${summary.p90_ms.toFixed(3)}  ` +
+        `p99: ${summary.p99_ms.toFixed(3)}  max: ${summary.max_ms.toFixed(3)} ms`
+      );
+    }
+  }
+
+  // ---------- benches (mirror manual.rs semantics) ----------
+
+  async function benchEncryptLoop(iterations, numKeybundles, includeRngInEncrypt) {
+    const samples = [];
+
+    for (let i = 0; i < iterations; i++) {
+      // fresh context per iter
+      const sender = new WSource();
+      const recipient = new WJournalist(numKeybundles);
+      const msg = new TextEncoder().encode('super secret msg');
+
+      const bundleIx = numKeybundles === 0 ? 0 : (randU32() % numKeybundles);
+
+      if (includeRngInEncrypt) {
+        const t0 = nowMs();
+        const seed = seed32(); // counted
+        const env = encrypt_once(seed, sender, recipient, bundleIx, msg);
+        const dt = nowMs() - t0;
+        samples.push(dt);
+        // consume result
+        void env; // (opaque WEnvelope)
+      } else {
+        const seed = seed32(); // NOT counted
+        const t0 = nowMs();
+        const env = encrypt_once(seed, sender, recipient, bundleIx, msg);
+        const dt = nowMs() - t0;
+        samples.push(dt);
+        void env;
+      }
+    }
+
+    return samples;
+  }
+
+  async function benchDecryptLoop(iterations, numKeybundles) {
+    const samples = [];
+
+    for (let i = 0; i < iterations; i++) {
+      // fresh context per iter
+      const sender = new WSource();
+      const recipient = new WJournalist(numKeybundles);
+      const msg = new TextEncoder().encode('super secret msg');
+
+      // prepare envelope (not timed)
+      const seed = seed32();
+      const bundleIx = numKeybundles === 0 ? 0 : (randU32() % numKeybundles);
+      const env = encrypt_once(seed, sender, recipient, bundleIx, msg);
+
+      // time only decrypt
+      const t0 = nowMs();
+      const pt = decrypt_once(recipient, env);
+      const dt = nowMs() - t0;
+      samples.push(dt);
+
+      // consume
+      void pt;
+    }
+
+    return samples;
+    }
+
+  async function benchFetchLoop(iterations, numKeybundles, challengesPerIter) {
+    const samples = [];
+
+    for (let i = 0; i < iterations; i++) {
+      // fresh context per iter
+      const journalist = new WJournalist(numKeybundles);
+      const source = new WSource();
+
+      // build store (prep). mirror: store_size = min(challengesPerIter, 100)
+      const storeSize = Math.min(challengesPerIter, 100);
+      const storeEntries = [];
+      for (let j = 0; j < storeSize; j++) {
+        const seed = seed32();
+        const bundleIx = numKeybundles === 0 ? 0 : (randU32() % numKeybundles);
+        const msg = new TextEncoder().encode(`iter${i}-msg${j}`);
+        const env = encrypt_once(seed, source, journalist, bundleIx, msg);
+
+        const messageId = new Uint8Array(16);
+        messageId.fill(j & 0xff); // same pattern as Rust
+        const entry = new WStoreEntry(messageId, env);
+        storeEntries.push(entry);
+      }
+
+      // compute challenges (not timed)
+      const challSeed = seed32();
+      const challenges = compute_fetch_challenges_once(challSeed, storeEntries, challengesPerIter);
+
+      // time only the solver
+      const t0 = nowMs();
+      const ids = fetch_once(journalist, challenges);
+      const dt = nowMs() - t0;
+      samples.push(dt);
+
+      // consume
+      void ids;
+    }
+
+    return samples;
+  }
+
+  // ---------- run ----------
+
+  (async function run() {
     try {
       const wasmUrl = new URL('../pkg/securedrop_protocol_bg.wasm', import.meta.url);
       await init(wasmUrl);
 
-      window.decrypt_bench = bench_decrypt;
-      window.encrypt_bench = bench_encrypt;
-      window.fetch_bench   = bench_fetch;
-      window.submit_bench  = bench_submit_message;
+      print('WASM benches ready');
 
-      console.log('WASM benches ready');
+      if (which === 'encrypt' || which === 'all') {
+        const e = await benchEncryptLoop(iterations, keybundles, includeRng);
+        output('encrypt', iterations, keybundles, null, e);
+      }
+
+      if (which === 'decrypt' || which === 'all') {
+        const d = await benchDecryptLoop(iterations, keybundles);
+        output('decrypt', iterations, keybundles, null, d);
+      }
+
+      if (which === 'fetch' || which === 'all') {
+        const f = await benchFetchLoop(iterations, keybundles, challenges);
+        output('fetch', iterations, keybundles, challenges, f);
+      }
+
     } catch (e) {
-      console.error('Failed to init wasm:', e);
+      console.error('Failed to init/run wasm benches:', e);
+      print('Error: ' + (e && e.stack || e));
     }
-  }
-  run();
+  })();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Quick benchmarking without full setup, key enrollment, etc: just encrypt, decrypt, and fetch (WIP)

reviewer notes: 
- this is ~ a port of https://gist.github.com/rocodes/f0df870778fb55ec7c0b7a69a153e894 structure-wise, and the initial criterion benchmarking setup with just DHKEM keys was AI-assisted. However, most of that ended up being refactored away to add in 0.3 key types, our own rng, etc.
- the unit tests and benchmarking tests in benches/encrypt_decrypt.rs are mostly AI-generated


Still todo:
- [x] journalist setup
- [x] metadata parsing + incorporating pq psk key in metadata
- [x] fetch
- [x] fixing some type errors
- [ ] convert chachapoly -> aesgcm: will handle after or in separate PR; wanted to get a minimal version working and ready for feedback asap [note: to discuss, may leave as is]

## Test plan
- [ ] Visual review; comparison with #92 
- [x] `make build-wasm` succeeding
- [ ] unit tests: `cargo test bench` 
- [x] all benches succeeding (`make bench`)