### PR TITLE
docs: SD-PKE/APKE APIs and their building blocks

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -125,16 +125,16 @@ In the table below:
 
 ## Functions and notation
 
-| Syntax                                                    | Description                                                          |
-| --------------------------------------------------------- | -------------------------------------------------------------------- |
-| $`h \gets \text{Hash}(m)`$                                | Hash message $m$ to digest $h$                                       |
-| $`k \Vert k_1 \Vert \dots \Vert k_n \gets \text{KDF}(m)`$ | Derive one or more keys $k$ from a message $m$                       |
-| $`\sigma \gets^{\$} \text{Sign}(sk, m)`$                  | Sign a message $m$ with the private key $sk$                         |
-| $`b \in \{0,1\} \gets \text{Vfy}(pk, m, \sigma)`$         | Verify a message $m$ and a signature $\sigma$ with a public key $pk$ |
-| $` g^x \gets \text{DH(g, x)}`$                            | Diffie-Hellman exponentiation of private component $x$               |
-| $`r \gets^{\$} \text{Rand}()`$                            | Generate a random value                                              |
-| $`mp \gets \text{Pad}(m)`$                                | Pad a message $m$ to a constant size[^1]                             |
-| $`\varepsilon`$                                           | The empty string                                                     |
+| Syntax                                                    | Description                                                                       |
+| --------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| $`h \gets \text{Hash}(m)`$                                | Hash message $m$ to digest $h$                                                    |
+| $`k \Vert k_1 \Vert \dots \Vert k_n \gets \text{KDF}(m)`$ | Derive one or more keys $k$ from a message $m$                                    |
+| $`\sigma \gets^{\$} \text{Sign}(sk_S, m)`$                | Sign a message $m$ with the sender's private key $sk_S$                           |
+| $`b \in \{0,1\} \gets \text{Vfy}(pk_S, m, \sigma)`$       | Verify a message $m$ and a signature $\sigma$ with the sender's public key $pk_S$ |
+| $` g^x \gets \text{DH(g, x)}`$                            | Diffie-Hellman exponentiation of private component $x$                            |
+| $`r \gets^{\$} \text{Rand}()`$                            | Generate a random value                                                           |
+| $`mp \gets \text{Pad}(m)`$                                | Pad a message $m$ to a constant size[^1]                                          |
+| $`\varepsilon`$                                           | The empty string                                                                  |
 
 The protocol composes two modes of [Hybrid Public-Key Encryption (RFC 9180)][RFC 9180]:
 
@@ -152,11 +152,11 @@ mode][RFC 9180 §5.1.1] with:
 - $\text{AEAD} =$ AES-GCM
 - $\text{KS} =$ HPKE's [`KeySchedule()`][RFC 9180 §5.1] with [HKDF-SHA256][RFC 9180 §7.2]
 
-| Syntax                                    | Description                                                  |
-| ----------------------------------------- | ------------------------------------------------------------ |
-| $`(sk, pk) \gets^{\$} \text{KGen}()`$     | Generate keys                                                |
-| $`(c, c'') \gets^{\$} \text{Enc}(pk, m)`$ | Encrypt a message $m$ via HPKE in [`mode_base`][RFC 9180 §5] |
-| $`m \gets \text{Dec}(sk, (c, c''))`$      | Decrypt a message $m$ via HPKE in [`mode_base`][RFC 9180 §5] |
+| Syntax                                      | Description                                                  |
+| ------------------------------------------- | ------------------------------------------------------------ |
+| $`(sk, pk) \gets^{\$} \text{KGen}()`$       | Generate keys                                                |
+| $`(c, c'') \gets^{\$} \text{Enc}(pk_R, m)`$ | Encrypt a message $m$ via HPKE in [`mode_base`][RFC 9180 §5] |
+| $`m \gets \text{Dec}(sk_R, (c, c''))`$      | Decrypt a message $m$ via HPKE in [`mode_base`][RFC 9180 §5] |
 
 ### Message encryption
 
@@ -168,11 +168,11 @@ $\text{DHKEM}(\text{Group}, \text{KDF})$ with:
 - $\text{Group} =$ [X25519][RFC 9180 §7.1]
 - $\text{KDF} =$ [HKDF-SHA256][RFC 9180 §7.1]
 
-| Syntax                                         | Description                                                                                                                                                                        |
-| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| $`(sk, pk) \gets^{\$} \text{KGen}()`$          | Generate keys; for DH-AKEM, $(sk, pk) = (x, \text{DH}(g, x)) = (x, g^x)$                                                                                                           |
-| $`(c, K) \gets^{\$} \text{AuthEncap}(sk, pk)`$ | Encapsulate a ciphertext $c$ and a shared secret $K$ using a (sender's) private key $sk$ and a (receiver's) public key $pk$; for DH-AKEM, $(c, K) = (pkE, K) = (pk, K) = (g^x, K)$ |
-| $`K \gets \text{AuthDecap}(sk, pk, c)`$        | Decapsulate a shared secret $K$ using a (receiver's) private key $sk$, a (sender's) public key $pk$, and a ciphertext $c$; for DH-AKEM, $c = pkE$                                  |
+| Syntax                                             | Description                                                                                                                                                                        |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| $`(sk_S, pk_S) \gets^{\$} \text{KGen}()`$          | Generate keys; for DH-AKEM, $(sk, pk) = (x, \text{DH}(g, x)) = (x, g^x)$                                                                                                           |
+| $`(c, K) \gets^{\$} \text{AuthEncap}(sk_S, pk_R)`$ | Encapsulate a ciphertext $c$ and a shared secret $K$ using a sender's private key $sk_S$ and a receiver's public key $pk_R$; for DH-AKEM, $(c, K) = (pkE, K) = (pk, K) = (g^x, K)$ |
+| $`K \gets \text{AuthDecap}(sk_R, pk_S, c)`$        | Decapsulate a shared secret $K$ using a receiver's private key $sk_R$, a sender's public key $pk_S$, and a ciphertext $c$; for DH-AKEM, $c = pkE$                                  |
 
 #### `pskAPKE`: Pre-shared-key authenticated PKE <!-- Figure 5 as of 7703a58 -->
 
@@ -183,10 +183,10 @@ $\text{pskAPKE}[\text{AKEM}, \text{KS}, \text{AEAD}]$ instantiates [HPKE
 - $\text{KS} =$ HPKE's [`KeySchedule()`][RFC 9180 §5.1] with [HKDF-SHA256][RFC 9180 §7.2]
 - $\text{AEAD} =$ AES-GCM
 
-| Syntax                                                            | Description                                                                                           |
-| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| $`(c_1, c') \gets^{\$} \text{pskAEnc}(sk, pk, psk, m, ad, info)`$ | Encrypt a message $m$ with associated data $ad$ and $info$ via HPKE in [`mode_auth_psk`][RFC 9180 §5] |
-| $`m \gets \text{pskADec}(pk, sk, psk, (c_1, c'), ad, info)`$      | Decrypt a message $m$ with associated data $ad$ and $info$ via HPKE in [`mode_auth_psk`][RFC 9180 §5] |
+| Syntax                                                                | Description                                                                                           |
+| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| $`(c_1, c') \gets^{\$} \text{pskAEnc}(sk_S, pk_R, psk, m, ad, info)`$ | Encrypt a message $m$ with associated data $ad$ and $info$ via HPKE in [`mode_auth_psk`][RFC 9180 §5] |
+| $`m \gets \text{pskADec}(pk_S, sk_R, psk, (c_1, c'), ad, info)`$      | Decrypt a message $m$ with associated data $ad$ and $info$ via HPKE in [`mode_auth_psk`][RFC 9180 §5] |
 
 #### `SD-APKE`: SecureDrop APKE <!-- Figure 3 as of 7703a58 -->
 
@@ -196,11 +196,11 @@ $\text{SD-APKE}[\text{AKEM}, \text{KEM}_{PQ}, \text{AEAD}]$ is constructed with:
 - $\text{KEM}_{PQ} =$ ML-KEM-768
 - $\text{pskAPKE}$ as above
 
-| Syntax                                                                                  | Description                                                |
-| --------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| $`(sk, pk) \gets^{\$} \text{KGen}()`$                                                   | Generate keys                                              |
-| $`((c_1, c'), c_2) \gets^{\$} \text{AuthEnc}((sk_1, sk_2), (pk_1, pk_2), m, ad, info)`$ | Encrypt a message $m$ with associated data $ad$ and $info$ |
-| $`m \gets \text{AuthDec}((sk_1, sk_2), (pk_1, pk_2), ((c_1, c'), c_2), ad, info)`$      | Decrypt a message $m$ with associated data $ad$ and $info$ |
+| Syntax                                                                                          | Description                                                |
+| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| $`(sk, pk) \gets^{\$} \text{KGen}()`$                                                           | Generate keys                                              |
+| $`((c_1, c'), c_2) \gets^{\$} \text{AuthEnc}((sk_S^1, sk_S^2), (pk_R^1, pk_R^2), m, ad, info)`$ | Encrypt a message $m$ with associated data $ad$ and $info$ |
+| $`m \gets \text{AuthDec}((sk_R^1, sk_R^2), (pk_S^1, pk_S^2), ((c_1, c'), c_2), ad, info)`$      | Decrypt a message $m$ with associated data $ad$ and $info$ |
 
 ## Setup
 


### PR DESCRIPTION
* Blocked on #92, which [now](https://github.com/freedomofpress/securedrop-protocol/pull/92#issuecomment-3283362544) updates the "Keys" section

Towards #101, updates the "Functions and Notation" section by:
* documenting the `SD-PKE` and `SD-APKE` APIs and their building blocks; and
* removing the HPKE<sup>pq</sup><sub>auth</sub> construction from #70