### PR TITLE
docs: refactor protocol steps to use SD-PKE/APKE APIs

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -137,7 +137,7 @@ Protocol" sections from the manuscript.
 | $` g^x \gets \text{DH(g, x)}`$                            | Diffie-Hellman exponentiation of private component $x$                            |
 | $`r \gets^{\$} \text{Rand}()`$                            | Generate a random value                                                           |
 | $`mp \gets \text{Pad}(m)`$                                | Pad a message $m$ to a constant size[^1]                                          |
-| $`\varepsilon`$                                           | The empty string                                                                  |
+| $`-`$                                                     | The empty string (or `None` in pseudocode)                                        |
 
 ## Cryptographic APIs
 


### PR DESCRIPTION
- [x] Blocked on #103 → #92

Towards #101, this should make good on #103's promise that:

> [w]ith these concrete definitions, this specification is sufficient to implement these APIs without reference to the manuscript[.]

In addition:
- Closes #72
- Closes #78