### PR TITLE
Update protocol.md with journalist dh-akem reply key and journalist self-signing procedure 

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -38,8 +38,11 @@ activate Server
 
 Note over Journalist, Server: 3.1. Journalist enrollment
 activate Journalist
-Journalist ->> Server: J{sig,fetch,dh},pk := journalist's long-term keys
-Newsroom ->> Server: σNR := newsroom's signature
+Journalist ->> Newsroom: Jsig,pk := journalist's signing key
+Newsroom ->> Journalist: σNR := newsroom's signature on Jsig,pk
+Journalist ->> Journalist: J{fetch,dh},pk := journalist's long-term keys
+Journalist ->> Journalist: σJ := signature over J{fetch,dh},pk using Jsig,sk
+Journalist ->> Server: J{sig,fetch,dh},pk<br>σNR, σJ
 deactivate Newsroom
 
 Note over Journalist, Server: 3.2. Setup and periodic replenishment<br>of n ephemeral keys
@@ -105,20 +108,20 @@ In the table below:
 > private or public. For Diffie-Hellman keys $x$, the public component is
 > represented by the exponentiation $DH(g, x)$.[^3]
 
-| Owner      | Private key or decapsulation | Public key or encapsulation | Purpose          | Usage    | Lifetime      | Algorithm              | Signed by           |
-| ---------- | ---------------------------- | --------------------------- | -------------- | -------- | ------------- | ---------------------- | ------------------- |
-| FPF        | $`FPF_{sig,sk}`$             | $`FPF_{sig,pk}`$            | Signing        |          | Long-term     | ?                      |                     |
-| Newsroom   | $`NR_{sig,sk}`$              | $`NR_{sig,pk}`$             | Signing        |          | Long-term     | ?                      | $`FPF_{sig,sk}`$    |
-| Journalist | $`J_{sig,sk}`$               | $`J_{sig,pk}`$              | Signing        |          | Long-term     | ?                      | $`NR_{sig,sk}`$     |
-| Journalist | $`J_{apke,sk}`$              | $`J_{apke,pk}`$             | Encryption (Outgoing messages) | SD-APKE (Message)    | Long-term      | DH-AKEM(X25519, HKDF-SHA256) | $`J_{sig,sk}`$      |
-| Journalist | $`J_{fetch,sk}`$             | $`J_{fetch,pk}`$            | Fetching       |          | **TBD**[^6]   | ristretto255 (Curve25519)                 | $`J_{sig,sk}`$[^4] |
-| Journalist | $`J_{epq,sk}`$               | $`J_{epq,pk}`$              | Encryption PSK (Incoming messages) | SD-APKE (Message)  | One-time      | ML-KEM-768             | $`J_{sig,sk}`$      |
-| Journalist | $`J_{epke,sk}`$              | $`J_{epke,pk}`$             | Encryption (Incoming messages)     | SD-APKE (Message)  | One-time      | DH-AKEM(X25519, HKDF-SHA256) | $`J_{sig,sk}`$      |
-| Journalist | $`J_{emd,sk}`$               | $`J_{emd,pk}`$              | Encryption (Incoming messages)    | SD-PKE (Metadata) | One-time      | X-Wing  (X25519, ML-KEM-768) | $`J_{sig,sk}`$      |
-| Source     | $`S_{fetch,sk}`$             | $`S_{fetch,pk}`$            | Fetching       |          | Permanent[^7] | ristretto255 (Curve25519) |                     |
-| Source     | $`S_{pq,sk}`$                | $`S_{pq,pk}`$               | Encryption PSK (Incoming messages) | SD-APKE (Message)  | Permanent[^7] | ML-KEM-768             |                     |
-| Source     | $`S_{pke,sk}`$               | $`S_{pke,pk}`$              | Encryption (Incoming and outgoing messages)     | SD-APKE (Message)  | Permanent[^7] | DH-AKEM(X25519, HKDF-SHA256) |                     |
-| Source     | $`S_{md,sk}`$                | $`S_{md,pk}`$               | Encryption (Incoming messages)     | SD-PKE (Metadata) | Permanent[^7] | X-Wing (X25519, ML-KEM-768) |                     |
+| Owner      | Private key or decapsulation | Public key or encapsulation | Purpose                                     | Usage             | Lifetime      | Algorithm                    | Signed by          |
+| ---------- | ---------------------------- | --------------------------- | ------------------------------------------- | ----------------- | ------------- | ---------------------------- | ------------------ |
+| FPF        | $`FPF_{sig,sk}`$             | $`FPF_{sig,pk}`$            | Signing                                     |                   | Long-term     | ?                            |                    |
+| Newsroom   | $`NR_{sig,sk}`$              | $`NR_{sig,pk}`$             | Signing                                     |                   | Long-term     | ?                            | $`FPF_{sig,sk}`$   |
+| Journalist | $`J_{sig,sk}`$               | $`J_{sig,pk}`$              | Signing                                     |                   | Long-term     | ?                            | $`NR_{sig,sk}`$    |
+| Journalist | $`J_{apke,sk}`$              | $`J_{apke,pk}`$             | Encryption (Outgoing messages)              | SD-APKE (Message) | Long-term     | DH-AKEM(X25519, HKDF-SHA256) | $`J_{sig,sk}`$     |
+| Journalist | $`J_{fetch,sk}`$             | $`J_{fetch,pk}`$            | Fetching                                    |                   | **TBD**[^6]   | ristretto255 (Curve25519)    | $`J_{sig,sk}`$[^4] |
+| Journalist | $`J_{epq,sk}`$               | $`J_{epq,pk}`$              | Encryption PSK (Incoming messages)          | SD-APKE (Message) | One-time      | ML-KEM-768                   | $`J_{sig,sk}`$     |
+| Journalist | $`J_{epke,sk}`$              | $`J_{epke,pk}`$             | Encryption (Incoming messages)              | SD-APKE (Message) | One-time      | DH-AKEM(X25519, HKDF-SHA256) | $`J_{sig,sk}`$     |
+| Journalist | $`J_{emd,sk}`$               | $`J_{emd,pk}`$              | Encryption (Incoming messages)              | SD-PKE (Metadata) | One-time      | X-Wing (X25519, ML-KEM-768)  | $`J_{sig,sk}`$     |
+| Source     | $`S_{fetch,sk}`$             | $`S_{fetch,pk}`$            | Fetching                                    |                   | Permanent[^7] | ristretto255 (Curve25519)    |                    |
+| Source     | $`S_{pq,sk}`$                | $`S_{pq,pk}`$               | Encryption PSK (Incoming messages)          | SD-APKE (Message) | Permanent[^7] | ML-KEM-768                   |                    |
+| Source     | $`S_{pke,sk}`$               | $`S_{pke,pk}`$              | Encryption (Incoming and outgoing messages) | SD-APKE (Message) | Permanent[^7] | DH-AKEM(X25519, HKDF-SHA256) |                    |
+| Source     | $`S_{md,sk}`$                | $`S_{md,pk}`$               | Encryption (Incoming messages)              | SD-PKE (Metadata) | Permanent[^7] | X-Wing (X25519, ML-KEM-768)  |                    |
 
 [^4]: **TODO:** Discussion of whether the newsroom's or the journalist's signing key signs the journalist's fetching key.
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -108,20 +108,20 @@ In the table below:
 > private or public. For Diffie-Hellman keys $x$, the public component is
 > represented by the exponentiation $DH(g, x)$.[^3]
 
-| Owner      | Private key or decapsulation | Public key or encapsulation | Purpose                                     | Usage             | Lifetime      | Algorithm                    | Signed by          |
-| ---------- | ---------------------------- | --------------------------- | ------------------------------------------- | ----------------- | ------------- | ---------------------------- | ------------------ |
-| FPF        | $`FPF_{sig,sk}`$             | $`FPF_{sig,pk}`$            | Signing                                     |                   | Long-term     | ?                            |                    |
-| Newsroom   | $`NR_{sig,sk}`$              | $`NR_{sig,pk}`$             | Signing                                     |                   | Long-term     | ?                            | $`FPF_{sig,sk}`$   |
-| Journalist | $`J_{sig,sk}`$               | $`J_{sig,pk}`$              | Signing                                     |                   | Long-term     | ?                            | $`NR_{sig,sk}`$    |
-| Journalist | $`J_{apke,sk}`$              | $`J_{apke,pk}`$             | Encryption (Outgoing messages)              | SD-APKE (Message) | Long-term     | DH-AKEM(X25519, HKDF-SHA256) | $`J_{sig,sk}`$     |
-| Journalist | $`J_{fetch,sk}`$             | $`J_{fetch,pk}`$            | Fetching                                    |                   | **TBD**[^6]   | ristretto255 (Curve25519)    | $`J_{sig,sk}`$[^4] |
-| Journalist | $`J_{epq,sk}`$               | $`J_{epq,pk}`$              | Encryption PSK (Incoming messages)          | SD-APKE (Message) | One-time      | ML-KEM-768                   | $`J_{sig,sk}`$     |
-| Journalist | $`J_{epke,sk}`$              | $`J_{epke,pk}`$             | Encryption (Incoming messages)              | SD-APKE (Message) | One-time      | DH-AKEM(X25519, HKDF-SHA256) | $`J_{sig,sk}`$     |
-| Journalist | $`J_{emd,sk}`$               | $`J_{emd,pk}`$              | Encryption (Incoming messages)              | SD-PKE (Metadata) | One-time      | X-Wing (X25519, ML-KEM-768)  | $`J_{sig,sk}`$     |
-| Source     | $`S_{fetch,sk}`$             | $`S_{fetch,pk}`$            | Fetching                                    |                   | Permanent[^7] | ristretto255 (Curve25519)    |                    |
-| Source     | $`S_{pq,sk}`$                | $`S_{pq,pk}`$               | Encryption PSK (Incoming messages)          | SD-APKE (Message) | Permanent[^7] | ML-KEM-768                   |                    |
-| Source     | $`S_{pke,sk}`$               | $`S_{pke,pk}`$              | Encryption (Incoming and outgoing messages) | SD-APKE (Message) | Permanent[^7] | DH-AKEM(X25519, HKDF-SHA256) |                    |
-| Source     | $`S_{md,sk}`$                | $`S_{md,pk}`$               | Encryption (Incoming messages)              | SD-PKE (Metadata) | Permanent[^7] | X-Wing (X25519, ML-KEM-768)  |                    |
+| Owner      | Secret Key       | Pubkey           | Usage   | Purpose  | Direction         | Lifetime      | Algorithm                    | Signed by          |
+| ---------- | ---------------- | ---------------- | ------- | -------- | ----------------- | ------------- | ---------------------------- | ------------------ |
+| FPF        | $`FPF_{sig,sk}`$ | $`FPF_{sig,pk}`$ |         | Signing  |                   | Long-term     | ?                            |                    |
+| Newsroom   | $`NR_{sig,sk}`$  | $`NR_{sig,pk}`$  |         | Signing  |                   | Long-term     | ?                            | $`FPF_{sig,sk}`$   |
+| Journalist | $`J_{sig,sk}`$   | $`J_{sig,pk}`$   |         | Signing  |                   | Long-term     | ?                            | $`NR_{sig,sk}`$    |
+| Journalist | $`J_{apke,sk}`$  | $`J_{apke,pk}`$  | SD-APKE | Message  | Outgoing          | Long-term     | DH-AKEM(X25519, HKDF-SHA256) | $`J_{sig,sk}`$     |
+| Journalist | $`J_{fetch,sk}`$ | $`J_{fetch,pk}`$ |         | Fetching |                   | **TBD**[^6]   | ristretto255 (Curve25519)    | $`J_{sig,sk}`$[^4] |
+| Journalist | $`J_{epq,sk}`$   | $`J_{epq,pk}`$   | SD-APKE | Message  | Incoming          | One-time      | ML-KEM-768                   | $`J_{sig,sk}`$     |
+| Journalist | $`J_{epke,sk}`$  | $`J_{epke,pk}`$  | SD-APKE | Message  | Incoming          | One-time      | DH-AKEM(X25519, HKDF-SHA256) | $`J_{sig,sk}`$     |
+| Journalist | $`J_{emd,sk}`$   | $`J_{emd,pk}`$   | SD-PKE  | Metadata | Incoming          | One-time      | X-Wing (X25519, ML-KEM-768)  | $`J_{sig,sk}`$     |
+| Source     | $`S_{fetch,sk}`$ | $`S_{fetch,pk}`$ |         | Fetching |                   | Permanent[^7] | ristretto255 (Curve25519)    |                    |
+| Source     | $`S_{pq,sk}`$    | $`S_{pq,pk}`$    | SD-APKE | Message  | Incoming          | Permanent[^7] | ML-KEM-768                   |                    |
+| Source     | $`S_{pke,sk}`$   | $`S_{pke,pk}`$   | SD-APKE | Message  | Incoming+Outgoing | Permanent[^7] | DH-AKEM(X25519, HKDF-SHA256) |                    |
+| Source     | $`S_{md,sk}`$    | $`S_{md,pk}`$    | SD-PKE  | Metadata | Incoming          | Permanent[^7] | X-Wing (X25519, ML-KEM-768)  |                    |
 
 [^4]: **TODO:** Discussion of whether the newsroom's or the journalist's signing key signs the journalist's fetching key.
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -105,19 +105,20 @@ In the table below:
 > private or public. For Diffie-Hellman keys $x$, the public component is
 > represented by the exponentiation $DH(g, x)$.[^3]
 
-| Owner      | Private key or decapsulation | Public key or encapsulation | Usage          | Scope    | Lifetime      | Algorithm              | Signed by           |
+| Owner      | Private key or decapsulation | Public key or encapsulation | Purpose          | Usage    | Lifetime      | Algorithm              | Signed by           |
 | ---------- | ---------------------------- | --------------------------- | -------------- | -------- | ------------- | ---------------------- | ------------------- |
 | FPF        | $`FPF_{sig,sk}`$             | $`FPF_{sig,pk}`$            | Signing        |          | Long-term     | ?                      |                     |
 | Newsroom   | $`NR_{sig,sk}`$              | $`NR_{sig,pk}`$             | Signing        |          | Long-term     | ?                      | $`FPF_{sig,sk}`$    |
 | Journalist | $`J_{sig,sk}`$               | $`J_{sig,pk}`$              | Signing        |          | Long-term     | ?                      | $`NR_{sig,sk}`$     |
-| Journalist | $`J_{fetch,sk}`$             | $`J_{fetch,pk}`$            | Fetching       |          | **TBD**[^6]   | X25519                 | $`NR_{sig,sk}`$[^4] |
-| Journalist | $`J_{epq,sk}`$               | $`J_{epq,pk}`$              | Encryption PSK | Message  | One-time      | ML-KEM-768             | $`J_{sig,sk}`$      |
-| Journalist | $`J_{epke,sk}`$              | $`J_{epke,pk}`$             | Encryption     | Message  | One-time      | SD-PKE (defined below) | $`J_{sig,sk}`$      |
-| Journalist | $`J_{emd,sk}`$               | $`J_{emd,pk}`$              | Encryption     | Metadata | One-time      | X-Wing                 | $`J_{sig,sk}`$      |
-| Source     | $`S_{fetch,sk}`$             | $`S_{fetch,pk}`$            | Fetching       |          | Permanent[^7] | X25519                 |                     |
-| Source     | $`S_{pq,sk}`$                | $`S_{pq,pk}`$               | Encryption PSK | Message  | Permanent[^7] | ML-KEM-768             |                     |
-| Source     | $`S_{pke,sk}`$               | $`S_{pke,pk}`$              | Encryption     | Message  | Permanent[^7] | SD-PKE (defined below) |                     |
-| Source     | $`S_{md,sk}`$                | $`S_{md,pk}`$               | Encryption     | Metadata | Permanent[^7] | X-Wing                 |                     |
+| Journalist | $`J_{apke,sk}`$              | $`J_{apke,pk}`$             | Encryption (Outgoing messages) | SD-APKE (Message)    | Long-term      | DH-AKEM(X25519, HKDF-SHA256) | $`J_{sig,sk}`$      |
+| Journalist | $`J_{fetch,sk}`$             | $`J_{fetch,pk}`$            | Fetching       |          | **TBD**[^6]   | ristretto255 (Curve25519)                 | $`J_{sig,sk}`$[^4] |
+| Journalist | $`J_{epq,sk}`$               | $`J_{epq,pk}`$              | Encryption PSK (Incoming messages) | SD-APKE (Message)  | One-time      | ML-KEM-768             | $`J_{sig,sk}`$      |
+| Journalist | $`J_{epke,sk}`$              | $`J_{epke,pk}`$             | Encryption (Incoming messages)     | SD-APKE (Message)  | One-time      | DH-AKEM(X25519, HKDF-SHA256) | $`J_{sig,sk}`$      |
+| Journalist | $`J_{emd,sk}`$               | $`J_{emd,pk}`$              | Encryption (Incoming messages)    | SD-PKE (Metadata) | One-time      | X-Wing  (X25519, ML-KEM-768) | $`J_{sig,sk}`$      |
+| Source     | $`S_{fetch,sk}`$             | $`S_{fetch,pk}`$            | Fetching       |          | Permanent[^7] | ristretto255 (Curve25519) |                     |
+| Source     | $`S_{pq,sk}`$                | $`S_{pq,pk}`$               | Encryption PSK (Incoming messages) | SD-APKE (Message)  | Permanent[^7] | ML-KEM-768             |                     |
+| Source     | $`S_{pke,sk}`$               | $`S_{pke,pk}`$              | Encryption (Incoming and outgoing messages)     | SD-APKE (Message)  | Permanent[^7] | DH-AKEM(X25519, HKDF-SHA256) |                     |
+| Source     | $`S_{md,sk}`$                | $`S_{md,pk}`$               | Encryption (Incoming messages)     | SD-PKE (Metadata) | Permanent[^7] | X-Wing (X25519, ML-KEM-768) |                     |
 
 [^4]: **TODO:** Discussion of whether the newsroom's or the journalist's signing key signs the journalist's fetching key.
 

--- a/docs/wip-protocol-0.3.md
+++ b/docs/wip-protocol-0.3.md
@@ -1,6 +1,6 @@
 ## Journalist Enrollemnt
 
-- see protocol.md (TODO)
+- see protocol.md (WIP)
 
 ## Initial keys fetch (`/journalists`)
 
@@ -84,8 +84,9 @@
 
 ### Messaging
 
-- Presumes Newsroom PKI set up (ie FPF has signed Newsroom key, newsroom has signed journalist signing keys. Still TBD whether newsroom or journalist signs journo fetching key.)
+- Presumes Newsroom PKI set up (ie FPF has signed Newsroom key, newsroom has signed journalist signing key. Under discussion: Journalist signs their own long-term dh-akem and fetching key.)
 - Fetching key lifetime still TBD; might want to make it easier to roll than the journo signing key
+- There is still an open issue to discuss the lifetime of the journalist messaging key bundles that are used by senders to send them messages. (Discussion of time-scoped keys instead of one-time keys depending on key exhaustion concerns).
 - Presumes source verifies signatures on keys before using (omits error checking)
 - Source creates message for each journalist individually (n journalists)
 - Journalist creates reply for all other journalists + source (n-1 + 1 = n, to be sure that ciphertext numbers match in each direction and avoid attacks that allow for probabilistically identifying a user's role)
@@ -93,11 +94,10 @@
 - Still for discussion: Message (plaintext) structure. Includes at minimum the pubkeys needed for replies, but could also include NR key/identifier (avoid cross-instance replays), additional application-level metadata.
 - "Clue" (output of DH agreement) needs to be exposed by whatever primitives library we are using.
 - Error-handling/robust implementation details omitted for clarity for now
+- Of note: In one-shot/unidirectional dead-drop mode, the source could avoid attaching their public keys used for replies, improving deniability.
 
 ### Fetch/delete
 
 - Fuzzy message expiry planned for messages on server (vs one-time delivery, sending a message to the server upon read, or any other mechanisms). This contrasts with the Tamarin model in progres where one-time message delivery is modeled.
 - Some discussion about issuing one fetch request (one ID per request) vs fetching multiple IDs at once. For now assume one fetch request is one message ID.
 - The ephemeral key used by the sender to generate the Clue isn't included anywhere or bound to the ciphertext at all; in previous designs it was the message ephemeral pubkey. EthZ says it is by design that nothing can link the key to the message; however, is it worth considering identifying the key _inside_ the message ciphertext (eg a key hash)?
-
-\*\*\*: In a unidirectional dead-drop mode, attaching these PQ keys could be avoided, since they are only used for replies.


### PR DESCRIPTION
### Description

- Add dh-akem journalist reply key to table.
- Update table headers a bit: I'd to preserve an at-a-glance way to see what specific parameter choices have been made, and I think saying SD-APKE is less clear at a glance than saying DHAKEM(X25519, HKDF-SHA256), so I've adjusted the headings a bit to make room for both types of information. 
- Update enrollment and table entry to Include journalist self-signing procedure for long-term reply key and fetching key. (The footnote that this is under discussion is preserved, but since it looks like this is the direction we are trying to go for, indicate that here so there's no ambiguity about our intention). 
- Closes #100 

### Checklist
- [x] base branch is `message-enc-flow-doc` (I sorely regret the name)
- [x] Visual review
- [x] mermaid diagram looks ok - not my strong suit
