### PR TITLE
Only sender pubkey in hpke.base metadata seal

### DIFF
--- a/securedrop-protocol/src/bench/encrypt_decrypt.rs
+++ b/securedrop-protocol/src/bench/encrypt_decrypt.rs
@@ -335,11 +335,12 @@ pub fn encrypt<R: RngCore + CryptoRng>(
     let mut mgdh = [0u8; LEN_DH_ITEM];
     let _ = scalarmult(&mut mgdh, &eph_sk, recipient.get_fetch_pk());
 
-    // Serialize sender Dh-AKEM pubkey for Metadata
+    // Serialize sender DH-AKEM pubkey
     let mut sender_pubkey_bytes: [u8; LEN_DHKEM_ENCAPS_KEY] = [0u8; LEN_DHKEM_ENCAPS_KEY];
     sender_pubkey_bytes.copy_from_slice(sender_hpke_keypair.public_key().as_slice());
 
-    // Serialize then encrypt sender pubkey metadata key (xwing) and Hpke Base mode:
+    // Serialize then encapsulate sender pubkey to recipient metadata key
+    // (xwing) in Hpke Base mode:
     // https://www.rfc-editor.org/rfc/rfc9180.html#name-metadata-protection
     // Although we do use a PSK and PSK_ID in the message, we don't need to
     // encrypt the message PSK_ID, because it is a hard-coded string


### PR DESCRIPTION
Refs https://github.com/freedomofpress/securedrop-protocol/pull/86#issuecomment-3422862655

### Description

Changes to benchmarking code:

- Moved the DH-AKEM encaps shared secret and the PQ PSK encaps shared secret out of the hpke.base encrypted "metadata" and directly into the `Envelope` (the message payload to the server) per followup discussion with ethz - no need to double-encrypt them. (This matches the manuscript).
  - That means there's no "metadata" type now
  - ~It theoretically means that there should be a wrapper type for the ciphertext in the Envelope (to keep with the `C, X, Z` format), but since it's a quick benchmark implementation I have left all the bytes as separate types rather than concatenating them and them parsing them.~ edit: there's a wrapper type. :) 
  - (There's the `CombinedCiphertext` type for serializing/deserializing all the parts, but I kept the type signature and even variable name in the `Envelope` struct unchanged, to avoid having to make any wasm-bindgen changes).
- bonus: Include keygen for journalist reply keys (they aren't used because we aren't benching replies yet, but for more completeness).
 
### Test plan
- [x] Visual review
- [x] CI 
- [x] Compare with manuscript and discussion 
- [x] `make bench`