### PR TITLE
docs: update specification from manuscript `243f384`

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -344,14 +344,14 @@ Then:
 Following [enrollment](#31-enrollment-), each journalist $J$ MUST generate and
 maintain a pool of $n$ ephemeral key bundles. For each key bundle $i$:
 
-| Journalist                                                                                                   |                                                                         | Server                                                                                                |
-| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| $`(sk_{J,i}^{APKE_E}, pk_{J,i}^{APKE_E}) \gets^{\$} \text{SD-APKE.KGen}()`$                                  |                                                                         |                                                                                                       |
-| $`(sk_{J,i}^{PKE_E}, pk_{J,i}^{PKE_E}) \gets^{\$} \text{SD-PKE.KGen}()`$                                     |                                                                         |                                                                                                       |
-| $`\sigma_{J,i} \gets^{\$} \text{SIG.Sign}(sk_J^{sig}, (pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E}, pk_J^{fetch}))`$ |                                                                         |                                                                                                       |
-|                                                                                                              | $`\longrightarrow (\sigma_{J,i}, pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E})`$ |
-|                                                                                                              |                                                                         | $`b = \text{SIG.Vfy}(vk_J^{sig}, (pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E}, pk_J^{fetch}), \sigma_{J,i})`$ |
-|                                                                                                              |                                                                         | If $b = 1$: Store $(\sigma_{J,i}, pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E})$ for $J$                       |
+| Journalist                                                                                                                      |                                                                         | Server                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| $`(sk_{J,i}^{APKE_E}, pk_{J,i}^{APKE_E}) \gets^{\$} \text{SD-APKE.KGen}()`$                                                     |                                                                         |                                                                                                       |
+| $`(sk_{J,i}^{PKE_E}, pk_{J,i}^{PKE_E}) \gets^{\$} \text{SD-PKE.KGen}()`$                                                        |                                                                         |                                                                                                       |
+| $`\sigma_{J,i} \gets^{\$} \text{SIG.Sign}(sk_J^{sig}, (pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E}, pk_J^{fetch}))`$ (**TODO:** [#127]) |                                                                         |                                                                                                       |
+|                                                                                                                                 | $`\longrightarrow (\sigma_{J,i}, pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E})`$ |
+|                                                                                                                                 |                                                                         | $`b = \text{SIG.Vfy}(vk_J^{sig}, (pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E}, pk_J^{fetch}), \sigma_{J,i})`$ |
+|                                                                                                                                 |                                                                         | If $b = 1$: Store $(\sigma_{J,i}, pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E})$ for $J$                       |
 
 ### 4. Source <!-- Section 4 as of 243f384 -->
 
@@ -389,15 +389,15 @@ Given:
 
 Then:
 
-| Sender                                                                                                                       |                                 | Server                                                                                                                              |
-| ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-|                                                                                                                              | $\longrightarrow$ `RequestKeys` |                                                                                                                                     |
-|                                                                                                                              |                                 | $`pks \gets \{(vk_J^{sig}, pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E}, pk_J^{fetch}, pk_J^{APKE})\}`$ for all $J$ and key bundles $i$[^10] |
-|                                                                                                                              |                                 | $`sigs \gets \{(\sigma_{NR,J}, \sigma_J, \sigma_{J,i})\}`$ for all $J$ and key bundles $i$                                          |
-|                                                                                                                              | $`pks, sigs \longleftarrow`$    |                                                                                                                                     |
-| If $`\text{SIG.Vfy}(vk_{NR}^{sig}, vk_J^{sig}, \sigma_{NR,J}) = 0`$ for some $J$: abort                                      |                                 |                                                                                                                                     |
-| If $`\text{SIG.Vfy}(vk_J^{sig}, (pk_J^{APKE}, pk_J^{fetch}), \sigma_J) = 0`$ for some $J$: abort                             |                                 |                                                                                                                                     |
-| If $`\text{SIG.Vfy}(vk_J^{sig}, (pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E}, pk_J^{fetch}), \sigma_{J,i}) = 0`$ for some $J$: abort |                                 |                                                                                                                                     |
+| Sender                                                                                                                                          |                                 | Server                                                                                                                              |
+| ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+|                                                                                                                                                 | $\longrightarrow$ `RequestKeys` |                                                                                                                                     |
+|                                                                                                                                                 |                                 | $`pks \gets \{(vk_J^{sig}, pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E}, pk_J^{fetch}, pk_J^{APKE})\}`$ for all $J$ and key bundles $i$[^10] |
+|                                                                                                                                                 |                                 | $`sigs \gets \{(\sigma_{NR,J}, \sigma_J, \sigma_{J,i})\}`$ for all $J$ and key bundles $i$                                          |
+|                                                                                                                                                 | $`pks, sigs \longleftarrow`$    |                                                                                                                                     |
+| If $`\text{SIG.Vfy}(vk_{NR}^{sig}, vk_J^{sig}, \sigma_{NR,J}) = 0`$ for some $J$: abort                                                         |                                 |                                                                                                                                     |
+| If $`\text{SIG.Vfy}(vk_J^{sig}, (pk_J^{APKE}, pk_J^{fetch}), \sigma_J) = 0`$ for some $J$: abort                                                |                                 |                                                                                                                                     |
+| If $`\text{SIG.Vfy}(vk_J^{sig}, (pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E}, pk_J^{fetch}), \sigma_{J,i}) = 0`$ (**TODO:** [#127]) for some $J$: abort |                                 |                                                                                                                                     |
 
 ### 6. Sender submits a message <!-- Figure 4 as of 243f384 -->
 
@@ -536,6 +536,7 @@ For some newsroom $NR$:
     `pks` is assumed to have this arity and sequence for the remainder of
     this document.
 
+[#127]: https://github.com/freedomofpress/securedrop-protocol/issues/127
 [alwen2020]: https://eprint.iacr.org/2020/1499
 [alwen2023]: https://eprint.iacr.org/2023/1480
 [RFC 2119]: https://datatracker.ietf.org/doc/html/rfc2119


### PR DESCRIPTION
Updates the v0.3 specification to match the definitions and figures in manuscript `243f384`.  Since there are no major functional or conceptual changes, just dotting of i's and crossing of t's, let's consider this an in-place refinement of version 0.3, not a new version 0.4.  Specifically, these changes address from #121....

From @felixlinker in <https://github.com/freedomofpress/securedrop-protocol/issues/121#issue-3539991576>:

> - The results of signature verification are left implicit. It will be clear to most readers that one should abort if signature verification fails, but this should be made explicit.
> - In [Section 2](https://github.com/freedomofpress/securedrop-protocol/blob/main/docs/protocol.md#2-newsroom), FPF signs the newsroom's key, but that signature is nowhere verified or referenced.
> - In [Section 6](https://github.com/freedomofpress/securedrop-protocol/blob/main/docs/protocol.md#6-sender-submits-a-message-), the sender includes their $pk^{PKE}_S$ in the plaintext, but journalists have no such key.
> - Signature verification is inconsistent with signature generation. The client verifies a signature by the journalist on three items: APKE key, PKE key, fetching key, but journalists never generate such a signature. Suggested fix: Include fetching key in the signature in [Section 3.2](https://github.com/freedomofpress/securedrop-protocol/blob/main/docs/protocol.md#32-setup-and-periodic-replenishment-of-n-ephemeral-keybundles).
> - Removing journalist keys and adding source keys as the last step doesn't type-check. First (this is a nit), we remove three-tuples from $pks$, but $pks$ contains four-tuples. Second, journalists have *sets* of ephemeral key bundles - not a single one. One could have the journalist remove all key bundles which include their key as the verification key.
> - The inclusion of $pk^{sig}_{NR}$ in "reply case" seems redundant. I think it should be removed there? I also don't underestand the case between "all senders" and "anyone" as this section will only be "executed" by senders anyways.


From @ssveitch in <https://github.com/freedomofpress/securedrop-protocol/issues/121#issuecomment-3462008886>:

> - I also would suggest writing up the key fetching a verification process as a separate subprotocol and clarify that this should happen whenever a source or journalist visits the instance (and then it can be made clear what happens when signature verification of these keys fails).
> - The one thing that is still unspecified is what happens if a (source) recipient tries to verify that a message they decrypted comes from a valid journalist and this verification step fails. (I would guess they just ignore the message?)
> - As discussed in a prior meeting, I would generate the source keys from the passphrase differently. Details can be copied from the paper.

Also:

- Closes #114