### PR TITLE
docs: abstract sequence diagram as "visual table of contents"

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -36,7 +36,8 @@ deactivate FPF
 
 activate Server
 activate Journalist
-Note over Server, Newsroom: 3.1. Journalist initial key setup and enrollment
+Note over Journalist, Newsroom: 3.1. (offline) Journalist initial key setup
+Note over Server, Journalist: 3.1. Journalist enrollment
 deactivate Newsroom
 
 Note over Journalist, Server: 3.2. Setup and periodic replenishment<br>of n ephemeral key bundles


### PR DESCRIPTION
Closes #118.  This will make the sequence diagram both (a) a better visual aid for people getting acquainted with the protocol and (b) more resilient to changes in the specification, which are reflected anyway in the "sequence tables" here and full sequence diagrams in the manuscript.