### PR TITLE
Benchmarking improvements

### DIFF
--- a/securedrop-protocol/src/bench/encrypt_decrypt.rs
+++ b/securedrop-protocol/src/bench/encrypt_decrypt.rs
@@ -52,15 +52,15 @@ const LEN_KMID: usize =
 
 #[derive(Debug, Clone)]
 pub struct CombinedCiphertext {
-    // authenc message ciphertext
-    ct_message: Vec<u8>,
-
     // dh-akem ss encaps (needed to decrypt message)
     message_dhakem_ss_encap: [u8; LEN_DHKEM_SHAREDSECRET_ENCAPS],
 
     // pq psk encap (needed to decaps psk)
-    // also passed as `info` param during hpke.authopen
+    // also passed as part of `info` param during hpke.authopen
     message_pqpsk_ss_encap: [u8; LEN_MLKEM_SHAREDSECRET_ENCAPS],
+
+    // authenc message ciphertext
+    ct_message: Vec<u8>,
 }
 
 impl CombinedCiphertext {
@@ -100,9 +100,9 @@ impl CombinedCiphertext {
             ct_bytes[LEN_DHKEM_SHAREDSECRET_ENCAPS + LEN_MLKEM_SHAREDSECRET_ENCAPS..].to_vec();
 
         Ok(CombinedCiphertext {
-            ct_message: (cmessage),
             message_dhakem_ss_encap: dhakem_ss_encaps,
             message_pqpsk_ss_encap: pqpsk_ss_encaps,
+            ct_message: (cmessage),
         })
     }
 }
@@ -365,9 +365,9 @@ pub fn encrypt<R: RngCore + CryptoRng>(
         ));
 
     let cmessage = CombinedCiphertext {
-        ct_message: message_ciphertext,
         message_dhakem_ss_encap: dhakem_ss_encaps_bytes,
         message_pqpsk_ss_encap: psk_ct,
+        ct_message: message_ciphertext,
     };
 
     Envelope {

--- a/securedrop-protocol/src/lib.rs
+++ b/securedrop-protocol/src/lib.rs
@@ -155,9 +155,8 @@ pub fn encrypt_once(
 /// Returns plaintext bytes.
 #[wasm_bindgen]
 pub fn decrypt_once(recipient: &WJournalist, envelope: &WEnvelope) -> Vec<u8> {
-    // add `impl Plaintext { pub fn into_bytes(self)->Vec<u8> { self.msg } }` in bench module if missing
     let pt: Plaintext = bench_decrypt(&recipient.inner, &envelope.inner);
-    pt.into_bytes()
+    pt.to_bytes()
 }
 
 /// Build challenges for fetch


### PR DESCRIPTION
Misc changes in line with 0.3 spec:
- rudimentary `Plaintext` struct that includes sender keys (refs #98) instead of just plaintext bytes
- commit to receiver fetching key in hpke info param (refs #124, #122)
- Include (mock) Newsroom ID in hpke.authenc (https://github.com/freedomofpress/securedrop-protocol/blob/main/docs/protocol.md?plain=1#L394). Note: this is not the intended style of this ID (see discussion in #113) and is a placeholder string to indicate that there is an input here. If people feel this is too far off I can create a more realistic NR_ID (eg KGen() and hash the pubkey as suggested in that ticket); I have gone in this direction because we're benching only encrypt/decrypt/fetch, but in a more fully-featured demo this will be changed. Feedback welcome on if this is ok for our purposes now.
- (nit) reorder CombinedCiphertext params 

Still not done:
- switch to aesgcm256
- ristretto255 (defer from benchmarks) 

Test plan:
- [ ] Visual review
- [ ] Feedback on above question re NR_ID
- [ ] CI passes
- [ ] `make bench`  succeeds