### PR TITLE
Update setup instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ To better understand the context of this research and the previous steps that le
 
 ## Setup instructions
 
-Install the Rust toolchain and `cargo-binstall`. To view browsable documentation, install `doxygen` and `dot` (Graphviz).
+Install the Rust toolchain. To view browsable documentation, install `doxygen` and `dot` (Graphviz). Use `make help` from the project root to see available make targets, e.g. to install lint tools, run formatting checks, or build crates.
 
-Developers can use `make help` to see available targets, including convenience targets for installing developer dependencies (lint tools). Lint tools are installed in the `lint-tools` directory to avoid interfering with system dependencies; use the make targets for linting, or specify that directory (e.g. `./lint-tools/bin/dprint fmt` )
+Lint tools are installed in the `lint-tools` directory to avoid interfering with the user's system dependencies; cargo will suggest adding the directory to your $PATH, but that's not required.
 
 ### Rust benchmarking
 


### PR DESCRIPTION
- Fixup to #138: we aren't actually using cargo-binstall, I had tried and reverted it but forgot to update the README.
- Clarify use of `lint-tools` for rust lint dependencies  