### PR TITLE
docs: link to `freedomofpress/securedrop-protocol-models`; clarify status of prior formal analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # SecureDrop Protocol
 
-|                                   | Version           |
-| --------------------------------- | ----------------- |
-| [Proof-of-Concept] Implementation | 0.1               |
-| [Specification]                   | 0.3 ([changelog]) |
+|                                         | Version           |
+| --------------------------------------- | ----------------- |
+| [Proof-of-concept implementation][v0.1] | 0.1               |
+| [Specification]                         | 0.3 ([changelog]) |
+| [Tamarin models]                        | 0.3               |
 
-[Proof-of-Concept]: ./demo-v0.1/README.md
+[v0.1]: ./demo-v0.1/README.md
 [changelog]: ./docs/protocol.md#changelog
 [specification]: ./docs/protocol.md
+[Tamarin models]: https://github.com/freedomofpress/securedrop-protocol-models
 
 ## Status
 
@@ -15,12 +17,11 @@
 > This repository contains proof-of-concept code and is not intended for production use. The protocol details are not yet finalized.
 
 **January 2025:** A formal analysis was performed by
-[Luca Maier](https://github.com/lumaier) in
-<https://github.com/lumaier/securedrop-formalanalysis> and published as ["A
-Formal Analysis of the SecureDrop
-Protocol"](https://doi.org/10.3929/ethz-b-000718325), supervised by David Basin,
-Felix Linker, and Shannon Veitch in the Information Security Group at ETH
-Zürich.
+[Luca Maier](https://github.com/lumaier) in in ["A Formal Analysis of the
+SecureDrop Protocol"](https://doi.org/10.3929/ethz-b-000718325), supervised by
+David Basin, Felix Linker, and Shannon Veitch in the Information Security Group
+at ETH Zürich. (This work is superseded by the [specification] and [Tamarin
+models] linked above.)
 
 **May 2024:** Proof-of-concept code was [announced publicly](https://securedrop.org/news/introducing-securedrop-protocol/).
 
@@ -28,7 +29,8 @@ Zürich.
 [Michele Orrù](https://github.com/mmaker). See
 <https://github.com/freedomofpress/securedrop-protocol/issues/36>.
 
-**Jan 2023:** Proof-of-concept implementation work with [Shielder](https://www.shielder.com/) began.
+**January 2023:** Proof-of-concept implementation work with
+[Shielder](https://www.shielder.com/) began.
 
 ## Background
 


### PR DESCRIPTION
Towards #136, in parallel with freedomofpress/securedrop-protocol-models#2.