### PR TITLE
protocol steps 1-2

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -98,7 +98,7 @@ Throughout this document, keys are notated as $component_{owner}^{scheme}$, wher
 | `SIG`                | Signature scheme                                          |                                                                                                                                                                                                                           |
 |                      | $`(sk, vk) \gets^{\$} \text{KGen}()`$                     | Generate keys                                                                                                                                                                                                             |
 |                      | $`\sigma \gets^{\$} \text{Sign}(sk, m)`$                  | Sign a message $m$ using a signing key $sk$                                                                                                                                                                               |
-|                      | $`b \in \{0, 1\} \gets \text{Vfy}(vk, m, \sigma)`$        | Verify signature $\sigma$ over a message $m$ using a verifying key $vk$                                                                                                                                                   |
+|                      | $`b \in \{0, 1\} \gets \text{Vfy}(vk, m, \sigma)`$        | Verify signature $\sigma$ over a message $m$ using a verification key $vk$                                                                                                                                                |
 | `AEAD`               | Nonce-based authenticated encryption with associated data |                                                                                                                                                                                                                           |
 |                      | $`c \gets \text{Enc}(k, nonce, ad, m)`$                   | Encrypt a message $m$ using a key $k$, a nonce $nonce$, and associated data $ad$                                                                                                                                          |
 |                      | $`m \gets \text{Dec}(k, nonce, ad, c)`$                   | Decrypt a ciphertext $c$; rest as above                                                                                                                                                                                   |
@@ -280,8 +280,8 @@ Then:
 |                                                                 |                                   | $`\sigma_{FPF} \gets^{\$} \text{SIG.Sign}(sk_{FPF}^{sig}, vk_{NR}^{sig})`$ |
 |                                                                 | $`\sigma_{FPF} \longleftarrow`$   |                                                                            |
 
-The server MUST be deployed with the newsroom's verifying key $vk_{NR}^{sig}$
-pinned. The server MAY be deployed with FPF's verifying key $vk_{FPF}^{sig}$
+The server MUST be deployed with the newsroom's verification key $vk_{NR}^{sig}$
+pinned. The server MAY be deployed with FPF's verification key $vk_{FPF}^{sig}$
 pinned.[^2]
 
 ### 3. Journalist
@@ -315,14 +315,14 @@ Following [enrollment](#31-journalist-initial-key-setup-), each journalist $J$
 MUST generate and maintain a pool of $n$ ephemeral key bundles. For each key
 bundle $i$:[^11]
 
-| Journalist                                                                                    |                                                                         | Server                                                                                     |
-| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| $`(sk_{J,i}^{APKE_E}, pk_{J,i}^{APKE_E}) \gets^{\$} \text{SD-APKE.KGen}()`$                   |                                                                         |                                                                                            |
-| $`(sk_{J,i}^{PKE_E}, pk_{J,i}^{PKE_E}) \gets^{\$} \text{SD-PKE.KGen}()`$                      |                                                                         |                                                                                            |
-| $`\sigma_{J,i} \gets^{\$} \text{SIG.Sign}(sk_J^{sig}, (pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E})`$ |                                                                         |                                                                                            |
-|                                                                                               | $`\longrightarrow (\sigma_{J,i}, pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E})`$ |                                                                                            |
+| Journalist                                                                                    |                                                                         | Server                                                                                      |
+| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| $`(sk_{J,i}^{APKE_E}, pk_{J,i}^{APKE_E}) \gets^{\$} \text{SD-APKE.KGen}()`$                   |                                                                         |                                                                                             |
+| $`(sk_{J,i}^{PKE_E}, pk_{J,i}^{PKE_E}) \gets^{\$} \text{SD-PKE.KGen}()`$                      |                                                                         |                                                                                             |
+| $`\sigma_{J,i} \gets^{\$} \text{SIG.Sign}(sk_J^{sig}, (pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E})`$ |                                                                         |                                                                                             |
+|                                                                                               | $`\longrightarrow (\sigma_{J,i}, pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E})`$ |                                                                                             |
 |                                                                                               |                                                                         | $`b \gets \text{SIG.Vfy}(vk_J^{sig}, (pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E}), \sigma_{J,i})`$ |
-|                                                                                               |                                                                         | If $b = 1$: Store $`(\sigma_{J,i}, pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E})`$ for $J$          |
+|                                                                                               |                                                                         | If $b = 1$: Store $`(\sigma_{J,i}, pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E})`$ for $J$           |
 
 ### 4. Source key setup
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -243,12 +243,18 @@ def AuthDec(
 
 ### 1. FPF signing setup
 
+FPF (Freedom of the Press Foundation) serves as the root of trust for the
+SecureDrop ecosystem. FPF generates a long-term signing keypair whose
+verification key is pinned into client and server software. This key is used to
+sign newsroom verification keys, establishing a chain of trust: FPF signs
+newsrooms, and newsrooms sign journalists.
+
 | FPF                                                               |
 | ----------------------------------------------------------------- |
 | $`(sk_{FPF}^{sig}, vk_{FPF}^{sig}) \gets^{\$} \text{SIG.KGen}()`$ |
 
 The server, the journalist client, and the source client SHOULD be built with
-FPF's signing key $vk_{FPF}^{sig}$ pinned.[^2]
+FPF's verification key $vk_{FPF}^{sig}$ pinned.[^2]
 
 ### 2. Newsroom signing setup
 
@@ -364,7 +370,7 @@ Then:
 
 ### 6. Sender submits a message <!-- Figure 3(c) as of b1e4d41 -->
 
-A sender knows their own keys, the newsroom's signing key $vk_{NR}^{sig}$, and
+A sender knows their own keys, the newsroom's verification key $vk_{NR}^{sig}$, and
 the $pks$ and $sigs$ they previously [fetched].
 
 In addition, in the **reply case,** if the sender is a journalist replying to a

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -309,7 +309,7 @@ bundle $i$:[^11]
 | $`(sk_{J,i}^{PKE_E}, pk_{J,i}^{PKE_E}) \gets^{\$} \text{SD-PKE.KGen}()`$                      |                                                                         |                                                                                            |
 | $`\sigma_{J,i} \gets^{\$} \text{SIG.Sign}(sk_J^{sig}, (pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E})`$ |                                                                         |                                                                                            |
 |                                                                                               | $`\longrightarrow (\sigma_{J,i}, pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E})`$ |                                                                                            |
-|                                                                                               |                                                                         | $`b \gets \text{SIG.Vfy}(vk_J^{sig}, (pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E}, \sigma_{J,i})`$ |
+|                                                                                               |                                                                         | $`b \gets \text{SIG.Vfy}(vk_J^{sig}, (pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E}), \sigma_{J,i})`$ |
 |                                                                                               |                                                                         | If $b = 1$: Store $`(\sigma_{J,i}, pk_{J,i}^{APKE_E}, pk_{J,i}^{PKE_E})`$ for $J$          |
 
 ### 4. Source key setup

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -258,6 +258,12 @@ FPF's verification key $vk_{FPF}^{sig}$ pinned.[^2]
 
 ### 2. Newsroom signing setup
 
+Each newsroom that operates a SecureDrop instance generates its own signing
+keypair. The newsroom sends its verification key to FPF, which manually verifies
+it (out of band) and signs it. The resulting signature $\sigma_{FPF}$ allows
+anyone holding FPF's pinned verification key to verify that this newsroom is
+legitimate.
+
 Given:
 
 |       | FPF              |

--- a/securedrop-protocol/bench/src/submit.rs
+++ b/securedrop-protocol/bench/src/submit.rs
@@ -1,6 +1,6 @@
+use alloc::{format, vec, vec::Vec};
 use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
-use alloc::{format, vec, vec::Vec};
 
 use securedrop_protocol_minimal::{
     journalist::JournalistClient, keys::FPFKeyPair, messages::core::SourceJournalistKeyResponse,
@@ -20,7 +20,8 @@ fn setup_test_environment() -> (SourceClient, Vec<SourceJournalistKeyResponse>) 
     let newsroom_verifying_key = newsroom_setup_request.newsroom_verifying_key;
 
     // Simulate FPF signing
-    let fpf_keypair = FPFKeyPair::new(ChaCha20Rng::seed_from_u64(666));
+    let fpf_keypair =
+        FPFKeyPair::new(ChaCha20Rng::seed_from_u64(666)).expect("FPF key generation failed");
     let newsroom_setup_response = newsroom_setup_request
         .sign(&fpf_keypair)
         .expect("Can sign newsroom setup request");
@@ -55,7 +56,7 @@ fn setup_test_environment() -> (SourceClient, Vec<SourceJournalistKeyResponse>) 
 
     // Source handles and verifies the newsroom key response
     source
-        .handle_newsroom_key_response(&newsroom_key_response, &fpf_keypair.vk)
+        .handle_newsroom_key_response(&newsroom_key_response, &fpf_keypair.verifying_key())
         .expect("Newsroom key response should be valid");
 
     // 7. Source fetches journalist keys

--- a/securedrop-protocol/protocol-minimal/src/keys.rs
+++ b/securedrop-protocol/protocol-minimal/src/keys.rs
@@ -137,19 +137,40 @@ pub struct SessionStorage {
     pub fpf_signature: Option<Signature>,
 }
 
-/// A key pair for FPF.
-///
-/// TODO: Make the signing key private.
+/// A key pair for FPF (Freedom of the Press Foundation).
 pub struct FPFKeyPair {
-    pub sk: SigningKey,
-    pub vk: VerifyingKey,
+    sk: SigningKey,
+    vk: VerifyingKey,
+}
+
+impl core::fmt::Debug for FPFKeyPair {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FPFKeyPair")
+            .field("vk", &self.vk)
+            .finish_non_exhaustive()
+    }
 }
 
 impl FPFKeyPair {
-    pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> FPFKeyPair {
-        let sk = SigningKey::new(&mut rng).unwrap();
+    /// Generate a new FPF key pair
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the key generation fails.
+    pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> Result<Self, anyhow::Error> {
+        let sk = SigningKey::new(&mut rng)?;
         let vk = sk.vk;
-        FPFKeyPair { sk, vk }
+        Ok(Self { sk, vk })
+    }
+
+    /// Get the verification key
+    pub fn verifying_key(&self) -> VerifyingKey {
+        self.vk
+    }
+
+    /// Sign a message using the FPF signing key
+    pub fn sign(&self, msg: &[u8]) -> crate::Signature {
+        self.sk.sign(msg)
     }
 }
 

--- a/securedrop-protocol/protocol-minimal/src/keys/newsroom.rs
+++ b/securedrop-protocol/protocol-minimal/src/keys/newsroom.rs
@@ -3,17 +3,34 @@ use rand_core::{CryptoRng, RngCore};
 use crate::sign::{SigningKey, VerifyingKey};
 
 /// Newsroom keypair used for signing.
-///
-/// TODO: Make the signing key private.
 pub struct NewsroomKeyPair {
-    pub vk: VerifyingKey,
-    pub sk: SigningKey,
+    vk: VerifyingKey,
+    sk: SigningKey,
+}
+
+impl core::fmt::Debug for NewsroomKeyPair {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Redacts secret key
+        f.debug_struct("NewsroomKeyPair")
+            .field("vk", &self.vk)
+            .finish_non_exhaustive()
+    }
 }
 
 impl NewsroomKeyPair {
-    pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> NewsroomKeyPair {
-        let sk = SigningKey::new(&mut rng).unwrap();
+    pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> Result<Self, anyhow::Error> {
+        let sk = SigningKey::new(&mut rng)?;
         let vk = sk.vk;
-        NewsroomKeyPair { sk, vk }
+        Ok(Self { sk, vk })
+    }
+
+    /// Get the verification key
+    pub fn verifying_key(&self) -> VerifyingKey {
+        self.vk
+    }
+
+    /// Sign a message using the newsroom signing key
+    pub fn sign(&self, msg: &[u8]) -> crate::Signature {
+        self.sk.sign(msg)
     }
 }

--- a/securedrop-protocol/protocol-minimal/src/messages/setup.rs
+++ b/securedrop-protocol/protocol-minimal/src/messages/setup.rs
@@ -14,6 +14,7 @@ use crate::{Signature, VerifyingKey};
 /// Request from the newsroom to FPF for verification.
 ///
 /// Step 2 in the spec.
+#[derive(Debug)]
 pub struct NewsroomSetupRequest {
     pub newsroom_verifying_key: VerifyingKey,
 }
@@ -21,6 +22,7 @@ pub struct NewsroomSetupRequest {
 /// Response from FPF to the newsroom.
 ///
 /// Step 2 in the spec.
+#[derive(Debug)]
 pub struct NewsroomSetupResponse {
     /// A signature over the newsroom verifying key by the FPF signing key
     pub sig: Signature,

--- a/securedrop-protocol/protocol-minimal/src/server.rs
+++ b/securedrop-protocol/protocol-minimal/src/server.rs
@@ -50,8 +50,8 @@ impl Server {
         &mut self,
         mut rng: R,
     ) -> Result<NewsroomSetupRequest, Error> {
-        let newsroom_keys = NewsroomKeyPair::new(&mut rng);
-        let newsroom_vk = newsroom_keys.vk;
+        let newsroom_keys = NewsroomKeyPair::new(&mut rng)?;
+        let newsroom_vk = newsroom_keys.verifying_key();
 
         // Store the newsroom keys in the session for later use (e.g., signing journalist keys)
         self.newsroom_keys = Some(newsroom_keys);
@@ -94,7 +94,7 @@ impl Server {
             .newsroom_keys
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Newsroom keys not found in session"))?;
-        let newsroom_signature = newsroom_keys.sk.sign(verifying_key_bytes);
+        let newsroom_signature = newsroom_keys.sign(verifying_key_bytes);
 
         // Insert journalist keys into storage
         let _journalist_id = self
@@ -136,8 +136,8 @@ impl Server {
     }
 
     /// Get the newsroom verifying key
-    pub fn get_newsroom_verifying_key(&self) -> Option<&VerifyingKey> {
-        self.newsroom_keys.as_ref().map(|keys| &keys.vk)
+    pub fn get_newsroom_verifying_key(&self) -> Option<VerifyingKey> {
+        self.newsroom_keys.as_ref().map(|keys| keys.verifying_key())
     }
 
     /// Set the FPF signature for the newsroom
@@ -175,7 +175,7 @@ impl Server {
                 .newsroom_keys
                 .as_ref()
                 .expect("Newsroom keys not found")
-                .vk,
+                .verifying_key(),
             fpf_sig: self
                 .signature
                 .as_ref()

--- a/securedrop-protocol/protocol-minimal/src/setup.rs
+++ b/securedrop-protocol/protocol-minimal/src/setup.rs
@@ -15,14 +15,16 @@ impl NewsroomSetupRequest {
     /// which produces a signature over the newsroom verifying key using the
     /// FPF signing key.
     ///
-    /// TODO: There is a manual verification step here, so the caller should
+    /// # Security
+    ///
+    /// There is a manual verification step here: the caller should
     /// instruct the user to stop, verify the fingerprint out of band, and
     /// then proceed. The caller should also persist the fingerprint and signature
     /// in its local data store.
     ///
     pub fn sign(self, fpf_keys: &FPFKeyPair) -> Result<NewsroomSetupResponse, Error> {
         let newsroom_pk_bytes = self.newsroom_verifying_key.into_bytes();
-        let sig = fpf_keys.sk.sign(&newsroom_pk_bytes);
+        let sig = fpf_keys.sign(&newsroom_pk_bytes);
         Ok(NewsroomSetupResponse { sig })
     }
 }

--- a/securedrop-protocol/protocol-minimal/src/sign.rs
+++ b/securedrop-protocol/protocol-minimal/src/sign.rs
@@ -8,9 +8,26 @@ pub struct SigningKey {
     sk: LibCruxSigningKey,
 }
 
+impl core::fmt::Debug for SigningKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Redacts secret key
+        f.debug_struct("SigningKey")
+            .field("vk", &self.vk)
+            .finish_non_exhaustive()
+    }
+}
+
 /// An Ed25519 verification key.
 #[derive(Copy, Clone)]
 pub struct VerifyingKey(LibCruxVerifyingKey);
+
+impl core::fmt::Debug for VerifyingKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("VerifyingKey")
+            .field(&self.into_bytes())
+            .finish()
+    }
+}
 
 // TODO (avoid confusion between journalist self-signature and newsroom signature)
 #[derive(Debug, Clone, Copy)]

--- a/securedrop-protocol/protocol-minimal/tests/core.rs
+++ b/securedrop-protocol/protocol-minimal/tests/core.rs
@@ -39,7 +39,7 @@ fn protocol_step_5_source_fetch_keys() {
     let newsroom_verifying_key = newsroom_setup_request.newsroom_verifying_key;
 
     // Simulate FPF signing (in real implementation, this would be done by FPF)
-    let fpf_keypair = FPFKeyPair::new(&mut rng);
+    let fpf_keypair = FPFKeyPair::new(&mut rng).expect("FPF key generation failed");
     let newsroom_setup_response = newsroom_setup_request
         .sign(&fpf_keypair)
         .expect("Can sign newsroom setup request");
@@ -82,7 +82,7 @@ fn protocol_step_5_source_fetch_keys() {
 
     // Source handles and verifies the newsroom key response
     source_session
-        .handle_newsroom_key_response(&newsroom_key_response, &fpf_keypair.vk)
+        .handle_newsroom_key_response(&newsroom_key_response, &fpf_keypair.verifying_key())
         .expect("Newsroom key response should be valid");
 
     // Source fetches journalist keys
@@ -150,18 +150,25 @@ fn protocol_step_5_source_fetch_keys() {
     assert_eq!(empty_responses.len(), 0);
 
     // Test that invalid FPF signatures are rejected
-    let wrong_fpf_keypair = FPFKeyPair::new(&mut rng);
+    let wrong_fpf_keypair = FPFKeyPair::new(&mut rng).expect("FPF key generation failed");
     assert!(
         source_session
-            .handle_newsroom_key_response(&newsroom_key_response, &wrong_fpf_keypair.vk)
+            .handle_newsroom_key_response(
+                &newsroom_key_response,
+                &wrong_fpf_keypair.verifying_key()
+            )
             .is_err()
     );
 
     // Test that invalid newsroom signatures on journalist keys are rejected
-    let wrong_newsroom_keypair = NewsroomKeyPair::new(&mut rng);
+    let wrong_newsroom_keypair =
+        NewsroomKeyPair::new(&mut rng).expect("Newsroom key generation failed");
     assert!(
         source_session
-            .handle_journalist_key_response(journalist_response, &wrong_newsroom_keypair.vk)
+            .handle_journalist_key_response(
+                journalist_response,
+                &wrong_newsroom_keypair.verifying_key()
+            )
             .is_err()
     );
 }
@@ -181,7 +188,7 @@ fn protocol_step_6_source_submits_message() {
 
     let newsroom_verifying_key = newsroom_setup_request.newsroom_verifying_key;
 
-    let fpf_keypair = FPFKeyPair::new(&mut rng);
+    let fpf_keypair = FPFKeyPair::new(&mut rng).expect("FPF key generation failed");
     let newsroom_setup_response = newsroom_setup_request
         .sign(&fpf_keypair)
         .expect("Can sign newsroom setup request");
@@ -225,7 +232,7 @@ fn protocol_step_6_source_submits_message() {
         server_session.handle_source_newsroom_key_request(newsroom_key_request);
 
     source
-        .handle_newsroom_key_response(&newsroom_key_response, &fpf_keypair.vk)
+        .handle_newsroom_key_response(&newsroom_key_response, &fpf_keypair.verifying_key())
         .expect("Newsroom key response should be valid");
 
     let journalist_key_request = source.fetch_journalist_keys();
@@ -270,7 +277,7 @@ fn protocol_step_7_message_id_fetch() {
 
     let newsroom_verifying_key = newsroom_setup_request.newsroom_verifying_key;
 
-    let fpf_keypair = FPFKeyPair::new(&mut rng);
+    let fpf_keypair = FPFKeyPair::new(&mut rng).expect("FPF key generation failed");
     let newsroom_setup_response = newsroom_setup_request
         .sign(&fpf_keypair)
         .expect("Can sign newsroom setup request");
@@ -313,7 +320,7 @@ fn protocol_step_7_message_id_fetch() {
         server_session.handle_source_newsroom_key_request(newsroom_key_request);
 
     source
-        .handle_newsroom_key_response(&newsroom_key_response, &fpf_keypair.vk)
+        .handle_newsroom_key_response(&newsroom_key_response, &fpf_keypair.verifying_key())
         .expect("Newsroom key response should be valid");
 
     let journalist_key_request = source.fetch_journalist_keys();

--- a/securedrop-protocol/protocol-minimal/tests/setup.rs
+++ b/securedrop-protocol/protocol-minimal/tests/setup.rs
@@ -23,8 +23,7 @@ fn get_rng() -> ChaCha20Rng {
 }
 
 fn setup_fpf_key<R: CryptoRng + RngCore>(mut rng: R) -> FPFKeyPair {
-    // Setup: FPF generates their keys (from previous step)
-    FPFKeyPair::new(&mut rng)
+    FPFKeyPair::new(&mut rng).expect("FPF key generation failed")
 }
 
 // Helper - set up server, set up newsroom key, and return server session
@@ -48,7 +47,7 @@ fn setup_server<R: CryptoRng + RngCore>(
 
     assert!(
         fpf_keys
-            .vk
+            .verifying_key()
             .verify(&newsroom_vk.clone().into_bytes(), &setup_response.sig)
             .is_ok()
     );
@@ -86,12 +85,11 @@ fn setup_journalist<R: RngCore + CryptoRng>(
 #[test]
 fn protocol_step_1_generate_fpf_keys() {
     let mut rng = get_rng();
-    let fpf_keys = FPFKeyPair::new(&mut rng);
+    let fpf_keys = FPFKeyPair::new(&mut rng).expect("FPF key generation failed");
 
-    // Test signing/verification roundtrip
     let message = b"test message";
-    let signature = fpf_keys.sk.sign(message);
-    assert!(fpf_keys.vk.verify(message, &signature).is_ok());
+    let signature = fpf_keys.sign(message);
+    assert!(fpf_keys.verifying_key().verify(message, &signature).is_ok());
 }
 
 /// Step 2: Newsroom setup
@@ -100,13 +98,17 @@ fn protocol_step_2_generate_newsroom_keys() {
     let mut rng = get_rng();
 
     // Setup: FPF generates their keys (from previous step)
-    let fpf_keys = FPFKeyPair::new(&mut rng);
+    let fpf_keys = FPFKeyPair::new(&mut rng).expect("FPF key generation failed");
 
     let (_, newsroom_vk, fpf_sig) = setup_server(rng, &fpf_keys);
 
-    // Newsroom: Verify the FPF signature on the newsroom's public key
     let newsroom_pk_bytes = newsroom_vk.into_bytes();
-    assert!(fpf_keys.vk.verify(&newsroom_pk_bytes, &fpf_sig).is_ok());
+    assert!(
+        fpf_keys
+            .verifying_key()
+            .verify(&newsroom_pk_bytes, &fpf_sig)
+            .is_ok()
+    );
 }
 
 /// Step 3.1: Journalist enrollment
@@ -115,13 +117,13 @@ fn protocol_step_3_1_journalist_enrollment() {
     let mut rng = get_rng();
 
     // Setup: FPF generates their keys (from step 1)
-    let fpf_keys = FPFKeyPair::new(&mut rng);
+    let fpf_keys = FPFKeyPair::new(&mut rng).expect("FPF key generation failed");
 
     let (mut server_session, newsroom_vk, fpf_sig) = setup_server(&mut rng, &fpf_keys);
 
     assert!(
         fpf_keys
-            .vk
+            .verifying_key()
             .verify(&newsroom_vk.into_bytes(), &fpf_sig)
             .is_ok()
     );
@@ -133,7 +135,8 @@ fn protocol_step_3_1_journalist_enrollment() {
 
     // Journalist: Create journalist session and generate setup request
     // todo keybundles
-    let (_, journalist_setup_request) = setup_journalist(rng, 10, &vk, &fpf_keys.vk, &fpf_sig);
+    let (_, journalist_setup_request) =
+        setup_journalist(rng, 10, &vk, &fpf_keys.verifying_key(), &fpf_sig);
 
     // Extract enrollment bundle for verification before moving the request
     let enrollment_bundle = journalist_setup_request.enrollment.clone();
@@ -199,7 +202,7 @@ fn protocol_step_3_2_journalist_ephemeral_keys() {
     let (mut server_session, vk_nr, sig) = setup_server(&mut rng, &fpf_keys);
 
     let (journalist, journalist_setup_request) =
-        setup_journalist(&mut rng, 10, &vk_nr, &fpf_keys.vk, &sig);
+        setup_journalist(&mut rng, 10, &vk_nr, &fpf_keys.verifying_key(), &sig);
 
     // Extract enrollment bundle for verification before moving the request
     let enrollment_bundle = journalist_setup_request.enrollment.clone();
@@ -269,7 +272,9 @@ fn protocol_step_3_2_journalist_ephemeral_keys() {
 
     // Test that server rejects ephemeral keys from unknown journalist
     let unknown_journalist_request = JournalistRefreshRequest {
-        vk: FPFKeyPair::new(&mut rng).vk, // Use a different key
+        vk: FPFKeyPair::new(&mut rng)
+            .expect("key generation failed")
+            .verifying_key(),
         bundles: bundles,
         bundle_sig: ek_bundle_signature,
     };


### PR DESCRIPTION
This PR takes a pass through the first two steps in the spec and:
- Adds a prose description of what's going on in those steps for legibility to more casual observers
- Ensuring the corresponding code meets the [Rust API guidelines](https://rust-lang.github.io/api-guidelines/checklist.html#rust-api-guidelines-checklist) (tackling some TODOs and cleanups on the way, see commit message d8598324d3f67a10d821300802d1d19792806fa3 for more detail)

⚠️ this is a PR into https://github.com/freedomofpress/securedrop-protocol/pull/180, will rebase on main once that is merged