### PR TITLE
ci(`hax`): extract, type-check, and verify F* proofs

### DIFF
--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -22,6 +22,16 @@ jobs:
           fstar: v2025.12.15 # keep in sync with "securedrop-protocol/protocol-minimal/Makefile"
           hax_reference: cargo-hax-v0.3.6 # keep in sync with "securedrop-protocol/protocol-minimal/Cargo.toml"
 
-      - name: Extract F*, type-check, and verify
-        run: make hax
+      - name: Extract F*
+        run: make extract
+        working-directory: securedrop-protocol/protocol-minimal
+
+      - name: Confirm no diff from committed proofs
+        run: |
+          git status --porcelain .
+          test -z "$(git status --porcelain .)"
+        working-directory: securedrop-protocol/protocol-minimal/proofs
+
+      - name: Type-check and verify
+        run: make verify
         working-directory: securedrop-protocol/protocol-minimal

--- a/securedrop-protocol/protocol-minimal/Makefile
+++ b/securedrop-protocol/protocol-minimal/Makefile
@@ -7,6 +7,17 @@ HAX_TARGETS += +securedrop_protocol_minimal::primitives::x25519::typed
 REPO_ROOT = $(shell git rev-parse --show-toplevel)
 PROOF_DIR = proofs/fstar/extraction
 
+.PHONY: clean
+clean:
+	cargo clean
+	cargo cache -a
+	rm -rf $(REPO_ROOT)/.fstar-cache
+	rm -f $(PROOF_DIR)/.depend
+	rm -f $(PROOF_DIR)/hax.fst.config.json
+
+.PHONY: compat
+compat: compat-fstar
+
 # Keep in sync with ".github/workflows/hax.yml":
 FSTAR_EXPECTED_VERSION = F* 2025.12.15
 FSTAR_ACTUAL_VERSION   = $(shell fstar.exe --version 2>/dev/null | head -1)
@@ -15,24 +26,19 @@ compat-fstar:
 	@[ "$(FSTAR_ACTUAL_VERSION)" = "$(FSTAR_EXPECTED_VERSION)" ] || \
 	  { echo "Error: expected fstar.exe version '$(FSTAR_EXPECTED_VERSION)', got '$(FSTAR_ACTUAL_VERSION)'"; exit 1; }
 
-.PHONY: compat
-compat: compat-fstar
+.PHONY: extract
+extract:
+	cargo hax into -i '$(HAX_TARGETS)' fstar
 
 .PHONY: hax
-hax: compat
+hax: compat extract verify
 
-	rm -f $(PROOF_DIR)/*.fst
-	cargo hax into -i '$(HAX_TARGETS)' fstar  # extract
-	OTHERFLAGS="--lax" $(MAKE) -C $(PROOF_DIR)  # type-check
-	$(MAKE) -C $(PROOF_DIR)  # verify
-
-.PHONY: clean
-clean:
-	cargo clean
-	cargo cache -a
-	rm -rf $(REPO_ROOT)/.fstar-cache
-	rm -f $(PROOF_DIR)/.depend
-	rm -f $(PROOF_DIR)/hax.fst.config.json
+.PHONY: verify
+verify:
+	# Type-check (fail fast):
+	OTHERFLAGS="--lax" $(MAKE) -C $(PROOF_DIR)
+	# Verify:
+	$(MAKE) -C $(PROOF_DIR)
 
 .PHONY: hax-lib-version
 hax-lib-version:


### PR DESCRIPTION
Closes #171.  This just wraps our `make hax` in the `hacspec/hax-actions` workflow.  It has about the same runtime (currently ~3 minutes with a warm cache) as #131 but without requiring that we maintain our own Docker image built with hax.