### PR TITLE
build(hax): silence F* warning (247) about missing cache items

### DIFF
--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Makefile
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Makefile
@@ -164,7 +164,7 @@ include-dirs:
 	$(Q)bash -c '${FINDLIBS}'
 
 FSTAR_FLAGS = \
-  --warn_error -321-331-241-274-239-271 \
+  --warn_error -321-331-241-247-274-239-271 \
   --cache_checked_modules --cache_dir $(CACHE_DIR) \
   --already_cached "+Prims+FStar+LowStar+C+Spec.Loops+TestLib" \
   $(addprefix --include ,$(FSTAR_INCLUDE_DIRS))


### PR DESCRIPTION
Fixes <https://github.com/freedomofpress/securedrop-protocol/pull/194#pullrequestreview-4038542748>: On first run, or on every CI run, F* will have an empty cache even for F* and hax core modules, leading to lots of noisy warnings 247.  Let's silence them.