### PR TITLE
protocol §6 message sending

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -404,6 +404,22 @@ In addition, in the **reply case,** if the sender is a journalist replying to a
 source, they also already know their recipient's keys without further
 verification.
 
+For each recipient, the sender produces two ciphertexts. The SD-APKE ciphertext
+carries the message itself along with the sender's long-term $fetch$ and $PKE$
+public keys. The SD-PKE ciphertext carries the
+sender's long-term APKE public key, encrypted to the recipient's $PKE$
+key.
+
+The sender also computes a hint from the recipient's fetching key: a fresh
+ephemeral DH public key $X = g^x$ and a Diffie–Hellman share $Z =
+(pk_R^{fetch})^x$. This lets the recipient privately scan for their messages in
+step 7 without disclosing their identity to the server. The server stores the two
+ciphertexts and hint under a randomly generated message ID.
+
+When a journalist is sending a reply, they substitute the source's long-term keys
+for their own in the recipient list, and address the remaining slots to all other
+enrolled journalists.
+
 |                                                   | All senders         | Reply case     |
 | ------------------------------------------------- | ------------------- | -------------- |
 | Published by server                               | $vk_{NR}^{sig}$     |                |

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -405,10 +405,12 @@ source, they also already know their recipient's keys without further
 verification.
 
 For each recipient, the sender produces two ciphertexts. The SD-APKE ciphertext
-carries the message itself along with the sender's long-term $fetch$ and $PKE$
-public keys. The SD-PKE ciphertext carries the
-sender's long-term APKE public key, encrypted to the recipient's $PKE$
-key.
+is sender authenticated and carries the message along with the sender's
+long-term $fetch$ and $PKE$ public keys. Because decrypting SD-APKE requires
+the recipient to know the sender's long-term APKE public key, a second SD-PKE
+ciphertext delivers that key, encrypted to the recipient's $PKE$ key, thus keeping
+the sender's identity hidden from the server, as described in HPKE's metadata
+protection guidance ([RFC 9180 §9.9]).
 
 The sender also computes a hint from the recipient's fetching key: a fresh
 ephemeral DH public key $X = g^x$ and a Diffie–Hellman share $Z =
@@ -591,4 +593,5 @@ insertion order.
 [RFC 9180 §6.1]: https://datatracker.ietf.org/doc/html/rfc9180#section-6.1
 [RFC 9180 §7.1]: https://datatracker.ietf.org/doc/html/rfc9180#name-key-encapsulation-mechanism
 [RFC 9180 §7.2]: https://datatracker.ietf.org/doc/html/rfc9180#name-key-derivation-functions-kd
+[RFC 9180 §9.9]: https://datatracker.ietf.org/doc/html/rfc9180#name-metadata-protection
 [semantic versioning]: https://semver.org

--- a/securedrop-protocol/bench/benches/manual.rs
+++ b/securedrop-protocol/bench/benches/manual.rs
@@ -163,7 +163,7 @@ fn bench_encrypt_loop(iterations: usize, keybundles: usize, include_rng: bool) -
             let mut seed = [0u8; 32];
             prep_rng.fill_bytes(&mut seed);
             let env: Envelope =
-                bench_encrypt(seed, &sender, &recipient.public(bundle_ix), plaintext);
+                bench_encrypt(seed, &sender, &recipient.public(bundle_ix), &plaintext);
             let dt = t0.elapsed();
             durations.push(dt);
             sink ^= env.size_hint();
@@ -174,7 +174,7 @@ fn bench_encrypt_loop(iterations: usize, keybundles: usize, include_rng: bool) -
 
             let t0 = Instant::now();
             let env: Envelope =
-                bench_encrypt(seed, &sender, &recipient.public(bundle_ix), plaintext);
+                bench_encrypt(seed, &sender, &recipient.public(bundle_ix), &plaintext);
             let dt = t0.elapsed();
             durations.push(dt);
             sink ^= env.size_hint();
@@ -206,7 +206,7 @@ fn bench_decrypt_loop(iterations: usize, keybundles: usize) -> Vec<Duration> {
         } else {
             (prep_rng.next_u32() as usize) % keybundles
         };
-        let env: Envelope = bench_encrypt(seed, &sender, &recipient.public(bundle_ix), pt);
+        let env: Envelope = bench_encrypt(seed, &sender, &recipient.public(bundle_ix), &pt);
 
         // Time ONLY decrypt
         let t0 = Instant::now();
@@ -245,7 +245,7 @@ fn bench_fetch_loop(iterations: usize, keybundles: usize, challenges: usize) -> 
 
             let pt = source.build_message(format!("iter{i}-msg{j}").into());
 
-            let env = bench_encrypt(seed, &source, &journalist.public(bundle_ix), pt);
+            let env = bench_encrypt(seed, &source, &journalist.public(bundle_ix), &pt);
             let mut message_id = [0u8; 16];
             message_id.fill((j & 0xff) as u8);
             store.insert(Uuid::from_bytes(message_id), env);

--- a/securedrop-protocol/bench/src/encrypt_decrypt.rs
+++ b/securedrop-protocol/bench/src/encrypt_decrypt.rs
@@ -141,7 +141,7 @@ pub fn encrypt_once(
         seed,
         &sender.inner,
         &recipient.inner.public(recipient_bundle_index),
-        plaintext,
+        &plaintext,
     );
     env.into()
 }
@@ -212,7 +212,7 @@ pub fn bench_encrypt<S: UserSecret, P: UserPublic>(
     seed32: [u8; 32],
     sender: &S,
     recipient: &P,
-    plaintext: Plaintext,
+    plaintext: &Plaintext,
 ) -> Envelope {
     let mut rng = ChaCha20Rng::from_seed(seed32);
     encrypt(&mut rng, sender, plaintext, recipient)

--- a/securedrop-protocol/bench/src/encrypt_decrypt.rs
+++ b/securedrop-protocol/bench/src/encrypt_decrypt.rs
@@ -15,9 +15,8 @@ use securedrop_protocol_minimal::{
     Envelope, FetchResponse, Journalist, Plaintext, Source, UserPublic, UserSecret,
 };
 
-use securedrop_protocol_minimal::encrypt_decrypt::{
-    LEN_DH_ITEM, LEN_MLKEM_ENCAPS_KEY, LEN_XWING_ENCAPS_KEY,
-};
+use securedrop_protocol_minimal::LEN_XWING_ENCAPS_KEY;
+use securedrop_protocol_minimal::encrypt_decrypt::{LEN_DH_ITEM, LEN_MLKEM_ENCAPS_KEY};
 
 #[inline]
 fn rng_from_seed(seed32: [u8; 32]) -> ChaCha20Rng {

--- a/securedrop-protocol/protocol-minimal/src/api.rs
+++ b/securedrop-protocol/protocol-minimal/src/api.rs
@@ -119,7 +119,7 @@ pub trait Api {
         // TODO: review padding
         let padded_message = crate::primitives::pad::pad_message(message);
         let plaintext = sender.build_message(padded_message);
-        let envelope = encrypt(rng, sender, plaintext, recipient);
+        let envelope = encrypt(rng, sender, &plaintext, recipient);
         Ok(envelope)
     }
 

--- a/securedrop-protocol/protocol-minimal/src/ciphertext.rs
+++ b/securedrop-protocol/protocol-minimal/src/ciphertext.rs
@@ -1,4 +1,8 @@
-use crate::constants::*;
+use crate::constants::{
+    LEN_DH_ITEM, LEN_DHKEM_SHAREDSECRET_ENCAPS, LEN_KMID, LEN_MLKEM_SHAREDSECRET_ENCAPS,
+    LEN_XWING_ENCAPS_KEY,
+};
+use crate::metadata::MetadataCiphertext;
 use alloc::vec::Vec;
 use anyhow::Error;
 
@@ -65,11 +69,8 @@ pub struct Envelope {
     // see CombinedCiphertext
     pub(crate) cmessage: Vec<u8>,
 
-    // baseenc "metadata", aka sender pubkey
-    pub(crate) cmetadata: Vec<u8>,
-
-    // "metadata" encaps shared secret
-    pub(crate) metadata_encap: [u8; LEN_XWING_SHAREDSECRET_ENCAPS],
+    // SD-PKE ciphertext (c, c'): encrypted sender APKE public key tuple
+    pub(crate) ct_pke: MetadataCiphertext,
 
     // clue material
     pub(crate) mgdh_pubkey: [u8; LEN_DH_ITEM],
@@ -79,16 +80,16 @@ pub struct Envelope {
 impl Envelope {
     // Used for benchmarks - see wasm_bindgen
     pub fn size_hint(&self) -> usize {
-        self.cmessage.len() + self.cmetadata.len()
+        self.cmessage.len() + self.cmetadata_len()
     }
 
     pub fn cmessage_len(&self) -> usize {
         self.cmessage.len()
     }
 
-    // sender dh-akem pubkey bytes
+    // SD-PKE ciphertext byte length: encapsulation c + AEAD ciphertext c'
     pub fn cmetadata_len(&self) -> usize {
-        self.cmetadata.len()
+        self.ct_pke.len()
     }
 }
 

--- a/securedrop-protocol/protocol-minimal/src/ciphertext.rs
+++ b/securedrop-protocol/protocol-minimal/src/ciphertext.rs
@@ -34,7 +34,7 @@ impl CombinedCiphertext {
     }
 
     // TOY ONLY
-    pub fn from_bytes(ct_bytes: &Vec<u8>) -> Result<Self, Error> {
+    pub fn from_bytes(ct_bytes: &[u8]) -> Result<Self, Error> {
         let mut dhakem_ss_encaps: [u8; LEN_DHKEM_SHAREDSECRET_ENCAPS] =
             [0u8; LEN_DHKEM_SHAREDSECRET_ENCAPS];
 
@@ -120,7 +120,7 @@ impl Plaintext {
     }
 
     // Toy parsing only
-    pub fn from_bytes(pt_bytes: &Vec<u8>) -> Result<Self, Error> {
+    pub fn from_bytes(pt_bytes: &[u8]) -> Result<Self, Error> {
         let mut offset = 0;
 
         let mut sender_reply_pubkey_hybrid = [0u8; LEN_XWING_ENCAPS_KEY];
@@ -142,7 +142,7 @@ impl Plaintext {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FetchResponse {
     pub(crate) enc_id: [u8; LEN_KMID],   // aka kmid
     pub(crate) pmgdh: [u8; LEN_DH_ITEM], // aka per-request clue
@@ -150,9 +150,6 @@ pub struct FetchResponse {
 
 impl FetchResponse {
     pub fn new(enc_id: [u8; LEN_KMID], pmgdh: [u8; LEN_DH_ITEM]) -> Self {
-        Self {
-            enc_id: enc_id,
-            pmgdh: pmgdh,
-        }
+        Self { enc_id, pmgdh }
     }
 }

--- a/securedrop-protocol/protocol-minimal/src/ciphertext.rs
+++ b/securedrop-protocol/protocol-minimal/src/ciphertext.rs
@@ -93,19 +93,21 @@ impl Envelope {
 }
 
 #[derive(Debug, Clone)]
-/// Toy pt structure - provide params in order
+/// Toy pt structure - TODO: provide params in correct order
 pub struct Plaintext {
-    pub sender_reply_pubkey_pq_psk: [u8; LEN_MLKEM_ENCAPS_KEY],
+    /// Metadata key: $pk_S^{PKE}$ in the spec
     pub sender_reply_pubkey_hybrid: [u8; LEN_XWING_ENCAPS_KEY],
+    /// Fetching key: $pk_S^{fetch}$ in the spec
     pub sender_fetch_key: [u8; LEN_DH_ITEM],
+    /// Message
     pub msg: Vec<u8>,
 }
 
 impl Plaintext {
     pub fn to_bytes(&self) -> alloc::vec::Vec<u8> {
+        // TODO: Deviates from spec
         let mut buf = Vec::new();
 
-        buf.extend_from_slice(&self.sender_reply_pubkey_pq_psk);
         buf.extend_from_slice(&self.sender_reply_pubkey_hybrid);
         buf.extend_from_slice(&self.sender_fetch_key);
         buf.extend_from_slice(&self.msg);
@@ -114,17 +116,12 @@ impl Plaintext {
     }
 
     pub fn len(&self) -> usize {
-        return LEN_MLKEM_ENCAPS_KEY + LEN_XWING_ENCAPS_KEY + LEN_DH_ITEM + &self.msg.len();
+        LEN_XWING_ENCAPS_KEY + LEN_DH_ITEM + self.msg.len()
     }
 
     // Toy parsing only
     pub fn from_bytes(pt_bytes: &Vec<u8>) -> Result<Self, Error> {
         let mut offset = 0;
-
-        let mut sender_reply_pubkey_pq_psk = [0u8; LEN_MLKEM_ENCAPS_KEY];
-        sender_reply_pubkey_pq_psk
-            .copy_from_slice(&pt_bytes[offset..offset + LEN_MLKEM_ENCAPS_KEY]);
-        offset += LEN_MLKEM_ENCAPS_KEY;
 
         let mut sender_reply_pubkey_hybrid = [0u8; LEN_XWING_ENCAPS_KEY];
         sender_reply_pubkey_hybrid
@@ -138,7 +135,6 @@ impl Plaintext {
         let msg = pt_bytes[offset..].to_vec();
 
         Ok(Plaintext {
-            sender_reply_pubkey_pq_psk,
             sender_reply_pubkey_hybrid,
             sender_fetch_key,
             msg,

--- a/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
+++ b/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
@@ -65,16 +65,16 @@ const LEN_KMID: usize =
 /// Encrypt a message from a sender to a receiver.
 /// A sender holds access to UserPublic + UserSecret, i.e. keypair access.
 /// A receiver holds access to UserPublic, i.e. pubkey access.
-pub fn encrypt<Rng, Sndr, Rcvr>(
-    rng: &mut Rng,
-    sender: &Sndr,
-    plaintext: Plaintext,
-    recipient: &Rcvr,
+pub fn encrypt<R, Sender, Recipient>(
+    rng: &mut R,
+    sender: &Sender,
+    plaintext: &Plaintext,
+    recipient: &Recipient,
 ) -> Envelope
 where
-    Rng: RngCore + CryptoRng,
-    Sndr: UserSecret + ?Sized,
-    Rcvr: UserPublic + ?Sized,
+    R: RngCore + CryptoRng,
+    Sender: UserSecret + ?Sized,
+    Recipient: UserPublic + ?Sized,
 {
     let mut hpke_authenc: Hpke<HpkeLibcrux> =
         Hpke::new(Mode::AuthPsk, DhKem25519, HkdfSha256, Aes256Gcm);
@@ -109,7 +109,7 @@ where
 
     // spec: ct^APKE = SD-APKE.AuthEnc(sk_S^APKE, pk_R^APKE, pt, NR_ID, pk_R^fetch)
     // HPKE AuthPSK message encryption
-    let (mesage_dhakem_shared_secret_encaps, message_ciphertext) = hpke_authenc
+    let (message_dhakem_shared_secret_encaps, message_ciphertext) = hpke_authenc
         .seal(
             &recipient_message_enc_dhakem_pub,
             // psk_encaps_ct as authenticated (info).
@@ -126,7 +126,7 @@ where
 
     let mut dhakem_ss_encaps_bytes: [u8; LEN_DHKEM_SHAREDSECRET_ENCAPS] =
         [0u8; LEN_DHKEM_SHAREDSECRET_ENCAPS];
-    dhakem_ss_encaps_bytes.copy_from_slice(mesage_dhakem_shared_secret_encaps.as_slice());
+    dhakem_ss_encaps_bytes.copy_from_slice(message_dhakem_shared_secret_encaps.as_slice());
 
     // Hint (X, Z): X = g^x, Z = (pk_R^fetch)^x for a fresh ephemeral scalar x
     // Create mgdh (message clue) with a DH agreement between an ephemeral curve25519 keypair
@@ -430,10 +430,10 @@ mod tests {
     ) {
         let pt = build_message(sender_public, msg);
 
-        let envelope = encrypt(&mut rng, sender_secret, pt.clone(), rcvr_public);
+        let envelope = encrypt(&mut rng, sender_secret, &pt, rcvr_public);
         let decrypted = decrypt(rcvr_secret, &envelope);
 
-        let pt_ref = &pt.clone();
+        let pt_ref = &pt;
 
         assert_eq!(pt_ref.msg, decrypted.msg);
         assert_eq!(pt_ref.len(), decrypted.to_bytes().len());
@@ -500,7 +500,7 @@ mod tests {
 
         let msg = b"Fetch this message";
         let plaintext = build_message(&source.public(), msg.to_vec());
-        let envelope = encrypt(&mut rng, &source, plaintext, &journalist_public);
+        let envelope = encrypt(&mut rng, &source, &plaintext, &journalist_public);
 
         // On server. TODO: in helper function
         let mut store = ServerMessageStore::new();
@@ -530,7 +530,7 @@ mod tests {
 
         let msg = b"Fetch this message";
         let plaintext = build_message(&source.public(), msg.to_vec());
-        let envelope = encrypt(&mut rng, &source, plaintext, &journalist_public);
+        let envelope = encrypt(&mut rng, &source, &plaintext, &journalist_public);
 
         // On server. TODO: in helper function
         let mut store = ServerMessageStore::new();

--- a/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
+++ b/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
@@ -1,3 +1,4 @@
+use crate::constants::LEN_XWING_ENCAPS_KEY;
 use crate::primitives::dh_akem::DH_AKEM_PUBLIC_KEY_LEN;
 use crate::primitives::dh_akem::DhAkemPublicKey;
 use crate::primitives::x25519::DHPublicKey;
@@ -17,7 +18,7 @@ use hpke_rs::HpkePrivateKey;
 use hpke_rs::HpkePublicKey;
 use hpke_rs::hpke_types::AeadAlgorithm::Aes256Gcm;
 use hpke_rs::hpke_types::KdfAlgorithm::HkdfSha256;
-use hpke_rs::hpke_types::KemAlgorithm::{DhKem25519, XWingDraft06};
+use hpke_rs::hpke_types::KemAlgorithm::DhKem25519;
 use hpke_rs::libcrux::HpkeLibcrux;
 use hpke_rs::{Hpke, Mode};
 use libcrux_kem::MlKem768;
@@ -29,8 +30,6 @@ use uuid::Uuid;
 const NR_ID: &[u8] = b"MOCK_NEWSROOM_ID";
 
 const HPKE_PSK_ID: &[u8] = b"PSK_INFO_ID_TAG"; // authpsk only, required by spec
-const HPKE_BASE_AAD: &[u8] = b""; // base only; in authpsk mode the NR_ID is supplied
-const HPKE_BASE_INFO: &[u8] = b""; // base mode only
 
 // Key lengths
 const LEN_DHKEM_ENCAPS_KEY: usize = libcrux_curve25519::EK_LEN;
@@ -46,13 +45,6 @@ const LEN_MLKEM_DECAPS_KEY: usize = 2400;
 const LEN_MLKEM_SHAREDSECRET_ENCAPS: usize = 1088;
 const LEN_MLKEM_SHAREDSECRET: usize = 32;
 const LEN_MLKEM_RAND_SEED_SIZE: usize = 64;
-
-// https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/#name-encoding-and-sizes
-pub const LEN_XWING_ENCAPS_KEY: usize = 1216;
-const LEN_XWING_DECAPS_KEY: usize = 32;
-const LEN_XWING_SHAREDSECRET_ENCAPS: usize = 1120;
-const LEN_XWING_SHAREDSECRET: usize = 32;
-const LEN_XWING_RAND_SEED_SIZE: usize = 96;
 
 // Message ID (uuid) and KMID
 const LEN_MESSAGE_ID: usize = 16;
@@ -78,9 +70,6 @@ where
 {
     let mut hpke_authenc: Hpke<HpkeLibcrux> =
         Hpke::new(Mode::AuthPsk, DhKem25519, HkdfSha256, Aes256Gcm);
-
-    let mut hpke_metadata: Hpke<HpkeLibcrux> =
-        Hpke::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
 
     // spec: pk_R^AKEM: the DH-AKEM component of the recipient's APKE key bundle
     let recipient_message_enc_dhakem_pub = recipient.message_enc_pk().clone().into();
@@ -145,31 +134,8 @@ where
     sender_apke_bytes.extend_from_slice(sender.message_auth_keypair().1.as_bytes()); // pk_S^AKEM (DH-AKEM)
     sender_apke_bytes.extend_from_slice(sender.message_psk_pk().as_bytes()); // pk_S^PQ (ML-KEM)
 
-    // Encapsulate the full sender APKE public key tuple to the recipient's metadata key
-    // (xwing) in HPKE Base mode:
-    // https://www.rfc-editor.org/rfc/rfc9180.html#name-metadata-protection
-    // Although we do use a PSK and PSK_ID in the message, we don't need to
-    // encrypt the message PSK_ID, because it is a hard-coded string
-    let recipient_md_pubkey = recipient.message_metadata_pk().clone().into();
-
-    // spec: SD-PKE.Enc
-    let (md_ss_encaps_vec, metadata_ciphertext) = hpke_metadata
-        .seal(
-            &recipient_md_pubkey,
-            HPKE_BASE_INFO, // b""
-            HPKE_BASE_AAD,  // b""
-            &sender_apke_bytes,
-            None,
-            None,
-            None,
-        )
-        .expect("Expected Hpke.BaseMode sealed ciphertext");
-
-    let metadata_ss_encaps: [u8; LEN_XWING_SHAREDSECRET_ENCAPS] =
-        md_ss_encaps_vec.try_into().expect(&format!(
-            "Need {} byte encapsulated shared secret",
-            LEN_XWING_SHAREDSECRET_ENCAPS
-        ));
+    // spec: ct^PKE = SD-PKE.Enc(pk_R^PKE, pk_S^APKE)
+    let ct_pke = recipient.message_metadata_pk().encrypt(&sender_apke_bytes);
 
     let cmessage = CombinedCiphertext {
         message_dhakem_ss_encap: dhakem_ss_encaps_bytes,
@@ -181,57 +147,31 @@ where
     // Send (C_S, X, Z) to server
     Envelope {
         cmessage: cmessage.to_bytes(),        // ct^APKE
-        cmetadata: metadata_ciphertext,       // ct^PKE ciphertext
-        metadata_encap: metadata_ss_encaps,   // ct^PKE encapsulation
+        ct_pke,                               // ct^PKE
         mgdh_pubkey: hint_epk.into_bytes(),   // X = g^x
         mgdh: hint_sharedsecret.into_bytes(), // Z = (pk_R^fetch)^x
     }
 }
 
 pub fn decrypt<U: UserSecret + ?Sized>(receiver: &U, envelope: &Envelope) -> Plaintext {
-    use hpke_rs::hpke_types::AeadAlgorithm::Aes256Gcm;
-    use hpke_rs::hpke_types::KdfAlgorithm::HkdfSha256;
-    use hpke_rs::hpke_types::KemAlgorithm::{DhKem25519, XWingDraft06};
-    use hpke_rs::{Hpke, Mode};
-
     let hpke_authenc: Hpke<HpkeLibcrux> =
         Hpke::new(Mode::AuthPsk, DhKem25519, HkdfSha256, Aes256Gcm);
 
-    let hpke_base: Hpke<HpkeLibcrux> = Hpke::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
-
-    // Receiver needs to know which keybundle to use, so they have to trial decrypt
-    // metadata.
-    // Explanation of what's happening:
-    // - for each keybundle, trial-decrypt the metadata using
-    // hpke_base::open (yields Result<metadata_bytes, HpkeError>)
-    // - filter only the successful ones (Ok) and
-    // - collect the successful decryptions (Vec<u8>) mapped to the
-    // correct keybundle, and
-    // - return the results of that collection.
-    // There should be exactly 1 result.
+    // Trial-decrypt ct^PKE with each keybundle's metadata private key to find
+    // the intended recipient's bundle. There should be exactly 1 result.
     let results: Vec<(&MessageKeyBundle, Vec<u8>)> = receiver
         .keybundles()
         .filter_map(|bundle| {
-            {
-                let md_key = bundle.xwing_md.sk.clone().into();
-
-                hpke_base.open(
-                    &envelope.metadata_encap,
-                    &md_key,
-                    HPKE_BASE_INFO,
-                    HPKE_BASE_AAD,
-                    &envelope.cmetadata,
-                    None,
-                    None,
-                    None,
-                )
-            }
-            .ok()
-            .map(|decrypted_metadata| (bundle, decrypted_metadata))
+            bundle
+                .metadata_kp
+                .private_key()
+                .decrypt(&envelope.ct_pke)
+                .ok()
+                .map(|m| (bundle, m))
         })
         .collect();
 
-    // Sanity
+    // Sanity check
     debug_assert_eq!(results.len(), 1);
 
     // Unpack the results of the trial decryption, yielding metadata and correct decryption keys
@@ -400,13 +340,12 @@ mod tests {
     use rand_core::SeedableRng;
 
     use crate::{
-        DhAkemKeyPair, Journalist, KeyBundlePublic, KeyPair, MlKem768KeyPair, Source, XWingKeyPair,
+        DhAkemKeyPair, Journalist, KeyBundlePublic, KeyPair, MlKem768KeyPair, Source,
         primitives::{
             dh_akem::DhAkemPrivateKey,
-            generate_dh_akem_keypair, generate_mlkem768_keypair, generate_xwing_keypair,
+            generate_dh_akem_keypair, generate_mlkem768_keypair,
             mlkem::{MLKEM768PrivateKey, MLKEM768PublicKey},
             x25519::DHPrivateKey,
-            xwing::{XWingPrivateKey, XWingPublicKey},
         },
         private,
     };

--- a/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
+++ b/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
@@ -1,4 +1,5 @@
 use crate::constants::LEN_XWING_ENCAPS_KEY;
+use crate::metadata;
 use crate::primitives::dh_akem::DH_AKEM_PUBLIC_KEY_LEN;
 use crate::primitives::dh_akem::DhAkemPublicKey;
 use crate::primitives::x25519::DHPublicKey;
@@ -135,7 +136,7 @@ where
     sender_apke_bytes.extend_from_slice(sender.message_psk_pk().as_bytes()); // pk_S^PQ (ML-KEM)
 
     // spec: ct^PKE = SD-PKE.Enc(pk_R^PKE, pk_S^APKE)
-    let ct_pke = recipient.message_metadata_pk().encrypt(&sender_apke_bytes);
+    let ct_pke = metadata::encrypt(recipient.message_metadata_pk(), &sender_apke_bytes);
 
     let cmessage = CombinedCiphertext {
         message_dhakem_ss_encap: dhakem_ss_encaps_bytes,
@@ -162,10 +163,7 @@ pub fn decrypt<U: UserSecret + ?Sized>(receiver: &U, envelope: &Envelope) -> Pla
     let results: Vec<(&MessageKeyBundle, Vec<u8>)> = receiver
         .keybundles()
         .filter_map(|bundle| {
-            bundle
-                .metadata_kp
-                .private_key()
-                .decrypt(&envelope.ct_pke)
+            metadata::decrypt(bundle.metadata_kp.private_key(), &envelope.ct_pke)
                 .ok()
                 .map(|m| (bundle, m))
         })

--- a/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
+++ b/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
@@ -63,9 +63,8 @@ const LEN_KMID: usize =
     libcrux_chacha20poly1305::TAG_LEN + libcrux_chacha20poly1305::NONCE_LEN + LEN_MESSAGE_ID;
 
 /// Encrypt a message from a sender to a receiver.
-/// A sender holds access to UserPublic + UserSecret, i.e. kepyair access.
+/// A sender holds access to UserPublic + UserSecret, i.e. keypair access.
 /// A receiver holds access to UserPublic, i.e. pubkey access.
-/// TODO: pass Plaintext instead of &[u8]
 pub fn encrypt<Rng, Sndr, Rcvr>(
     rng: &mut Rng,
     sender: &Sndr,
@@ -83,8 +82,9 @@ where
     let mut hpke_metadata: Hpke<HpkeLibcrux> =
         Hpke::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
 
+    // spec: pk_R^AKEM: the DH-AKEM component of the recipient's APKE key bundle
     let recipient_message_enc_dhakem_pub = recipient.message_enc_pk().clone().into();
-
+    // spec: sk_S^AKEM: the DH-AKEM component of the sender's long-term APKE key tuple (sk_S^APKE)
     let hpke_sender_key = sender.message_auth_keypair().0.clone().into();
 
     // Note: Don't need SEED_GEN len randomness (64), just SHARED_SECRET len (32),
@@ -97,6 +97,7 @@ where
         .expect("PSK encaps failed");
 
     // Info parameter is pq_psk_encaps_bytes || receiver_fetch_pubkey_bytes
+    // spec: SD-APKE AuthEnc sets info = c2 || pk_R^fetch
     let mut info = Vec::new();
     info.extend_from_slice(&psk_ct);
     info.extend_from_slice(&recipient.fetch_pk().clone().into_bytes());
@@ -106,6 +107,7 @@ where
     // for sending replies, key identifiers, newsroom key/identifier, etc.)
     // At the moment the message being passed here is just the plaintext, but it will have a message structure.
 
+    // spec: ct^APKE = SD-APKE.AuthEnc(sk_S^APKE, pk_R^APKE, pt, NR_ID, pk_R^fetch)
     // HPKE AuthPSK message encryption
     let (mesage_dhakem_shared_secret_encaps, message_ciphertext) = hpke_authenc
         .seal(
@@ -126,30 +128,37 @@ where
         [0u8; LEN_DHKEM_SHAREDSECRET_ENCAPS];
     dhakem_ss_encaps_bytes.copy_from_slice(mesage_dhakem_shared_secret_encaps.as_slice());
 
+    // Hint (X, Z): X = g^x, Z = (pk_R^fetch)^x for a fresh ephemeral scalar x
     // Create mgdh (message clue) with a DH agreement between an ephemeral curve25519 keypair
     // and the recipient's Fetching key
+    // spec: `hint_esk` = x
+    // spec: `hint_epk` = X
     let (hint_esk, hint_epk) = generate_dh_keypair(rng).expect("Dh Keygen (fetch) failed");
 
+    // spec: `hint_sharedsecret` = Z = (pk_R^fetch)^x
     let hint_sharedsecret: DHSharedSecret =
         dh_shared_secret(recipient.fetch_pk(), hint_esk.into_bytes())
             .expect("Failed to generate shared secret");
 
-    // Serialize sender DH-AKEM pubkey
-    let sender_pubkey_bytes = sender.message_auth_keypair().1.as_bytes();
+    // Serialize the full sender APKE public key tuple: pk_S^AKEM || pk_S^PQ
+    let mut sender_apke_bytes = Vec::new();
+    sender_apke_bytes.extend_from_slice(sender.message_auth_keypair().1.as_bytes()); // pk_S^AKEM (DH-AKEM)
+    sender_apke_bytes.extend_from_slice(sender.message_psk_pk().as_bytes()); // pk_S^PQ (ML-KEM)
 
-    // Serialize then encapsulate sender pubkey to recipient metadata key
-    // (xwing) in Hpke Base mode:
+    // Encapsulate the full sender APKE public key tuple to the recipient's metadata key
+    // (xwing) in HPKE Base mode:
     // https://www.rfc-editor.org/rfc/rfc9180.html#name-metadata-protection
     // Although we do use a PSK and PSK_ID in the message, we don't need to
     // encrypt the message PSK_ID, because it is a hard-coded string
     let recipient_md_pubkey = recipient.message_metadata_pk().clone().into();
 
+    // spec: SD-PKE.Enc
     let (md_ss_encaps_vec, metadata_ciphertext) = hpke_metadata
         .seal(
             &recipient_md_pubkey,
             HPKE_BASE_INFO, // b""
             HPKE_BASE_AAD,  // b""
-            sender_pubkey_bytes,
+            &sender_apke_bytes,
             None,
             None,
             None,
@@ -167,20 +176,15 @@ where
         message_pqpsk_ss_encap: psk_ct,
         ct_message: message_ciphertext,
     };
+    // TODO: define C_S as in the spec
 
+    // Send (C_S, X, Z) to server
     Envelope {
-        // authenc ciphertext
-        cmessage: cmessage.to_bytes(),
-
-        // sender pubkey ciphertext
-        cmetadata: metadata_ciphertext,
-
-        // sender pubkey ss encaps
-        metadata_encap: metadata_ss_encaps,
-
-        // clue stuff
-        mgdh_pubkey: hint_epk.into_bytes(),
-        mgdh: hint_sharedsecret.into_bytes(),
+        cmessage: cmessage.to_bytes(),        // ct^APKE
+        cmetadata: metadata_ciphertext,       // ct^PKE ciphertext
+        metadata_encap: metadata_ss_encaps,   // ct^PKE encapsulation
+        mgdh_pubkey: hint_epk.into_bytes(),   // X = g^x
+        mgdh: hint_sharedsecret.into_bytes(), // Z = (pk_R^fetch)^x
     }
 }
 
@@ -235,14 +239,20 @@ pub fn decrypt<U: UserSecret + ?Sized>(receiver: &U, envelope: &Envelope) -> Pla
     let receiver_dhakem: &HpkePrivateKey = &bundle.dh_akem.sk.clone().into();
     let receiver_pqkem_bytes: &[u8; LEN_MLKEM_DECAPS_KEY] = bundle.mlkem.sk.as_bytes();
 
-    // kind of silly, but just enforcing expected length of metadata
-    let raw_md_bytes: [u8; DH_AKEM_PUBLIC_KEY_LEN] = raw_metadata
-        .as_slice()
+    // we should have the full APKE public key tuple: pk_S^AKEM (DH-AKEM) || pk_S^PQ (ML-KEM)
+    assert_eq!(
+        raw_metadata.len(),
+        DH_AKEM_PUBLIC_KEY_LEN + LEN_MLKEM_ENCAPS_KEY,
+        "Metadata must contain the full sender APKE key tuple"
+    );
+    let sender_dhakem_bytes: [u8; DH_AKEM_PUBLIC_KEY_LEN] = raw_metadata[..DH_AKEM_PUBLIC_KEY_LEN]
         .try_into()
-        .expect("Need {DH_AKEM_PUBLIC_KEY_LEN} array");
+        .expect("Need DH_AKEM_PUBLIC_KEY_LEN bytes for sender DH-AKEM key");
+    let _sender_mlkem_bytes: [u8; LEN_MLKEM_ENCAPS_KEY] = raw_metadata[DH_AKEM_PUBLIC_KEY_LEN..]
+        .try_into()
+        .expect("Need LEN_MLKEM_ENCAPS_KEY bytes for sender ML-KEM key");
 
-    // Sender DH-AKEM pubkey required to decrypt ciphertext
-    let sender_dhakem: HpkePublicKey = DhAkemPublicKey::from_bytes(raw_md_bytes).into();
+    let sender_dhakem: HpkePublicKey = DhAkemPublicKey::from_bytes(sender_dhakem_bytes).into();
 
     // toy (unsafe) parse combined ciphertext
     let combined_ct = CombinedCiphertext::from_bytes(&envelope.cmessage).unwrap();
@@ -368,9 +378,6 @@ pub fn solve_fetch_challenges<S: UserSecret>(
 /// TODO: only sources need to attach their pubkeys (for replies),
 /// but for toy purposes, everyone builds a Plaintext message the same way
 pub fn build_message(sender: &impl UserPublic, message: Vec<u8>) -> Plaintext {
-    let mut reply_key_pq_psk = [0u8; LEN_MLKEM_ENCAPS_KEY];
-    reply_key_pq_psk.copy_from_slice(sender.message_psk_pk().as_bytes());
-
     let mut fetch_pk = [0u8; LEN_DH_ITEM];
     fetch_pk.copy_from_slice(&sender.fetch_pk().clone().into_bytes());
 
@@ -378,7 +385,6 @@ pub fn build_message(sender: &impl UserPublic, message: Vec<u8>) -> Plaintext {
     reply_key_pq_hybrid.copy_from_slice(sender.message_metadata_pk().as_bytes());
 
     Plaintext {
-        sender_reply_pubkey_pq_psk: reply_key_pq_psk,
         sender_fetch_key: fetch_pk,
         sender_reply_pubkey_hybrid: reply_key_pq_hybrid,
         msg: message,
@@ -441,12 +447,8 @@ mod tests {
             sender_public.message_metadata_pk().as_bytes()
         );
         assert_eq!(
-            &pt_ref.sender_reply_pubkey_pq_psk,
-            sender_public.message_psk_pk().as_bytes()
-        );
-        assert_eq!(
             pt.len(),
-            &pt_ref.msg.len() + LEN_DH_ITEM + LEN_MLKEM_ENCAPS_KEY + LEN_XWING_ENCAPS_KEY
+            &pt_ref.msg.len() + LEN_DH_ITEM + LEN_XWING_ENCAPS_KEY
         );
     }
 

--- a/securedrop-protocol/protocol-minimal/src/journalist.rs
+++ b/securedrop-protocol/protocol-minimal/src/journalist.rs
@@ -2,6 +2,7 @@ use crate::VerifyingKey;
 use crate::api::Api;
 use crate::api::JournalistApi;
 use crate::api::restricted;
+use crate::metadata::{MetadataPublicKey, keygen as metadata_keygen};
 use crate::primitives::dh_akem::DhAkemPrivateKey;
 use crate::primitives::dh_akem::DhAkemPublicKey;
 use crate::primitives::dh_akem::generate_dh_akem_keypair;
@@ -10,8 +11,6 @@ use crate::primitives::mlkem::generate_mlkem768_keypair;
 use crate::primitives::x25519::DHPrivateKey;
 use crate::primitives::x25519::DHPublicKey;
 use crate::primitives::x25519::generate_dh_keypair;
-use crate::primitives::xwing::XWingPublicKey;
-use crate::primitives::xwing::generate_xwing_keypair;
 use crate::sign::{JournalistEphemeralKey, JournalistLongTermKey, Signature, SigningKey};
 use alloc::vec::Vec;
 use rand_core::{CryptoRng, RngCore};
@@ -82,8 +81,8 @@ impl UserPublic for JournalistPublicView {
         &self.kb.0.mlkem_pk
     }
 
-    fn message_metadata_pk(&self) -> &XWingPublicKey {
-        &self.kb.0.xwing_pk
+    fn message_metadata_pk(&self) -> &MetadataPublicKey {
+        &self.kb.0.metadata_pk
     }
 
     fn message_enc_pk(&self) -> &DhAkemPublicKey {
@@ -219,8 +218,7 @@ impl Journalist {
             let (sk_pqkem_psk, pk_pqkem_psk) =
                 generate_mlkem768_keypair(rng).expect("Failed to generate ml-kem keys!");
 
-            let (sk_md, pk_md) =
-                generate_xwing_keypair(rng).expect("Failed to generate xwing keys");
+            let metadata_kp = metadata_keygen(rng).expect("Failed to generate metadata keys");
 
             let bundle = MessageKeyBundle::new(
                 KeyPair {
@@ -231,10 +229,7 @@ impl Journalist {
                     sk: sk_pqkem_psk,
                     pk: pk_pqkem_psk,
                 },
-                KeyPair {
-                    sk: sk_md,
-                    pk: pk_md,
-                },
+                metadata_kp,
             );
 
             let pubkey_bytes = bundle.public().as_bytes();
@@ -324,12 +319,20 @@ mod tests {
                 kbs[i].mlkem.pk.as_bytes()
             );
             assert_eq!(
-                journalist.message_keys[i].bundle.xwing_md.sk.as_bytes(),
-                kbs[i].xwing_md.sk.as_bytes()
+                journalist.message_keys[i]
+                    .bundle
+                    .metadata_kp
+                    .private_key()
+                    .as_bytes(),
+                kbs[i].metadata_kp.private_key().as_bytes()
             );
             assert_eq!(
-                journalist.message_keys[i].bundle.xwing_md.pk.as_bytes(),
-                kbs[i].xwing_md.pk.as_bytes()
+                journalist.message_keys[i]
+                    .bundle
+                    .metadata_kp
+                    .public_key()
+                    .as_bytes(),
+                kbs[i].metadata_kp.public_key().as_bytes()
             );
         }
     }

--- a/securedrop-protocol/protocol-minimal/src/journalist.rs
+++ b/securedrop-protocol/protocol-minimal/src/journalist.rs
@@ -29,7 +29,10 @@ pub struct Journalist {
     signing_key: SigningKeyPair,
     fetch_key: DhFetchKeyPair,
     message_keys: Vec<SignedMessageKeyBundle>,
+    /// DH-AKEM component of the long-term APKE key tuple (pk_J^APKE)
     reply_key: DhAkemKeyPair,
+    /// ML-KEM component of the long-term APKE key tuple (pk_J^APKE)
+    reply_mlkem_key: MlKem768KeyPair,
     self_signature: Signature<JournalistLongTermKey>,
     signed_longterm_key_bytes: SignedLongtermPubKeyBytes,
     session_storage: SessionStorage,
@@ -139,13 +142,17 @@ impl UserSecret for Journalist {
         (&self.reply_key.sk, &self.reply_key.pk)
     }
 
+    fn message_psk_pk(&self) -> &MLKEM768PublicKey {
+        // ML-KEM component of the journalist's long-term APKE key tuple (pk_J^PQ)
+        &self.reply_mlkem_key.pk
+    }
+
     fn build_message(&self, message: Vec<u8>) -> Plaintext {
         // TODO: the journalist doesn't attach their own keys,
         // because the source pulls a fresh set of keys and verifies them
         // in order to reply. either fill with random bytes or use
         // another scheme (fixme)
         Plaintext {
-            sender_reply_pubkey_pq_psk: [0u8; LEN_MLKEM_ENCAPS_KEY],
             sender_fetch_key: [0u8; LEN_DH_ITEM],
             sender_reply_pubkey_hybrid: [0u8; LEN_XWING_ENCAPS_KEY],
             msg: message,
@@ -166,6 +173,7 @@ impl Enrollable for Journalist {
                 self.signing_key.pk,
                 self.fetch_key.pk.clone(),
                 self.reply_key.pk.clone(),
+                self.reply_mlkem_key.pk.clone(),
             ),
         }
     }
@@ -194,8 +202,13 @@ impl Journalist {
         let (sk_reply, pk_reply) =
             generate_dh_akem_keypair(&mut *rng).expect("DH-AKEM Keygen (Reply) failed");
 
+        let (sk_reply_mlkem, pk_reply_mlkem) =
+            generate_mlkem768_keypair(rng).expect("ML-KEM Keygen (Reply) failed");
+
         // Self-sign long-term pubkeys (for enrollment).
-        let selfsigned_pubkeys = SignedLongtermPubKeyBytes::from_keys(&pk_reply, &pk_fetch);
+        // Covers pk_J^APKE = (pk_J^AKEM, pk_J^PQ) and pk_J^fetch
+        let selfsigned_pubkeys =
+            SignedLongtermPubKeyBytes::from_keys(&pk_reply, &pk_reply_mlkem, &pk_fetch);
         let self_signature: Signature<JournalistLongTermKey> =
             signing_key.sign(selfsigned_pubkeys.as_bytes());
 
@@ -249,6 +262,10 @@ impl Journalist {
             reply_key: KeyPair {
                 sk: sk_reply,
                 pk: pk_reply,
+            },
+            reply_mlkem_key: KeyPair {
+                sk: sk_reply_mlkem,
+                pk: pk_reply_mlkem,
             },
             message_keys: key_bundles,
             self_signature,

--- a/securedrop-protocol/protocol-minimal/src/keys.rs
+++ b/securedrop-protocol/protocol-minimal/src/keys.rs
@@ -126,8 +126,7 @@ impl SignedLongtermPubKeyBytes {
         pubkey_bytes[offset..offset + LEN_DHKEM_ENCAPS_KEY]
             .copy_from_slice(reply_dhakem.as_bytes());
         offset += LEN_DHKEM_ENCAPS_KEY;
-        pubkey_bytes[offset..offset + LEN_MLKEM_ENCAPS_KEY]
-            .copy_from_slice(reply_mlkem.as_bytes());
+        pubkey_bytes[offset..offset + LEN_MLKEM_ENCAPS_KEY].copy_from_slice(reply_mlkem.as_bytes());
         offset += LEN_MLKEM_ENCAPS_KEY;
         pubkey_bytes[offset..].copy_from_slice(&fetch_pk.into_bytes());
 
@@ -144,7 +143,12 @@ impl SignedLongtermPubKeyBytes {
 pub struct Enrollment {
     pub bundle: SignedLongtermPubKeyBytes,
     pub selfsig: Signature<JournalistLongTermKey>,
-    pub keys: (VerifyingKey, DHPublicKey, DhAkemPublicKey, MLKEM768PublicKey),
+    pub keys: (
+        VerifyingKey,
+        DHPublicKey,
+        DhAkemPublicKey,
+        MLKEM768PublicKey,
+    ),
 }
 
 // in memory session storage

--- a/securedrop-protocol/protocol-minimal/src/keys.rs
+++ b/securedrop-protocol/protocol-minimal/src/keys.rs
@@ -7,14 +7,13 @@ use crate::sign::{
     VerifyingKey,
 };
 
+use crate::metadata::{MetadataKeyPair, MetadataPublicKey};
 use crate::primitives::dh_akem::DhAkemPrivateKey;
 use crate::primitives::dh_akem::DhAkemPublicKey;
 use crate::primitives::mlkem::MLKEM768PrivateKey;
 use crate::primitives::mlkem::MLKEM768PublicKey;
 use crate::primitives::x25519::DHPrivateKey;
 use crate::primitives::x25519::DHPublicKey;
-use crate::primitives::xwing::XWingPrivateKey;
-use crate::primitives::xwing::XWingPublicKey;
 use alloc::vec::Vec;
 
 use crate::constants::*;
@@ -32,7 +31,6 @@ pub type DhAkemKeyPair = KeyPair<DhAkemPrivateKey, DhAkemPublicKey>;
 // eventually: ristretto255
 pub type DhFetchKeyPair = KeyPair<DHPrivateKey, DHPublicKey>;
 pub type SigningKeyPair = KeyPair<SigningKey, VerifyingKey>;
-pub type XWingKeyPair = KeyPair<XWingPrivateKey, XWingPublicKey>;
 
 /// The public half of an ephemeral key bundle together with the journalist's
 /// self-signature over it.
@@ -43,15 +41,15 @@ pub type SignedKeyBundlePublic = (KeyBundlePublic, Signature<JournalistEphemeral
 /// Each bundle contains one key for each cryptographic role:
 /// - `dhakem_pk`: SD-APKE ephemeral key (`pk_{J,i}^{APKE_E}`), DHKEM(X25519) component
 /// - `mlkem_pk`: SD-APKE ephemeral key (`pk_{J,i}^{APKE_E}`), ML-KEM-768 component
-/// - `xwing_pk`: SD-PKE ephemeral key (`pk_{J,i}^{PKE_E}`), X-Wing
+/// - `metadata_pk`: SD-PKE ephemeral key (`pk_{J,i}^{PKE_E}`), X-Wing
 #[derive(Debug, Clone)]
 pub struct KeyBundlePublic {
     /// DHKEM(X25519) component of the ephemeral SD-APKE key.
     pub dhakem_pk: DhAkemPublicKey,
     /// ML-KEM-768 component of the ephemeral SD-APKE key.
     pub mlkem_pk: MLKEM768PublicKey,
-    /// X-Wing ephemeral SD-PKE key, used for metadata protection.
-    pub xwing_pk: XWingPublicKey,
+    /// SD-PKE ephemeral key, used for metadata protection.
+    pub metadata_pk: MetadataPublicKey,
 }
 
 impl KeyBundlePublic {
@@ -62,7 +60,7 @@ impl KeyBundlePublic {
         let mut out = Vec::new();
         out.extend(self.dhakem_pk.as_bytes());
         out.extend(self.mlkem_pk.as_bytes());
-        out.extend(self.xwing_pk.as_bytes());
+        out.extend(self.metadata_pk.as_bytes());
         out
     }
 }
@@ -70,11 +68,15 @@ impl KeyBundlePublic {
 pub(crate) struct MessageKeyBundle {
     pub(crate) dh_akem: DhAkemKeyPair,
     pub(crate) mlkem: MlKem768KeyPair,
-    pub(crate) xwing_md: XWingKeyPair,
+    pub(crate) metadata_kp: MetadataKeyPair,
 }
 
 impl MessageKeyBundle {
-    pub fn new(dh_akem: DhAkemKeyPair, mlkem: MlKem768KeyPair, xwing_md: XWingKeyPair) -> Self {
+    pub fn new(
+        dh_akem: DhAkemKeyPair,
+        mlkem: MlKem768KeyPair,
+        metadata_kp: MetadataKeyPair,
+    ) -> Self {
         // // ID is derived from pubkey hashes in specific order
         // let mut hasher = libcrux_sha2::Sha256::default();
 
@@ -88,7 +90,7 @@ impl MessageKeyBundle {
         Self {
             dh_akem,
             mlkem,
-            xwing_md,
+            metadata_kp,
         }
     }
 
@@ -96,7 +98,7 @@ impl MessageKeyBundle {
         KeyBundlePublic {
             dhakem_pk: self.dh_akem.pk.clone(),
             mlkem_pk: self.mlkem.pk.clone(),
-            xwing_pk: self.xwing_md.pk.clone(),
+            metadata_pk: self.metadata_kp.public_key().clone(),
         }
     }
 }

--- a/securedrop-protocol/protocol-minimal/src/keys.rs
+++ b/securedrop-protocol/protocol-minimal/src/keys.rs
@@ -107,16 +107,29 @@ pub(crate) struct SignedMessageKeyBundle {
 }
 
 #[derive(Debug, Clone)]
-pub struct SignedLongtermPubKeyBytes(pub [u8; LEN_DHKEM_ENCAPS_KEY + LEN_DH_ITEM]);
+pub struct SignedLongtermPubKeyBytes(
+    pub [u8; LEN_DHKEM_ENCAPS_KEY + LEN_MLKEM_ENCAPS_KEY + LEN_DH_ITEM],
+);
 
 impl SignedLongtermPubKeyBytes {
     /// Serialize long-term public keys into the canonical byte encoding.
     ///
     /// Byte layout (per spec §3.1): `pk_J^APKE || pk_J^fetch`
-    pub(crate) fn from_keys(reply_dhakem: &DhAkemPublicKey, fetch_pk: &DHPublicKey) -> Self {
-        let mut pubkey_bytes = [0u8; LEN_DHKEM_ENCAPS_KEY + LEN_DH_ITEM];
-        pubkey_bytes[0..LEN_DHKEM_ENCAPS_KEY].copy_from_slice(reply_dhakem.as_bytes());
-        pubkey_bytes[LEN_DHKEM_ENCAPS_KEY..].copy_from_slice(&fetch_pk.into_bytes());
+    /// where `pk_J^APKE = pk_J^AKEM (DH-AKEM) || pk_J^PQ (ML-KEM)`
+    pub(crate) fn from_keys(
+        reply_dhakem: &DhAkemPublicKey,
+        reply_mlkem: &MLKEM768PublicKey,
+        fetch_pk: &DHPublicKey,
+    ) -> Self {
+        let mut pubkey_bytes = [0u8; LEN_DHKEM_ENCAPS_KEY + LEN_MLKEM_ENCAPS_KEY + LEN_DH_ITEM];
+        let mut offset = 0;
+        pubkey_bytes[offset..offset + LEN_DHKEM_ENCAPS_KEY]
+            .copy_from_slice(reply_dhakem.as_bytes());
+        offset += LEN_DHKEM_ENCAPS_KEY;
+        pubkey_bytes[offset..offset + LEN_MLKEM_ENCAPS_KEY]
+            .copy_from_slice(reply_mlkem.as_bytes());
+        offset += LEN_MLKEM_ENCAPS_KEY;
+        pubkey_bytes[offset..].copy_from_slice(&fetch_pk.into_bytes());
 
         Self(pubkey_bytes)
     }
@@ -131,7 +144,7 @@ impl SignedLongtermPubKeyBytes {
 pub struct Enrollment {
     pub bundle: SignedLongtermPubKeyBytes,
     pub selfsig: Signature<JournalistLongTermKey>,
-    pub keys: (VerifyingKey, DHPublicKey, DhAkemPublicKey),
+    pub keys: (VerifyingKey, DHPublicKey, DhAkemPublicKey, MLKEM768PublicKey),
 }
 
 // in memory session storage

--- a/securedrop-protocol/protocol-minimal/src/lib.rs
+++ b/securedrop-protocol/protocol-minimal/src/lib.rs
@@ -41,3 +41,4 @@ pub use sign::{
 pub mod storage;
 
 pub mod encrypt_decrypt;
+pub mod metadata;

--- a/securedrop-protocol/protocol-minimal/src/lib.rs
+++ b/securedrop-protocol/protocol-minimal/src/lib.rs
@@ -20,7 +20,7 @@ pub use ciphertext::{CombinedCiphertext, Envelope, FetchResponse, Plaintext};
 
 pub use keys::{
     DhAkemKeyPair, DhFetchKeyPair, Enrollment, KeyBundlePublic, KeyPair, MlKem768KeyPair,
-    SessionStorage, SignedKeyBundlePublic, SignedLongtermPubKeyBytes, SigningKeyPair, XWingKeyPair,
+    SessionStorage, SignedKeyBundlePublic, SignedLongtermPubKeyBytes, SigningKeyPair,
 };
 
 pub use traits::{Enrollable, JournalistPublic, UserPublic, UserSecret};

--- a/securedrop-protocol/protocol-minimal/src/metadata.rs
+++ b/securedrop-protocol/protocol-minimal/src/metadata.rs
@@ -103,26 +103,6 @@ impl MetadataPublicKey {
     pub fn as_bytes(&self) -> &[u8] {
         self.0.as_bytes()
     }
-
-    /// SD-PKE.Enc: encrypt message `m` to this key, returning `(c, c')`.
-    ///
-    /// `m` is the sender's serialized long-term APKE public key.
-    pub fn encrypt(&self, m: &[u8]) -> MetadataCiphertext {
-        let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
-        let pk_r = self.0.clone().into();
-
-        // MetadataPublicKey always holds a valid XWing key, so seal cannot fail.
-        let (c_vec, cp) = hpke
-            .seal(&pk_r, b"", b"", m, None, None, None)
-            .expect("SD-PKE encryption failed");
-
-        // XWing will always produce this length ciphertext, so this .expect is fine.
-        let c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS] = c_vec
-            .try_into()
-            .expect("X-Wing encapsulation output has unexpected length");
-
-        MetadataCiphertext { c, cp }
-    }
 }
 
 impl MetadataPrivateKey {
@@ -131,19 +111,39 @@ impl MetadataPrivateKey {
     pub(crate) fn as_bytes(&self) -> &[u8] {
         self.0.as_bytes()
     }
+}
 
-    /// SD-PKE.Dec: decrypt `(c, c')` using this key, returning message `m`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if HPKE decryption fails.
-    pub fn decrypt(&self, ct: &MetadataCiphertext) -> Result<Vec<u8>, Error> {
-        let hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
-        let sk_r = self.0.clone().into();
+/// SD-PKE.Enc: encrypt message `m` to recipient key `pk_r`, returning `(c, c')`.
+///
+/// `m` is the sender's serialized long-term APKE public key.
+pub fn encrypt(pk_r: &MetadataPublicKey, m: &[u8]) -> MetadataCiphertext {
+    let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
+    let pk_r_hpke = pk_r.0.clone().into();
 
-        hpke.open(&ct.c, &sk_r, b"", b"", &ct.cp, None, None, None)
-            .map_err(|e| anyhow::anyhow!("SD-PKE decryption failed: {:?}", e))
-    }
+    // MetadataPublicKey always holds a valid XWing key, so seal cannot fail.
+    let (c_vec, cp) = hpke
+        .seal(&pk_r_hpke, b"", b"", m, None, None, None)
+        .expect("SD-PKE encryption failed");
+
+    // XWing will always produce this length ciphertext, so this .expect is fine.
+    let c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS] = c_vec
+        .try_into()
+        .expect("X-Wing encapsulation output has unexpected length");
+
+    MetadataCiphertext { c, cp }
+}
+
+/// SD-PKE.Dec: decrypt `(c, c')` using recipient key `sk_r`, returning message `m`.
+///
+/// # Errors
+///
+/// Returns an error if HPKE decryption fails.
+pub fn decrypt(sk_r: &MetadataPrivateKey, ct: &MetadataCiphertext) -> Result<Vec<u8>, Error> {
+    let hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
+    let sk_r_hpke = sk_r.0.clone().into();
+
+    hpke.open(&ct.c, &sk_r_hpke, b"", b"", &ct.cp, None, None, None)
+        .map_err(|e| anyhow::anyhow!("SD-PKE decryption failed: {:?}", e))
 }
 
 #[cfg(test)]
@@ -165,8 +165,8 @@ mod tests {
             let mut rng = get_rng();
             let kp = keygen(&mut rng).expect("KGen failed");
 
-            let ct = kp.public_key().encrypt(&m);
-            let decrypted = kp.private_key().decrypt(&ct).expect("Decryption failed");
+            let ct = encrypt(kp.public_key(), &m);
+            let decrypted = decrypt(kp.private_key(), &ct).expect("Decryption failed");
 
             prop_assert_eq!(m, decrypted);
         }
@@ -178,7 +178,7 @@ mod tests {
         let kp = keygen(&mut rng).expect("KGen failed");
         let wrong_kp = keygen(&mut rng).expect("KGen failed");
 
-        let ct = kp.public_key().encrypt(b"some sender apke key bytes");
-        assert!(wrong_kp.private_key().decrypt(&ct).is_err());
+        let ct = encrypt(kp.public_key(), b"some sender apke key bytes");
+        assert!(decrypt(wrong_kp.private_key(), &ct).is_err());
     }
 }

--- a/securedrop-protocol/protocol-minimal/src/metadata.rs
+++ b/securedrop-protocol/protocol-minimal/src/metadata.rs
@@ -105,6 +105,8 @@ impl MetadataPublicKey {
     }
 
     /// SD-PKE.Enc: encrypt message `m` to this key, returning `(c, c')`.
+    ///
+    /// `m` is the sender's serialized long-term APKE public key.
     pub fn encrypt(&self, m: &[u8]) -> MetadataCiphertext {
         let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
         let pk_r = self.0.clone().into();

--- a/securedrop-protocol/protocol-minimal/src/metadata.rs
+++ b/securedrop-protocol/protocol-minimal/src/metadata.rs
@@ -17,12 +17,10 @@
 
 use alloc::vec::Vec;
 use anyhow::Error;
-use hpke_rs::Hpke;
-use hpke_rs::Mode;
-use hpke_rs::hpke_types::AeadAlgorithm::Aes256Gcm;
-use hpke_rs::hpke_types::KdfAlgorithm::HkdfSha256;
-use hpke_rs::hpke_types::KemAlgorithm::XWingDraft06;
-use hpke_rs::libcrux::HpkeLibcrux;
+use hpke_rs::{
+    Hpke, Mode, hpke_types::AeadAlgorithm::Aes256Gcm, hpke_types::KdfAlgorithm::HkdfSha256,
+    hpke_types::KemAlgorithm::XWingDraft06, libcrux::HpkeLibcrux,
+};
 use rand_core::{CryptoRng, RngCore};
 
 use crate::constants::LEN_XWING_SHAREDSECRET_ENCAPS;
@@ -124,24 +122,32 @@ impl MetadataPrivateKey {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
     use rand_chacha::ChaCha20Rng;
     use rand_core::SeedableRng;
 
-    #[test]
-    fn test_metadata_encrypt_decrypt_roundtrip() {
-        let mut rng = ChaCha20Rng::seed_from_u64(42);
-        let kp = keygen(&mut rng).expect("KGen failed");
+    fn get_rng() -> ChaCha20Rng {
+        let mut seed = [0u8; 32];
+        getrandom::fill(&mut seed).expect("OS random source failed");
+        ChaCha20Rng::from_seed(seed)
+    }
 
-        let m = b"pk_S^AKEM || pk_S^PQ";
-        let ct = kp.public_key().encrypt(m);
-        let decrypted = kp.private_key().decrypt(&ct).expect("Decryption failed");
+    proptest! {
+        #[test]
+        fn test_metadata_encrypt_decrypt_roundtrip(m in proptest::collection::vec(any::<u8>(), 0..200)) {
+            let mut rng = get_rng();
+            let kp = keygen(&mut rng).expect("KGen failed");
 
-        assert_eq!(m.as_slice(), decrypted.as_slice());
+            let ct = kp.public_key().encrypt(&m);
+            let decrypted = kp.private_key().decrypt(&ct).expect("Decryption failed");
+
+            prop_assert_eq!(m, decrypted);
+        }
     }
 
     #[test]
     fn test_metadata_decrypt_wrong_key_fails() {
-        let mut rng = ChaCha20Rng::seed_from_u64(42);
+        let mut rng = get_rng();
         let kp = keygen(&mut rng).expect("KGen failed");
         let wrong_kp = keygen(&mut rng).expect("KGen failed");
 

--- a/securedrop-protocol/protocol-minimal/src/metadata.rs
+++ b/securedrop-protocol/protocol-minimal/src/metadata.rs
@@ -27,6 +27,7 @@ use crate::constants::LEN_XWING_SHAREDSECRET_ENCAPS;
 use crate::primitives::xwing::{XWingPrivateKey, XWingPublicKey, generate_xwing_keypair};
 
 /// The recipient's metadata public key (`pk_R^PKE` in the spec).
+#[derive(Debug, Clone)]
 pub struct MetadataPublicKey(pub(crate) XWingPublicKey);
 
 /// The recipient's metadata private key (`sk_R^PKE` in the spec).
@@ -52,6 +53,7 @@ impl MetadataKeyPair {
 
 /// SD-PKE ciphertext `(c, c')`: X-Wing encapsulation `c` together with HPKE
 /// ciphertext `c'`.
+#[derive(Debug, Clone)]
 pub struct MetadataCiphertext {
     /// HPKE encapsulation output (`c` in the spec)
     pub(crate) c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS],
@@ -59,15 +61,10 @@ pub struct MetadataCiphertext {
     pub(crate) cp: Vec<u8>,
 }
 
-impl From<XWingPublicKey> for MetadataPublicKey {
-    fn from(key: XWingPublicKey) -> Self {
-        Self(key)
-    }
-}
-
-impl From<XWingPrivateKey> for MetadataPrivateKey {
-    fn from(key: XWingPrivateKey) -> Self {
-        Self(key)
+impl MetadataCiphertext {
+    /// Total byte length of the ciphertext: encapsulation `c` + AEAD ciphertext `c'`.
+    pub fn len(&self) -> usize {
+        self.c.len() + self.cp.len()
     }
 }
 
@@ -84,7 +81,29 @@ pub fn keygen<R: RngCore + CryptoRng>(rng: &mut R) -> Result<MetadataKeyPair, an
     })
 }
 
+/// SD-PKE.KGen (deterministic): derive a `MetadataKeyPair` from 32 bytes of seed material.
+///
+/// For use in passphrase-derived key generation only; do not use with random bytes
+/// from a live RNG (use [`keygen`] instead).
+///
+/// # Errors
+///
+/// Returns an error if X-Wing key generation fails.
+pub(crate) fn deterministic_keygen(randomness: [u8; 32]) -> Result<MetadataKeyPair, anyhow::Error> {
+    use crate::primitives::xwing::deterministic_keygen as xwing_derand;
+    let (sk_s, pk_s) = xwing_derand(randomness)?;
+    Ok(MetadataKeyPair {
+        sk: MetadataPrivateKey(sk_s),
+        pk: MetadataPublicKey(pk_s),
+    })
+}
+
 impl MetadataPublicKey {
+    /// Returns the public key as bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+
     /// SD-PKE.Enc: encrypt message `m` to this key, returning `(c, c')`.
     pub fn encrypt(&self, m: &[u8]) -> MetadataCiphertext {
         let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
@@ -105,6 +124,12 @@ impl MetadataPublicKey {
 }
 
 impl MetadataPrivateKey {
+    /// Returns the private key as bytes.
+    #[cfg(test)]
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+
     /// SD-PKE.Dec: decrypt `(c, c')` using this key, returning message `m`.
     ///
     /// # Errors

--- a/securedrop-protocol/protocol-minimal/src/metadata.rs
+++ b/securedrop-protocol/protocol-minimal/src/metadata.rs
@@ -1,0 +1,151 @@
+//! SD-PKE: metadata encryption
+//!
+//! Spec pseudocode:
+//! ```text
+//! def KGen():
+//!     (skS, pkS) = KEM_H.KGen()
+//!     return (skS, pkS)
+//!
+//! def Enc(pkR, m):
+//!     c, cp = HPKE.SealBase(pkR=pkR, info=None, aad=None, pt=m)
+//!     return (c, cp)
+//!
+//! def Dec(skR, c, cp):
+//!     m = HPKE.OpenBase(enc=c, skR=skR, info=None, aad=None, ct=cp)
+//!     return m
+//! ```
+
+use alloc::vec::Vec;
+use anyhow::Error;
+use hpke_rs::Hpke;
+use hpke_rs::Mode;
+use hpke_rs::hpke_types::AeadAlgorithm::Aes256Gcm;
+use hpke_rs::hpke_types::KdfAlgorithm::HkdfSha256;
+use hpke_rs::hpke_types::KemAlgorithm::XWingDraft06;
+use hpke_rs::libcrux::HpkeLibcrux;
+use rand_core::{CryptoRng, RngCore};
+
+use crate::constants::LEN_XWING_SHAREDSECRET_ENCAPS;
+use crate::primitives::xwing::{XWingPrivateKey, XWingPublicKey, generate_xwing_keypair};
+
+/// The recipient's metadata public key (`pk_R^PKE` in the spec).
+pub struct MetadataPublicKey(pub(crate) XWingPublicKey);
+
+/// The recipient's metadata private key (`sk_R^PKE` in the spec).
+pub struct MetadataPrivateKey(pub(crate) XWingPrivateKey);
+
+/// A `(MetadataPrivateKey, MetadataPublicKey)` SD-PKE keypair.
+pub struct MetadataKeyPair {
+    sk: MetadataPrivateKey,
+    pk: MetadataPublicKey,
+}
+
+impl MetadataKeyPair {
+    /// Returns the public key.
+    pub fn public_key(&self) -> &MetadataPublicKey {
+        &self.pk
+    }
+
+    /// Returns the private key.
+    pub fn private_key(&self) -> &MetadataPrivateKey {
+        &self.sk
+    }
+}
+
+/// SD-PKE ciphertext `(c, c')`: X-Wing encapsulation `c` together with HPKE
+/// ciphertext `c'`.
+pub struct MetadataCiphertext {
+    /// HPKE encapsulation output (`c` in the spec)
+    pub(crate) c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS],
+    /// HPKE AEAD ciphertext (`c'` / `cp` in the spec)
+    pub(crate) cp: Vec<u8>,
+}
+
+impl From<XWingPublicKey> for MetadataPublicKey {
+    fn from(key: XWingPublicKey) -> Self {
+        Self(key)
+    }
+}
+
+impl From<XWingPrivateKey> for MetadataPrivateKey {
+    fn from(key: XWingPrivateKey) -> Self {
+        Self(key)
+    }
+}
+
+/// SD-PKE.KGen: generate a `MetadataKeyPair`.
+///
+/// # Errors
+///
+/// Returns an error if X-Wing key generation fails.
+pub fn keygen<R: RngCore + CryptoRng>(rng: &mut R) -> Result<MetadataKeyPair, anyhow::Error> {
+    let (sk_s, pk_s) = generate_xwing_keypair(rng)?;
+    Ok(MetadataKeyPair {
+        sk: MetadataPrivateKey(sk_s),
+        pk: MetadataPublicKey(pk_s),
+    })
+}
+
+impl MetadataPublicKey {
+    /// SD-PKE.Enc: encrypt message `m` to this key, returning `(c, c')`.
+    pub fn encrypt(&self, m: &[u8]) -> MetadataCiphertext {
+        let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
+        let pk_r = self.0.clone().into();
+
+        // MetadataPublicKey always holds a valid XWing key, so seal cannot fail.
+        let (c_vec, cp) = hpke
+            .seal(&pk_r, b"", b"", m, None, None, None)
+            .expect("SD-PKE encryption failed");
+
+        // XWing will always produce this length ciphertext, so this .expect is fine.
+        let c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS] = c_vec
+            .try_into()
+            .expect("X-Wing encapsulation output has unexpected length");
+
+        MetadataCiphertext { c, cp }
+    }
+}
+
+impl MetadataPrivateKey {
+    /// SD-PKE.Dec: decrypt `(c, c')` using this key, returning message `m`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if HPKE decryption fails.
+    pub fn decrypt(&self, ct: &MetadataCiphertext) -> Result<Vec<u8>, Error> {
+        let hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
+        let sk_r = self.0.clone().into();
+
+        hpke.open(&ct.c, &sk_r, b"", b"", &ct.cp, None, None, None)
+            .map_err(|e| anyhow::anyhow!("SD-PKE decryption failed: {:?}", e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand_chacha::ChaCha20Rng;
+    use rand_core::SeedableRng;
+
+    #[test]
+    fn test_metadata_encrypt_decrypt_roundtrip() {
+        let mut rng = ChaCha20Rng::seed_from_u64(42);
+        let kp = keygen(&mut rng).expect("KGen failed");
+
+        let m = b"pk_S^AKEM || pk_S^PQ";
+        let ct = kp.public_key().encrypt(m);
+        let decrypted = kp.private_key().decrypt(&ct).expect("Decryption failed");
+
+        assert_eq!(m.as_slice(), decrypted.as_slice());
+    }
+
+    #[test]
+    fn test_metadata_decrypt_wrong_key_fails() {
+        let mut rng = ChaCha20Rng::seed_from_u64(42);
+        let kp = keygen(&mut rng).expect("KGen failed");
+        let wrong_kp = keygen(&mut rng).expect("KGen failed");
+
+        let ct = kp.public_key().encrypt(b"some sender apke key bytes");
+        assert!(wrong_kp.private_key().decrypt(&ct).is_err());
+    }
+}

--- a/securedrop-protocol/protocol-minimal/src/primitives.rs
+++ b/securedrop-protocol/protocol-minimal/src/primitives.rs
@@ -7,11 +7,10 @@ pub mod dh_akem;
 pub mod mlkem;
 pub mod pad;
 pub mod x25519;
-pub mod xwing;
+pub(crate) mod xwing;
 
 pub use crate::primitives::dh_akem::generate_dh_akem_keypair;
 pub use crate::primitives::mlkem::generate_mlkem768_keypair;
-pub use crate::primitives::xwing::generate_xwing_keypair;
 
 /// Fixed number of message ID entries to return in privacy-preserving fetch
 ///

--- a/securedrop-protocol/protocol-minimal/src/primitives/xwing.rs
+++ b/securedrop-protocol/protocol-minimal/src/primitives/xwing.rs
@@ -3,37 +3,37 @@ use libcrux_kem::{PrivateKey, PublicKey};
 use rand_core::{CryptoRng, RngCore};
 
 // From: https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/
-pub const XWING_PUBLIC_KEY_LEN: usize = 1216;
-pub const XWING_PRIVATE_KEY_LEN: usize = 32;
+pub(crate) const XWING_PUBLIC_KEY_LEN: usize = 1216;
+pub(crate) const XWING_PRIVATE_KEY_LEN: usize = 32;
 
 /// XWING public key.
 #[derive(Debug, Clone)]
-pub struct XWingPublicKey([u8; XWING_PUBLIC_KEY_LEN]);
+pub(crate) struct XWingPublicKey([u8; XWING_PUBLIC_KEY_LEN]);
 
 /// XWING private key.
 #[derive(Debug, Clone)]
-pub struct XWingPrivateKey([u8; XWING_PRIVATE_KEY_LEN]);
+pub(crate) struct XWingPrivateKey([u8; XWING_PRIVATE_KEY_LEN]);
 
 impl XWingPublicKey {
     /// Get the public key as bytes
-    pub fn as_bytes(&self) -> &[u8; XWING_PUBLIC_KEY_LEN] {
+    pub(crate) fn as_bytes(&self) -> &[u8; XWING_PUBLIC_KEY_LEN] {
         &self.0
     }
 
     /// Create from bytes
-    pub fn from_bytes(bytes: [u8; XWING_PUBLIC_KEY_LEN]) -> Self {
+    pub(crate) fn from_bytes(bytes: [u8; XWING_PUBLIC_KEY_LEN]) -> Self {
         Self(bytes)
     }
 }
 
 impl XWingPrivateKey {
     /// Get the private key as bytes
-    pub fn as_bytes(&self) -> &[u8; XWING_PRIVATE_KEY_LEN] {
+    pub(crate) fn as_bytes(&self) -> &[u8; XWING_PRIVATE_KEY_LEN] {
         &self.0
     }
 
     /// Create from bytes
-    pub fn from_bytes(bytes: [u8; XWING_PRIVATE_KEY_LEN]) -> Self {
+    pub(crate) fn from_bytes(bytes: [u8; XWING_PRIVATE_KEY_LEN]) -> Self {
         Self(bytes)
     }
 }
@@ -52,7 +52,7 @@ impl From<XWingPublicKey> for HpkePublicKey {
 
 /// Generate XWING keypair from external randomness
 /// FOR TEST PURPOSES ONLY
-pub fn deterministic_keygen(
+pub(crate) fn deterministic_keygen(
     randomness: [u8; 32],
 ) -> Result<(XWingPrivateKey, XWingPublicKey), anyhow::Error> {
     use libcrux_kem::{Algorithm, key_gen_derand};
@@ -119,7 +119,7 @@ fn typed(
 }
 
 /// Generate a new XWING keypair using libcrux_kem
-pub fn generate_xwing_keypair<R: RngCore + CryptoRng>(
+pub(crate) fn generate_xwing_keypair<R: RngCore + CryptoRng>(
     rng: &mut R,
 ) -> Result<(XWingPrivateKey, XWingPublicKey), anyhow::Error> {
     use libcrux_kem::{Algorithm, key_gen};

--- a/securedrop-protocol/protocol-minimal/src/server.rs
+++ b/securedrop-protocol/protocol-minimal/src/server.rs
@@ -206,6 +206,7 @@ impl Server {
                 signing_key,
                 fetching_key,
                 reply_key,
+                _reply_mlkem_key,
                 journalist_self_sig,
                 signed_pubkey_bytes,
                 newsroom_sig,

--- a/securedrop-protocol/protocol-minimal/src/source.rs
+++ b/securedrop-protocol/protocol-minimal/src/source.rs
@@ -1,5 +1,6 @@
 use crate::VerifyingKey;
 use crate::api::Api;
+use crate::metadata::{MetadataPublicKey, deterministic_keygen as kgen_deterministic_metadata};
 use crate::primitives::dh_akem::DhAkemPrivateKey;
 use crate::primitives::dh_akem::DhAkemPublicKey;
 use crate::primitives::dh_akem::deterministic_keygen as kgen_deterministic_dhakem;
@@ -8,8 +9,6 @@ use crate::primitives::mlkem::deterministic_keygen as kgen_deterministic_mlkem;
 use crate::primitives::x25519::DHPrivateKey;
 use crate::primitives::x25519::DHPublicKey;
 use crate::primitives::x25519::deterministic_dh_keygen;
-use crate::primitives::xwing::XWingPublicKey;
-use crate::primitives::xwing::deterministic_keygen as kgen_deterministic_xwing;
 use alloc::vec::Vec;
 use argon2::{Algorithm, Argon2, Params, Version};
 use rand_core::{CryptoRng, RngCore};
@@ -66,8 +65,8 @@ impl UserPublic for SourcePublicView {
         &self.message_pks.mlkem_pk
     }
 
-    fn message_metadata_pk(&self) -> &XWingPublicKey {
-        &self.message_pks.xwing_pk
+    fn message_metadata_pk(&self) -> &MetadataPublicKey {
+        &self.message_pks.metadata_pk
     }
 
     fn message_enc_pk(&self) -> &DhAkemPublicKey {
@@ -110,7 +109,7 @@ impl UserSecret for Source {
         fetch_pk.copy_from_slice(&self.fetch_key.pk.clone().into_bytes());
 
         let mut reply_key_pq_hybrid = [0u8; LEN_XWING_ENCAPS_KEY];
-        reply_key_pq_hybrid.copy_from_slice(self.message_keys.xwing_md.pk.as_bytes());
+        reply_key_pq_hybrid.copy_from_slice(self.message_keys.metadata_kp.public_key().as_bytes());
 
         Plaintext {
             sender_fetch_key: fetch_pk,
@@ -205,8 +204,8 @@ impl Source {
         let (mlkem_decaps, mlkem_encaps) =
             kgen_deterministic_mlkem(kem_result.into()).expect("Need MLKEM keygen");
 
-        let (xwing_decaps, xwing_encaps) =
-            kgen_deterministic_xwing(pke_result.into()).expect("Need X-Wing keygen");
+        let metadata_kp =
+            kgen_deterministic_metadata(pke_result.into()).expect("Need X-Wing keygen");
 
         let session = SessionStorage {
             fpf_key: None,
@@ -228,10 +227,7 @@ impl Source {
                     sk: mlkem_decaps,
                     pk: mlkem_encaps,
                 },
-                KeyPair {
-                    sk: xwing_decaps,
-                    pk: xwing_encaps,
-                },
+                metadata_kp,
             ),
             passphrase: passphrase.to_vec(),
             session,
@@ -305,18 +301,18 @@ mod tests {
 
         // Metadata keys
         assert_eq!(
-            source1.message_keys.xwing_md.pk.as_bytes(),
-            source2.message_keys.xwing_md.pk.as_bytes(),
+            source1.message_keys.metadata_kp.public_key().as_bytes(),
+            source2.message_keys.metadata_kp.public_key().as_bytes(),
             "XWING Encaps Key should be identical"
         );
         assert_eq!(
-            source1.message_keys.xwing_md.sk.as_bytes(),
-            source2.message_keys.xwing_md.sk.as_bytes(),
+            source1.message_keys.metadata_kp.private_key().as_bytes(),
+            source2.message_keys.metadata_kp.private_key().as_bytes(),
             "XWING Decaps Key should be identical"
         );
         assert_ne!(
-            *source1.message_keys.xwing_md.sk.as_bytes(),
-            [0u8; LEN_XWING_DECAPS_KEY]
+            source1.message_keys.metadata_kp.private_key().as_bytes(),
+            &[0u8; LEN_XWING_DECAPS_KEY]
         );
     }
 }

--- a/securedrop-protocol/protocol-minimal/src/source.rs
+++ b/securedrop-protocol/protocol-minimal/src/source.rs
@@ -101,10 +101,11 @@ impl UserSecret for Source {
         (&self.message_keys.dh_akem.sk, &self.message_keys.dh_akem.pk)
     }
 
-    fn build_message(&self, message: Vec<u8>) -> Plaintext {
-        let mut reply_key_pq_psk = [0u8; LEN_MLKEM_ENCAPS_KEY];
-        reply_key_pq_psk.copy_from_slice(self.message_keys.mlkem.pk.as_bytes());
+    fn message_psk_pk(&self) -> &MLKEM768PublicKey {
+        &self.message_keys.mlkem.pk
+    }
 
+    fn build_message(&self, message: Vec<u8>) -> Plaintext {
         let mut fetch_pk = [0u8; LEN_DH_ITEM];
         fetch_pk.copy_from_slice(&self.fetch_key.pk.clone().into_bytes());
 
@@ -112,7 +113,6 @@ impl UserSecret for Source {
         reply_key_pq_hybrid.copy_from_slice(self.message_keys.xwing_md.pk.as_bytes());
 
         Plaintext {
-            sender_reply_pubkey_pq_psk: reply_key_pq_psk,
             sender_fetch_key: fetch_pk,
             sender_reply_pubkey_hybrid: reply_key_pq_hybrid,
             msg: message,

--- a/securedrop-protocol/protocol-minimal/src/storage.rs
+++ b/securedrop-protocol/protocol-minimal/src/storage.rs
@@ -5,6 +5,7 @@ use rand_core::{CryptoRng, RngCore};
 use uuid::Uuid;
 
 use crate::primitives::dh_akem::DhAkemPublicKey;
+use crate::primitives::mlkem::MLKEM768PublicKey;
 use crate::primitives::x25519::DHPublicKey;
 use crate::sign::{JournalistLongTermKey, NewsroomOnJournalist, Signature, VerifyingKey};
 use crate::{Enrollment, Envelope, SignedKeyBundlePublic, SignedLongtermPubKeyBytes};
@@ -20,6 +21,7 @@ pub struct ServerStorage {
             VerifyingKey,
             DHPublicKey,
             DhAkemPublicKey,
+            MLKEM768PublicKey,
             Signature<JournalistLongTermKey>,
             SignedLongtermPubKeyBytes,
             Signature<NewsroomOnJournalist>,
@@ -119,6 +121,7 @@ impl ServerStorage {
             VerifyingKey,
             DHPublicKey,
             DhAkemPublicKey,
+            MLKEM768PublicKey,
             Signature<JournalistLongTermKey>,
             SignedLongtermPubKeyBytes,
             Signature<NewsroomOnJournalist>,
@@ -139,6 +142,7 @@ impl ServerStorage {
             journalist.keys.0,
             journalist.keys.1,
             journalist.keys.2,
+            journalist.keys.3,
             journalist.selfsig,
             journalist.bundle,
             newsroom_signature,
@@ -153,7 +157,7 @@ impl ServerStorage {
     ///
     /// TODO: Remove?
     pub fn find_journalist_by_verifying_key(&self, verifying_key: &VerifyingKey) -> Option<Uuid> {
-        for (journalist_id, (stored_vk, _, _, _, _, _)) in &self.journalists {
+        for (journalist_id, (stored_vk, _, _, _, _, _, _)) in &self.journalists {
             if stored_vk.into_bytes() == verifying_key.into_bytes() {
                 return Some(*journalist_id);
             }

--- a/securedrop-protocol/protocol-minimal/src/traits.rs
+++ b/securedrop-protocol/protocol-minimal/src/traits.rs
@@ -66,6 +66,7 @@ pub trait UserSecret: private::Sealed {
     fn num_bundles(&self) -> usize;
     fn fetch_keypair(&self) -> (&DHPrivateKey, &DHPublicKey);
     fn message_auth_keypair(&self) -> (&DhAkemPrivateKey, &DhAkemPublicKey);
+    fn message_psk_pk(&self) -> &MLKEM768PublicKey;
     fn build_message(&self, message: Vec<u8>) -> Plaintext;
     fn keybundles(&self) -> impl Iterator<Item = &MessageKeyBundle>;
 }

--- a/securedrop-protocol/protocol-minimal/src/traits.rs
+++ b/securedrop-protocol/protocol-minimal/src/traits.rs
@@ -1,10 +1,10 @@
 use crate::VerifyingKey;
+use crate::metadata::MetadataPublicKey;
 use crate::primitives::dh_akem::DhAkemPrivateKey;
 use crate::primitives::dh_akem::DhAkemPublicKey;
 use crate::primitives::mlkem::MLKEM768PublicKey;
 use crate::primitives::x25519::DHPrivateKey;
 use crate::primitives::x25519::DHPublicKey;
-use crate::primitives::xwing::XWingPublicKey;
 use crate::sign::{JournalistEphemeralKey, JournalistLongTermKey, Signature};
 use alloc::vec::Vec;
 
@@ -34,7 +34,7 @@ pub trait UserPublic {
     fn fetch_pk(&self) -> &DHPublicKey;
     fn message_auth_pk(&self) -> &DhAkemPublicKey;
     fn message_psk_pk(&self) -> &MLKEM768PublicKey;
-    fn message_metadata_pk(&self) -> &XWingPublicKey;
+    fn message_metadata_pk(&self) -> &MetadataPublicKey;
     fn message_enc_pk(&self) -> &DhAkemPublicKey;
 }
 


### PR DESCRIPTION
Followup to #197, similar idea, aligning the code and spec for step 6:
* Adds prose description of step 6
* The plaintext had an additional field `sender_reply_pubkey_pq_psk` which is not included in the `pt` in step 6 in the spec, so I've removed it. The APKE plaintext now is just the message, the fetching key, and the PKE/metadata key as in the spec. The byte ordering differs from the spec, which I've left as is for now and opened #207 to track.
* The long-term journalist APKE key lacked the ML-KEM component, added that (per discussion in #161 / #195) 
* I've sprinkled a few notes in terms of what's going on in `encrypt` with respect to the spec (the comments prefixed with `// spec:`) to make the two refactors in #206 and #196 easier