### PR TITLE
[stacked PR 2] refactor: add SD-PKE abstraction

### DIFF
--- a/securedrop-protocol/bench/src/encrypt_decrypt.rs
+++ b/securedrop-protocol/bench/src/encrypt_decrypt.rs
@@ -15,9 +15,8 @@ use securedrop_protocol_minimal::{
     Envelope, FetchResponse, Journalist, Plaintext, Source, UserPublic, UserSecret,
 };
 
-use securedrop_protocol_minimal::encrypt_decrypt::{
-    LEN_DH_ITEM, LEN_MLKEM_ENCAPS_KEY, LEN_XWING_ENCAPS_KEY,
-};
+use securedrop_protocol_minimal::LEN_XWING_ENCAPS_KEY;
+use securedrop_protocol_minimal::encrypt_decrypt::{LEN_DH_ITEM, LEN_MLKEM_ENCAPS_KEY};
 
 #[inline]
 fn rng_from_seed(seed32: [u8; 32]) -> ChaCha20Rng {

--- a/securedrop-protocol/protocol-minimal/src/ciphertext.rs
+++ b/securedrop-protocol/protocol-minimal/src/ciphertext.rs
@@ -1,4 +1,8 @@
-use crate::constants::*;
+use crate::constants::{
+    LEN_DH_ITEM, LEN_DHKEM_SHAREDSECRET_ENCAPS, LEN_KMID, LEN_MLKEM_SHAREDSECRET_ENCAPS,
+    LEN_XWING_ENCAPS_KEY,
+};
+use crate::metadata::MetadataCiphertext;
 use alloc::vec::Vec;
 use anyhow::Error;
 
@@ -65,11 +69,8 @@ pub struct Envelope {
     // see CombinedCiphertext
     pub(crate) cmessage: Vec<u8>,
 
-    // baseenc "metadata", aka sender pubkey
-    pub(crate) cmetadata: Vec<u8>,
-
-    // "metadata" encaps shared secret
-    pub(crate) metadata_encap: [u8; LEN_XWING_SHAREDSECRET_ENCAPS],
+    // SD-PKE ciphertext (c, c'): encrypted sender APKE public key tuple
+    pub(crate) ct_pke: MetadataCiphertext,
 
     // clue material
     pub(crate) mgdh_pubkey: [u8; LEN_DH_ITEM],
@@ -79,16 +80,16 @@ pub struct Envelope {
 impl Envelope {
     // Used for benchmarks - see wasm_bindgen
     pub fn size_hint(&self) -> usize {
-        self.cmessage.len() + self.cmetadata.len()
+        self.cmessage.len() + self.cmetadata_len()
     }
 
     pub fn cmessage_len(&self) -> usize {
         self.cmessage.len()
     }
 
-    // sender dh-akem pubkey bytes
+    // SD-PKE ciphertext byte length: encapsulation c + AEAD ciphertext c'
     pub fn cmetadata_len(&self) -> usize {
-        self.cmetadata.len()
+        self.ct_pke.len()
     }
 }
 

--- a/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
+++ b/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
@@ -1,3 +1,4 @@
+use crate::constants::LEN_XWING_ENCAPS_KEY;
 use crate::primitives::dh_akem::DH_AKEM_PUBLIC_KEY_LEN;
 use crate::primitives::dh_akem::DhAkemPublicKey;
 use crate::primitives::x25519::DHPublicKey;
@@ -17,7 +18,7 @@ use hpke_rs::HpkePrivateKey;
 use hpke_rs::HpkePublicKey;
 use hpke_rs::hpke_types::AeadAlgorithm::Aes256Gcm;
 use hpke_rs::hpke_types::KdfAlgorithm::HkdfSha256;
-use hpke_rs::hpke_types::KemAlgorithm::{DhKem25519, XWingDraft06};
+use hpke_rs::hpke_types::KemAlgorithm::DhKem25519;
 use hpke_rs::libcrux::HpkeLibcrux;
 use hpke_rs::{Hpke, Mode};
 use libcrux_kem::MlKem768;
@@ -29,8 +30,6 @@ use uuid::Uuid;
 const NR_ID: &[u8] = b"MOCK_NEWSROOM_ID";
 
 const HPKE_PSK_ID: &[u8] = b"PSK_INFO_ID_TAG"; // authpsk only, required by spec
-const HPKE_BASE_AAD: &[u8] = b""; // base only; in authpsk mode the NR_ID is supplied
-const HPKE_BASE_INFO: &[u8] = b""; // base mode only
 
 // Key lengths
 const LEN_DHKEM_ENCAPS_KEY: usize = libcrux_curve25519::EK_LEN;
@@ -46,13 +45,6 @@ const LEN_MLKEM_DECAPS_KEY: usize = 2400;
 const LEN_MLKEM_SHAREDSECRET_ENCAPS: usize = 1088;
 const LEN_MLKEM_SHAREDSECRET: usize = 32;
 const LEN_MLKEM_RAND_SEED_SIZE: usize = 64;
-
-// https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/#name-encoding-and-sizes
-pub const LEN_XWING_ENCAPS_KEY: usize = 1216;
-const LEN_XWING_DECAPS_KEY: usize = 32;
-const LEN_XWING_SHAREDSECRET_ENCAPS: usize = 1120;
-const LEN_XWING_SHAREDSECRET: usize = 32;
-const LEN_XWING_RAND_SEED_SIZE: usize = 96;
 
 // Message ID (uuid) and KMID
 const LEN_MESSAGE_ID: usize = 16;
@@ -78,9 +70,6 @@ where
 {
     let mut hpke_authenc: Hpke<HpkeLibcrux> =
         Hpke::new(Mode::AuthPsk, DhKem25519, HkdfSha256, Aes256Gcm);
-
-    let mut hpke_metadata: Hpke<HpkeLibcrux> =
-        Hpke::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
 
     // spec: pk_R^AKEM: the DH-AKEM component of the recipient's APKE key bundle
     let recipient_message_enc_dhakem_pub = recipient.message_enc_pk().clone().into();
@@ -145,31 +134,8 @@ where
     sender_apke_bytes.extend_from_slice(sender.message_auth_keypair().1.as_bytes()); // pk_S^AKEM (DH-AKEM)
     sender_apke_bytes.extend_from_slice(sender.message_psk_pk().as_bytes()); // pk_S^PQ (ML-KEM)
 
-    // Encapsulate the full sender APKE public key tuple to the recipient's metadata key
-    // (xwing) in HPKE Base mode:
-    // https://www.rfc-editor.org/rfc/rfc9180.html#name-metadata-protection
-    // Although we do use a PSK and PSK_ID in the message, we don't need to
-    // encrypt the message PSK_ID, because it is a hard-coded string
-    let recipient_md_pubkey = recipient.message_metadata_pk().clone().into();
-
-    // spec: SD-PKE.Enc
-    let (md_ss_encaps_vec, metadata_ciphertext) = hpke_metadata
-        .seal(
-            &recipient_md_pubkey,
-            HPKE_BASE_INFO, // b""
-            HPKE_BASE_AAD,  // b""
-            &sender_apke_bytes,
-            None,
-            None,
-            None,
-        )
-        .expect("Expected Hpke.BaseMode sealed ciphertext");
-
-    let metadata_ss_encaps: [u8; LEN_XWING_SHAREDSECRET_ENCAPS] =
-        md_ss_encaps_vec.try_into().expect(&format!(
-            "Need {} byte encapsulated shared secret",
-            LEN_XWING_SHAREDSECRET_ENCAPS
-        ));
+    // spec: ct^PKE = SD-PKE.Enc(pk_R^PKE, pk_S^APKE)
+    let ct_pke = recipient.message_metadata_pk().encrypt(&sender_apke_bytes);
 
     let cmessage = CombinedCiphertext {
         message_dhakem_ss_encap: dhakem_ss_encaps_bytes,
@@ -181,57 +147,31 @@ where
     // Send (C_S, X, Z) to server
     Envelope {
         cmessage: cmessage.to_bytes(),        // ct^APKE
-        cmetadata: metadata_ciphertext,       // ct^PKE ciphertext
-        metadata_encap: metadata_ss_encaps,   // ct^PKE encapsulation
+        ct_pke,                               // ct^PKE
         mgdh_pubkey: hint_epk.into_bytes(),   // X = g^x
         mgdh: hint_sharedsecret.into_bytes(), // Z = (pk_R^fetch)^x
     }
 }
 
 pub fn decrypt<U: UserSecret + ?Sized>(receiver: &U, envelope: &Envelope) -> Plaintext {
-    use hpke_rs::hpke_types::AeadAlgorithm::Aes256Gcm;
-    use hpke_rs::hpke_types::KdfAlgorithm::HkdfSha256;
-    use hpke_rs::hpke_types::KemAlgorithm::{DhKem25519, XWingDraft06};
-    use hpke_rs::{Hpke, Mode};
-
     let hpke_authenc: Hpke<HpkeLibcrux> =
         Hpke::new(Mode::AuthPsk, DhKem25519, HkdfSha256, Aes256Gcm);
 
-    let hpke_base: Hpke<HpkeLibcrux> = Hpke::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
-
-    // Receiver needs to know which keybundle to use, so they have to trial decrypt
-    // metadata.
-    // Explanation of what's happening:
-    // - for each keybundle, trial-decrypt the metadata using
-    // hpke_base::open (yields Result<metadata_bytes, HpkeError>)
-    // - filter only the successful ones (Ok) and
-    // - collect the successful decryptions (Vec<u8>) mapped to the
-    // correct keybundle, and
-    // - return the results of that collection.
-    // There should be exactly 1 result.
+    // Trial-decrypt ct^PKE with each keybundle's metadata private key to find
+    // the intended recipient's bundle. There should be exactly 1 result.
     let results: Vec<(&MessageKeyBundle, Vec<u8>)> = receiver
         .keybundles()
         .filter_map(|bundle| {
-            {
-                let md_key = bundle.xwing_md.sk.clone().into();
-
-                hpke_base.open(
-                    &envelope.metadata_encap,
-                    &md_key,
-                    HPKE_BASE_INFO,
-                    HPKE_BASE_AAD,
-                    &envelope.cmetadata,
-                    None,
-                    None,
-                    None,
-                )
-            }
-            .ok()
-            .map(|decrypted_metadata| (bundle, decrypted_metadata))
+            bundle
+                .metadata_kp
+                .private_key()
+                .decrypt(&envelope.ct_pke)
+                .ok()
+                .map(|m| (bundle, m))
         })
         .collect();
 
-    // Sanity
+    // Sanity check
     debug_assert_eq!(results.len(), 1);
 
     // Unpack the results of the trial decryption, yielding metadata and correct decryption keys
@@ -400,13 +340,12 @@ mod tests {
     use rand_core::SeedableRng;
 
     use crate::{
-        DhAkemKeyPair, Journalist, KeyBundlePublic, KeyPair, MlKem768KeyPair, Source, XWingKeyPair,
+        DhAkemKeyPair, Journalist, KeyBundlePublic, KeyPair, MlKem768KeyPair, Source,
         primitives::{
             dh_akem::DhAkemPrivateKey,
-            generate_dh_akem_keypair, generate_mlkem768_keypair, generate_xwing_keypair,
+            generate_dh_akem_keypair, generate_mlkem768_keypair,
             mlkem::{MLKEM768PrivateKey, MLKEM768PublicKey},
             x25519::DHPrivateKey,
-            xwing::{XWingPrivateKey, XWingPublicKey},
         },
         private,
     };

--- a/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
+++ b/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
@@ -1,4 +1,5 @@
 use crate::constants::LEN_XWING_ENCAPS_KEY;
+use crate::metadata;
 use crate::primitives::dh_akem::DH_AKEM_PUBLIC_KEY_LEN;
 use crate::primitives::dh_akem::DhAkemPublicKey;
 use crate::primitives::x25519::DHPublicKey;
@@ -135,7 +136,7 @@ where
     sender_apke_bytes.extend_from_slice(sender.message_psk_pk().as_bytes()); // pk_S^PQ (ML-KEM)
 
     // spec: ct^PKE = SD-PKE.Enc(pk_R^PKE, pk_S^APKE)
-    let ct_pke = recipient.message_metadata_pk().encrypt(&sender_apke_bytes);
+    let ct_pke = metadata::encrypt(recipient.message_metadata_pk(), &sender_apke_bytes);
 
     let cmessage = CombinedCiphertext {
         message_dhakem_ss_encap: dhakem_ss_encaps_bytes,
@@ -162,10 +163,7 @@ pub fn decrypt<U: UserSecret + ?Sized>(receiver: &U, envelope: &Envelope) -> Pla
     let results: Vec<(&MessageKeyBundle, Vec<u8>)> = receiver
         .keybundles()
         .filter_map(|bundle| {
-            bundle
-                .metadata_kp
-                .private_key()
-                .decrypt(&envelope.ct_pke)
+            metadata::decrypt(bundle.metadata_kp.private_key(), &envelope.ct_pke)
                 .ok()
                 .map(|m| (bundle, m))
         })

--- a/securedrop-protocol/protocol-minimal/src/journalist.rs
+++ b/securedrop-protocol/protocol-minimal/src/journalist.rs
@@ -2,6 +2,7 @@ use crate::VerifyingKey;
 use crate::api::Api;
 use crate::api::JournalistApi;
 use crate::api::restricted;
+use crate::metadata::{MetadataPublicKey, keygen as metadata_keygen};
 use crate::primitives::dh_akem::DhAkemPrivateKey;
 use crate::primitives::dh_akem::DhAkemPublicKey;
 use crate::primitives::dh_akem::generate_dh_akem_keypair;
@@ -10,8 +11,6 @@ use crate::primitives::mlkem::generate_mlkem768_keypair;
 use crate::primitives::x25519::DHPrivateKey;
 use crate::primitives::x25519::DHPublicKey;
 use crate::primitives::x25519::generate_dh_keypair;
-use crate::primitives::xwing::XWingPublicKey;
-use crate::primitives::xwing::generate_xwing_keypair;
 use crate::sign::{JournalistEphemeralKey, JournalistLongTermKey, Signature, SigningKey};
 use alloc::vec::Vec;
 use rand_core::{CryptoRng, RngCore};
@@ -82,8 +81,8 @@ impl UserPublic for JournalistPublicView {
         &self.kb.0.mlkem_pk
     }
 
-    fn message_metadata_pk(&self) -> &XWingPublicKey {
-        &self.kb.0.xwing_pk
+    fn message_metadata_pk(&self) -> &MetadataPublicKey {
+        &self.kb.0.metadata_pk
     }
 
     fn message_enc_pk(&self) -> &DhAkemPublicKey {
@@ -219,8 +218,7 @@ impl Journalist {
             let (sk_pqkem_psk, pk_pqkem_psk) =
                 generate_mlkem768_keypair(rng).expect("Failed to generate ml-kem keys!");
 
-            let (sk_md, pk_md) =
-                generate_xwing_keypair(rng).expect("Failed to generate xwing keys");
+            let metadata_kp = metadata_keygen(rng).expect("Failed to generate metadata keys");
 
             let bundle = MessageKeyBundle::new(
                 KeyPair {
@@ -231,10 +229,7 @@ impl Journalist {
                     sk: sk_pqkem_psk,
                     pk: pk_pqkem_psk,
                 },
-                KeyPair {
-                    sk: sk_md,
-                    pk: pk_md,
-                },
+                metadata_kp,
             );
 
             let pubkey_bytes = bundle.public().as_bytes();
@@ -324,12 +319,20 @@ mod tests {
                 kbs[i].mlkem.pk.as_bytes()
             );
             assert_eq!(
-                journalist.message_keys[i].bundle.xwing_md.sk.as_bytes(),
-                kbs[i].xwing_md.sk.as_bytes()
+                journalist.message_keys[i]
+                    .bundle
+                    .metadata_kp
+                    .private_key()
+                    .as_bytes(),
+                kbs[i].metadata_kp.private_key().as_bytes()
             );
             assert_eq!(
-                journalist.message_keys[i].bundle.xwing_md.pk.as_bytes(),
-                kbs[i].xwing_md.pk.as_bytes()
+                journalist.message_keys[i]
+                    .bundle
+                    .metadata_kp
+                    .public_key()
+                    .as_bytes(),
+                kbs[i].metadata_kp.public_key().as_bytes()
             );
         }
     }

--- a/securedrop-protocol/protocol-minimal/src/keys.rs
+++ b/securedrop-protocol/protocol-minimal/src/keys.rs
@@ -7,14 +7,13 @@ use crate::sign::{
     VerifyingKey,
 };
 
+use crate::metadata::{MetadataKeyPair, MetadataPublicKey};
 use crate::primitives::dh_akem::DhAkemPrivateKey;
 use crate::primitives::dh_akem::DhAkemPublicKey;
 use crate::primitives::mlkem::MLKEM768PrivateKey;
 use crate::primitives::mlkem::MLKEM768PublicKey;
 use crate::primitives::x25519::DHPrivateKey;
 use crate::primitives::x25519::DHPublicKey;
-use crate::primitives::xwing::XWingPrivateKey;
-use crate::primitives::xwing::XWingPublicKey;
 use alloc::vec::Vec;
 
 use crate::constants::*;
@@ -32,7 +31,6 @@ pub type DhAkemKeyPair = KeyPair<DhAkemPrivateKey, DhAkemPublicKey>;
 // eventually: ristretto255
 pub type DhFetchKeyPair = KeyPair<DHPrivateKey, DHPublicKey>;
 pub type SigningKeyPair = KeyPair<SigningKey, VerifyingKey>;
-pub type XWingKeyPair = KeyPair<XWingPrivateKey, XWingPublicKey>;
 
 /// The public half of an ephemeral key bundle together with the journalist's
 /// self-signature over it.
@@ -43,15 +41,15 @@ pub type SignedKeyBundlePublic = (KeyBundlePublic, Signature<JournalistEphemeral
 /// Each bundle contains one key for each cryptographic role:
 /// - `dhakem_pk`: SD-APKE ephemeral key (`pk_{J,i}^{APKE_E}`), DHKEM(X25519) component
 /// - `mlkem_pk`: SD-APKE ephemeral key (`pk_{J,i}^{APKE_E}`), ML-KEM-768 component
-/// - `xwing_pk`: SD-PKE ephemeral key (`pk_{J,i}^{PKE_E}`), X-Wing
+/// - `metadata_pk`: SD-PKE ephemeral key (`pk_{J,i}^{PKE_E}`), X-Wing
 #[derive(Debug, Clone)]
 pub struct KeyBundlePublic {
     /// DHKEM(X25519) component of the ephemeral SD-APKE key.
     pub dhakem_pk: DhAkemPublicKey,
     /// ML-KEM-768 component of the ephemeral SD-APKE key.
     pub mlkem_pk: MLKEM768PublicKey,
-    /// X-Wing ephemeral SD-PKE key, used for metadata protection.
-    pub xwing_pk: XWingPublicKey,
+    /// SD-PKE ephemeral key, used for metadata protection.
+    pub metadata_pk: MetadataPublicKey,
 }
 
 impl KeyBundlePublic {
@@ -62,7 +60,7 @@ impl KeyBundlePublic {
         let mut out = Vec::new();
         out.extend(self.dhakem_pk.as_bytes());
         out.extend(self.mlkem_pk.as_bytes());
-        out.extend(self.xwing_pk.as_bytes());
+        out.extend(self.metadata_pk.as_bytes());
         out
     }
 }
@@ -70,11 +68,15 @@ impl KeyBundlePublic {
 pub(crate) struct MessageKeyBundle {
     pub(crate) dh_akem: DhAkemKeyPair,
     pub(crate) mlkem: MlKem768KeyPair,
-    pub(crate) xwing_md: XWingKeyPair,
+    pub(crate) metadata_kp: MetadataKeyPair,
 }
 
 impl MessageKeyBundle {
-    pub fn new(dh_akem: DhAkemKeyPair, mlkem: MlKem768KeyPair, xwing_md: XWingKeyPair) -> Self {
+    pub fn new(
+        dh_akem: DhAkemKeyPair,
+        mlkem: MlKem768KeyPair,
+        metadata_kp: MetadataKeyPair,
+    ) -> Self {
         // // ID is derived from pubkey hashes in specific order
         // let mut hasher = libcrux_sha2::Sha256::default();
 
@@ -88,7 +90,7 @@ impl MessageKeyBundle {
         Self {
             dh_akem,
             mlkem,
-            xwing_md,
+            metadata_kp,
         }
     }
 
@@ -96,7 +98,7 @@ impl MessageKeyBundle {
         KeyBundlePublic {
             dhakem_pk: self.dh_akem.pk.clone(),
             mlkem_pk: self.mlkem.pk.clone(),
-            xwing_pk: self.xwing_md.pk.clone(),
+            metadata_pk: self.metadata_kp.public_key().clone(),
         }
     }
 }

--- a/securedrop-protocol/protocol-minimal/src/lib.rs
+++ b/securedrop-protocol/protocol-minimal/src/lib.rs
@@ -41,3 +41,4 @@ pub use sign::{
 pub mod storage;
 
 pub mod encrypt_decrypt;
+pub mod metadata;

--- a/securedrop-protocol/protocol-minimal/src/lib.rs
+++ b/securedrop-protocol/protocol-minimal/src/lib.rs
@@ -20,7 +20,7 @@ pub use ciphertext::{CombinedCiphertext, Envelope, FetchResponse, Plaintext};
 
 pub use keys::{
     DhAkemKeyPair, DhFetchKeyPair, Enrollment, KeyBundlePublic, KeyPair, MlKem768KeyPair,
-    SessionStorage, SignedKeyBundlePublic, SignedLongtermPubKeyBytes, SigningKeyPair, XWingKeyPair,
+    SessionStorage, SignedKeyBundlePublic, SignedLongtermPubKeyBytes, SigningKeyPair,
 };
 
 pub use traits::{Enrollable, JournalistPublic, UserPublic, UserSecret};

--- a/securedrop-protocol/protocol-minimal/src/metadata.rs
+++ b/securedrop-protocol/protocol-minimal/src/metadata.rs
@@ -103,26 +103,6 @@ impl MetadataPublicKey {
     pub fn as_bytes(&self) -> &[u8] {
         self.0.as_bytes()
     }
-
-    /// SD-PKE.Enc: encrypt message `m` to this key, returning `(c, c')`.
-    ///
-    /// `m` is the sender's serialized long-term APKE public key.
-    pub fn encrypt(&self, m: &[u8]) -> MetadataCiphertext {
-        let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
-        let pk_r = self.0.clone().into();
-
-        // MetadataPublicKey always holds a valid XWing key, so seal cannot fail.
-        let (c_vec, cp) = hpke
-            .seal(&pk_r, b"", b"", m, None, None, None)
-            .expect("SD-PKE encryption failed");
-
-        // XWing will always produce this length ciphertext, so this .expect is fine.
-        let c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS] = c_vec
-            .try_into()
-            .expect("X-Wing encapsulation output has unexpected length");
-
-        MetadataCiphertext { c, cp }
-    }
 }
 
 impl MetadataPrivateKey {
@@ -131,19 +111,39 @@ impl MetadataPrivateKey {
     pub(crate) fn as_bytes(&self) -> &[u8] {
         self.0.as_bytes()
     }
+}
 
-    /// SD-PKE.Dec: decrypt `(c, c')` using this key, returning message `m`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if HPKE decryption fails.
-    pub fn decrypt(&self, ct: &MetadataCiphertext) -> Result<Vec<u8>, Error> {
-        let hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
-        let sk_r = self.0.clone().into();
+/// SD-PKE.Enc: encrypt message `m` to recipient key `pk_r`, returning `(c, c')`.
+///
+/// `m` is the sender's serialized long-term APKE public key.
+pub fn encrypt(pk_r: &MetadataPublicKey, m: &[u8]) -> MetadataCiphertext {
+    let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
+    let pk_r_hpke = pk_r.0.clone().into();
 
-        hpke.open(&ct.c, &sk_r, b"", b"", &ct.cp, None, None, None)
-            .map_err(|e| anyhow::anyhow!("SD-PKE decryption failed: {:?}", e))
-    }
+    // MetadataPublicKey always holds a valid XWing key, so seal cannot fail.
+    let (c_vec, cp) = hpke
+        .seal(&pk_r_hpke, b"", b"", m, None, None, None)
+        .expect("SD-PKE encryption failed");
+
+    // XWing will always produce this length ciphertext, so this .expect is fine.
+    let c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS] = c_vec
+        .try_into()
+        .expect("X-Wing encapsulation output has unexpected length");
+
+    MetadataCiphertext { c, cp }
+}
+
+/// SD-PKE.Dec: decrypt `(c, c')` using recipient key `sk_r`, returning message `m`.
+///
+/// # Errors
+///
+/// Returns an error if HPKE decryption fails.
+pub fn decrypt(sk_r: &MetadataPrivateKey, ct: &MetadataCiphertext) -> Result<Vec<u8>, Error> {
+    let hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
+    let sk_r_hpke = sk_r.0.clone().into();
+
+    hpke.open(&ct.c, &sk_r_hpke, b"", b"", &ct.cp, None, None, None)
+        .map_err(|e| anyhow::anyhow!("SD-PKE decryption failed: {:?}", e))
 }
 
 #[cfg(test)]
@@ -165,8 +165,8 @@ mod tests {
             let mut rng = get_rng();
             let kp = keygen(&mut rng).expect("KGen failed");
 
-            let ct = kp.public_key().encrypt(&m);
-            let decrypted = kp.private_key().decrypt(&ct).expect("Decryption failed");
+            let ct = encrypt(kp.public_key(), &m);
+            let decrypted = decrypt(kp.private_key(), &ct).expect("Decryption failed");
 
             prop_assert_eq!(m, decrypted);
         }
@@ -178,7 +178,7 @@ mod tests {
         let kp = keygen(&mut rng).expect("KGen failed");
         let wrong_kp = keygen(&mut rng).expect("KGen failed");
 
-        let ct = kp.public_key().encrypt(b"some sender apke key bytes");
-        assert!(wrong_kp.private_key().decrypt(&ct).is_err());
+        let ct = encrypt(kp.public_key(), b"some sender apke key bytes");
+        assert!(decrypt(wrong_kp.private_key(), &ct).is_err());
     }
 }

--- a/securedrop-protocol/protocol-minimal/src/metadata.rs
+++ b/securedrop-protocol/protocol-minimal/src/metadata.rs
@@ -105,6 +105,8 @@ impl MetadataPublicKey {
     }
 
     /// SD-PKE.Enc: encrypt message `m` to this key, returning `(c, c')`.
+    ///
+    /// `m` is the sender's serialized long-term APKE public key.
     pub fn encrypt(&self, m: &[u8]) -> MetadataCiphertext {
         let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
         let pk_r = self.0.clone().into();

--- a/securedrop-protocol/protocol-minimal/src/metadata.rs
+++ b/securedrop-protocol/protocol-minimal/src/metadata.rs
@@ -17,12 +17,10 @@
 
 use alloc::vec::Vec;
 use anyhow::Error;
-use hpke_rs::Hpke;
-use hpke_rs::Mode;
-use hpke_rs::hpke_types::AeadAlgorithm::Aes256Gcm;
-use hpke_rs::hpke_types::KdfAlgorithm::HkdfSha256;
-use hpke_rs::hpke_types::KemAlgorithm::XWingDraft06;
-use hpke_rs::libcrux::HpkeLibcrux;
+use hpke_rs::{
+    Hpke, Mode, hpke_types::AeadAlgorithm::Aes256Gcm, hpke_types::KdfAlgorithm::HkdfSha256,
+    hpke_types::KemAlgorithm::XWingDraft06, libcrux::HpkeLibcrux,
+};
 use rand_core::{CryptoRng, RngCore};
 
 use crate::constants::LEN_XWING_SHAREDSECRET_ENCAPS;
@@ -124,24 +122,32 @@ impl MetadataPrivateKey {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
     use rand_chacha::ChaCha20Rng;
     use rand_core::SeedableRng;
 
-    #[test]
-    fn test_metadata_encrypt_decrypt_roundtrip() {
-        let mut rng = ChaCha20Rng::seed_from_u64(42);
-        let kp = keygen(&mut rng).expect("KGen failed");
+    fn get_rng() -> ChaCha20Rng {
+        let mut seed = [0u8; 32];
+        getrandom::fill(&mut seed).expect("OS random source failed");
+        ChaCha20Rng::from_seed(seed)
+    }
 
-        let m = b"pk_S^AKEM || pk_S^PQ";
-        let ct = kp.public_key().encrypt(m);
-        let decrypted = kp.private_key().decrypt(&ct).expect("Decryption failed");
+    proptest! {
+        #[test]
+        fn test_metadata_encrypt_decrypt_roundtrip(m in proptest::collection::vec(any::<u8>(), 0..200)) {
+            let mut rng = get_rng();
+            let kp = keygen(&mut rng).expect("KGen failed");
 
-        assert_eq!(m.as_slice(), decrypted.as_slice());
+            let ct = kp.public_key().encrypt(&m);
+            let decrypted = kp.private_key().decrypt(&ct).expect("Decryption failed");
+
+            prop_assert_eq!(m, decrypted);
+        }
     }
 
     #[test]
     fn test_metadata_decrypt_wrong_key_fails() {
-        let mut rng = ChaCha20Rng::seed_from_u64(42);
+        let mut rng = get_rng();
         let kp = keygen(&mut rng).expect("KGen failed");
         let wrong_kp = keygen(&mut rng).expect("KGen failed");
 

--- a/securedrop-protocol/protocol-minimal/src/metadata.rs
+++ b/securedrop-protocol/protocol-minimal/src/metadata.rs
@@ -27,6 +27,7 @@ use crate::constants::LEN_XWING_SHAREDSECRET_ENCAPS;
 use crate::primitives::xwing::{XWingPrivateKey, XWingPublicKey, generate_xwing_keypair};
 
 /// The recipient's metadata public key (`pk_R^PKE` in the spec).
+#[derive(Debug, Clone)]
 pub struct MetadataPublicKey(pub(crate) XWingPublicKey);
 
 /// The recipient's metadata private key (`sk_R^PKE` in the spec).
@@ -52,6 +53,7 @@ impl MetadataKeyPair {
 
 /// SD-PKE ciphertext `(c, c')`: X-Wing encapsulation `c` together with HPKE
 /// ciphertext `c'`.
+#[derive(Debug, Clone)]
 pub struct MetadataCiphertext {
     /// HPKE encapsulation output (`c` in the spec)
     pub(crate) c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS],
@@ -59,15 +61,10 @@ pub struct MetadataCiphertext {
     pub(crate) cp: Vec<u8>,
 }
 
-impl From<XWingPublicKey> for MetadataPublicKey {
-    fn from(key: XWingPublicKey) -> Self {
-        Self(key)
-    }
-}
-
-impl From<XWingPrivateKey> for MetadataPrivateKey {
-    fn from(key: XWingPrivateKey) -> Self {
-        Self(key)
+impl MetadataCiphertext {
+    /// Total byte length of the ciphertext: encapsulation `c` + AEAD ciphertext `c'`.
+    pub fn len(&self) -> usize {
+        self.c.len() + self.cp.len()
     }
 }
 
@@ -84,7 +81,29 @@ pub fn keygen<R: RngCore + CryptoRng>(rng: &mut R) -> Result<MetadataKeyPair, an
     })
 }
 
+/// SD-PKE.KGen (deterministic): derive a `MetadataKeyPair` from 32 bytes of seed material.
+///
+/// For use in passphrase-derived key generation only; do not use with random bytes
+/// from a live RNG (use [`keygen`] instead).
+///
+/// # Errors
+///
+/// Returns an error if X-Wing key generation fails.
+pub(crate) fn deterministic_keygen(randomness: [u8; 32]) -> Result<MetadataKeyPair, anyhow::Error> {
+    use crate::primitives::xwing::deterministic_keygen as xwing_derand;
+    let (sk_s, pk_s) = xwing_derand(randomness)?;
+    Ok(MetadataKeyPair {
+        sk: MetadataPrivateKey(sk_s),
+        pk: MetadataPublicKey(pk_s),
+    })
+}
+
 impl MetadataPublicKey {
+    /// Returns the public key as bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+
     /// SD-PKE.Enc: encrypt message `m` to this key, returning `(c, c')`.
     pub fn encrypt(&self, m: &[u8]) -> MetadataCiphertext {
         let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
@@ -105,6 +124,12 @@ impl MetadataPublicKey {
 }
 
 impl MetadataPrivateKey {
+    /// Returns the private key as bytes.
+    #[cfg(test)]
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+
     /// SD-PKE.Dec: decrypt `(c, c')` using this key, returning message `m`.
     ///
     /// # Errors

--- a/securedrop-protocol/protocol-minimal/src/metadata.rs
+++ b/securedrop-protocol/protocol-minimal/src/metadata.rs
@@ -1,0 +1,151 @@
+//! SD-PKE: metadata encryption
+//!
+//! Spec pseudocode:
+//! ```text
+//! def KGen():
+//!     (skS, pkS) = KEM_H.KGen()
+//!     return (skS, pkS)
+//!
+//! def Enc(pkR, m):
+//!     c, cp = HPKE.SealBase(pkR=pkR, info=None, aad=None, pt=m)
+//!     return (c, cp)
+//!
+//! def Dec(skR, c, cp):
+//!     m = HPKE.OpenBase(enc=c, skR=skR, info=None, aad=None, ct=cp)
+//!     return m
+//! ```
+
+use alloc::vec::Vec;
+use anyhow::Error;
+use hpke_rs::Hpke;
+use hpke_rs::Mode;
+use hpke_rs::hpke_types::AeadAlgorithm::Aes256Gcm;
+use hpke_rs::hpke_types::KdfAlgorithm::HkdfSha256;
+use hpke_rs::hpke_types::KemAlgorithm::XWingDraft06;
+use hpke_rs::libcrux::HpkeLibcrux;
+use rand_core::{CryptoRng, RngCore};
+
+use crate::constants::LEN_XWING_SHAREDSECRET_ENCAPS;
+use crate::primitives::xwing::{XWingPrivateKey, XWingPublicKey, generate_xwing_keypair};
+
+/// The recipient's metadata public key (`pk_R^PKE` in the spec).
+pub struct MetadataPublicKey(pub(crate) XWingPublicKey);
+
+/// The recipient's metadata private key (`sk_R^PKE` in the spec).
+pub struct MetadataPrivateKey(pub(crate) XWingPrivateKey);
+
+/// A `(MetadataPrivateKey, MetadataPublicKey)` SD-PKE keypair.
+pub struct MetadataKeyPair {
+    sk: MetadataPrivateKey,
+    pk: MetadataPublicKey,
+}
+
+impl MetadataKeyPair {
+    /// Returns the public key.
+    pub fn public_key(&self) -> &MetadataPublicKey {
+        &self.pk
+    }
+
+    /// Returns the private key.
+    pub fn private_key(&self) -> &MetadataPrivateKey {
+        &self.sk
+    }
+}
+
+/// SD-PKE ciphertext `(c, c')`: X-Wing encapsulation `c` together with HPKE
+/// ciphertext `c'`.
+pub struct MetadataCiphertext {
+    /// HPKE encapsulation output (`c` in the spec)
+    pub(crate) c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS],
+    /// HPKE AEAD ciphertext (`c'` / `cp` in the spec)
+    pub(crate) cp: Vec<u8>,
+}
+
+impl From<XWingPublicKey> for MetadataPublicKey {
+    fn from(key: XWingPublicKey) -> Self {
+        Self(key)
+    }
+}
+
+impl From<XWingPrivateKey> for MetadataPrivateKey {
+    fn from(key: XWingPrivateKey) -> Self {
+        Self(key)
+    }
+}
+
+/// SD-PKE.KGen: generate a `MetadataKeyPair`.
+///
+/// # Errors
+///
+/// Returns an error if X-Wing key generation fails.
+pub fn keygen<R: RngCore + CryptoRng>(rng: &mut R) -> Result<MetadataKeyPair, anyhow::Error> {
+    let (sk_s, pk_s) = generate_xwing_keypair(rng)?;
+    Ok(MetadataKeyPair {
+        sk: MetadataPrivateKey(sk_s),
+        pk: MetadataPublicKey(pk_s),
+    })
+}
+
+impl MetadataPublicKey {
+    /// SD-PKE.Enc: encrypt message `m` to this key, returning `(c, c')`.
+    pub fn encrypt(&self, m: &[u8]) -> MetadataCiphertext {
+        let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
+        let pk_r = self.0.clone().into();
+
+        // MetadataPublicKey always holds a valid XWing key, so seal cannot fail.
+        let (c_vec, cp) = hpke
+            .seal(&pk_r, b"", b"", m, None, None, None)
+            .expect("SD-PKE encryption failed");
+
+        // XWing will always produce this length ciphertext, so this .expect is fine.
+        let c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS] = c_vec
+            .try_into()
+            .expect("X-Wing encapsulation output has unexpected length");
+
+        MetadataCiphertext { c, cp }
+    }
+}
+
+impl MetadataPrivateKey {
+    /// SD-PKE.Dec: decrypt `(c, c')` using this key, returning message `m`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if HPKE decryption fails.
+    pub fn decrypt(&self, ct: &MetadataCiphertext) -> Result<Vec<u8>, Error> {
+        let hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
+        let sk_r = self.0.clone().into();
+
+        hpke.open(&ct.c, &sk_r, b"", b"", &ct.cp, None, None, None)
+            .map_err(|e| anyhow::anyhow!("SD-PKE decryption failed: {:?}", e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand_chacha::ChaCha20Rng;
+    use rand_core::SeedableRng;
+
+    #[test]
+    fn test_metadata_encrypt_decrypt_roundtrip() {
+        let mut rng = ChaCha20Rng::seed_from_u64(42);
+        let kp = keygen(&mut rng).expect("KGen failed");
+
+        let m = b"pk_S^AKEM || pk_S^PQ";
+        let ct = kp.public_key().encrypt(m);
+        let decrypted = kp.private_key().decrypt(&ct).expect("Decryption failed");
+
+        assert_eq!(m.as_slice(), decrypted.as_slice());
+    }
+
+    #[test]
+    fn test_metadata_decrypt_wrong_key_fails() {
+        let mut rng = ChaCha20Rng::seed_from_u64(42);
+        let kp = keygen(&mut rng).expect("KGen failed");
+        let wrong_kp = keygen(&mut rng).expect("KGen failed");
+
+        let ct = kp.public_key().encrypt(b"some sender apke key bytes");
+        assert!(wrong_kp.private_key().decrypt(&ct).is_err());
+    }
+}

--- a/securedrop-protocol/protocol-minimal/src/primitives.rs
+++ b/securedrop-protocol/protocol-minimal/src/primitives.rs
@@ -7,11 +7,10 @@ pub mod dh_akem;
 pub mod mlkem;
 pub mod pad;
 pub mod x25519;
-pub mod xwing;
+pub(crate) mod xwing;
 
 pub use crate::primitives::dh_akem::generate_dh_akem_keypair;
 pub use crate::primitives::mlkem::generate_mlkem768_keypair;
-pub use crate::primitives::xwing::generate_xwing_keypair;
 
 /// Fixed number of message ID entries to return in privacy-preserving fetch
 ///

--- a/securedrop-protocol/protocol-minimal/src/primitives/xwing.rs
+++ b/securedrop-protocol/protocol-minimal/src/primitives/xwing.rs
@@ -3,37 +3,37 @@ use libcrux_kem::{PrivateKey, PublicKey};
 use rand_core::{CryptoRng, RngCore};
 
 // From: https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/
-pub const XWING_PUBLIC_KEY_LEN: usize = 1216;
-pub const XWING_PRIVATE_KEY_LEN: usize = 32;
+pub(crate) const XWING_PUBLIC_KEY_LEN: usize = 1216;
+pub(crate) const XWING_PRIVATE_KEY_LEN: usize = 32;
 
 /// XWING public key.
 #[derive(Debug, Clone)]
-pub struct XWingPublicKey([u8; XWING_PUBLIC_KEY_LEN]);
+pub(crate) struct XWingPublicKey([u8; XWING_PUBLIC_KEY_LEN]);
 
 /// XWING private key.
 #[derive(Debug, Clone)]
-pub struct XWingPrivateKey([u8; XWING_PRIVATE_KEY_LEN]);
+pub(crate) struct XWingPrivateKey([u8; XWING_PRIVATE_KEY_LEN]);
 
 impl XWingPublicKey {
     /// Get the public key as bytes
-    pub fn as_bytes(&self) -> &[u8; XWING_PUBLIC_KEY_LEN] {
+    pub(crate) fn as_bytes(&self) -> &[u8; XWING_PUBLIC_KEY_LEN] {
         &self.0
     }
 
     /// Create from bytes
-    pub fn from_bytes(bytes: [u8; XWING_PUBLIC_KEY_LEN]) -> Self {
+    pub(crate) fn from_bytes(bytes: [u8; XWING_PUBLIC_KEY_LEN]) -> Self {
         Self(bytes)
     }
 }
 
 impl XWingPrivateKey {
     /// Get the private key as bytes
-    pub fn as_bytes(&self) -> &[u8; XWING_PRIVATE_KEY_LEN] {
+    pub(crate) fn as_bytes(&self) -> &[u8; XWING_PRIVATE_KEY_LEN] {
         &self.0
     }
 
     /// Create from bytes
-    pub fn from_bytes(bytes: [u8; XWING_PRIVATE_KEY_LEN]) -> Self {
+    pub(crate) fn from_bytes(bytes: [u8; XWING_PRIVATE_KEY_LEN]) -> Self {
         Self(bytes)
     }
 }
@@ -52,7 +52,7 @@ impl From<XWingPublicKey> for HpkePublicKey {
 
 /// Generate XWING keypair from external randomness
 /// FOR TEST PURPOSES ONLY
-pub fn deterministic_keygen(
+pub(crate) fn deterministic_keygen(
     randomness: [u8; 32],
 ) -> Result<(XWingPrivateKey, XWingPublicKey), anyhow::Error> {
     use libcrux_kem::{Algorithm, key_gen_derand};
@@ -119,7 +119,7 @@ fn typed(
 }
 
 /// Generate a new XWING keypair using libcrux_kem
-pub fn generate_xwing_keypair<R: RngCore + CryptoRng>(
+pub(crate) fn generate_xwing_keypair<R: RngCore + CryptoRng>(
     rng: &mut R,
 ) -> Result<(XWingPrivateKey, XWingPublicKey), anyhow::Error> {
     use libcrux_kem::{Algorithm, key_gen};

--- a/securedrop-protocol/protocol-minimal/src/source.rs
+++ b/securedrop-protocol/protocol-minimal/src/source.rs
@@ -1,5 +1,6 @@
 use crate::VerifyingKey;
 use crate::api::Api;
+use crate::metadata::{MetadataPublicKey, deterministic_keygen as kgen_deterministic_metadata};
 use crate::primitives::dh_akem::DhAkemPrivateKey;
 use crate::primitives::dh_akem::DhAkemPublicKey;
 use crate::primitives::dh_akem::deterministic_keygen as kgen_deterministic_dhakem;
@@ -8,8 +9,6 @@ use crate::primitives::mlkem::deterministic_keygen as kgen_deterministic_mlkem;
 use crate::primitives::x25519::DHPrivateKey;
 use crate::primitives::x25519::DHPublicKey;
 use crate::primitives::x25519::deterministic_dh_keygen;
-use crate::primitives::xwing::XWingPublicKey;
-use crate::primitives::xwing::deterministic_keygen as kgen_deterministic_xwing;
 use alloc::vec::Vec;
 use argon2::{Algorithm, Argon2, Params, Version};
 use rand_core::{CryptoRng, RngCore};
@@ -66,8 +65,8 @@ impl UserPublic for SourcePublicView {
         &self.message_pks.mlkem_pk
     }
 
-    fn message_metadata_pk(&self) -> &XWingPublicKey {
-        &self.message_pks.xwing_pk
+    fn message_metadata_pk(&self) -> &MetadataPublicKey {
+        &self.message_pks.metadata_pk
     }
 
     fn message_enc_pk(&self) -> &DhAkemPublicKey {
@@ -110,7 +109,7 @@ impl UserSecret for Source {
         fetch_pk.copy_from_slice(&self.fetch_key.pk.clone().into_bytes());
 
         let mut reply_key_pq_hybrid = [0u8; LEN_XWING_ENCAPS_KEY];
-        reply_key_pq_hybrid.copy_from_slice(self.message_keys.xwing_md.pk.as_bytes());
+        reply_key_pq_hybrid.copy_from_slice(self.message_keys.metadata_kp.public_key().as_bytes());
 
         Plaintext {
             sender_fetch_key: fetch_pk,
@@ -205,8 +204,8 @@ impl Source {
         let (mlkem_decaps, mlkem_encaps) =
             kgen_deterministic_mlkem(kem_result.into()).expect("Need MLKEM keygen");
 
-        let (xwing_decaps, xwing_encaps) =
-            kgen_deterministic_xwing(pke_result.into()).expect("Need X-Wing keygen");
+        let metadata_kp =
+            kgen_deterministic_metadata(pke_result.into()).expect("Need X-Wing keygen");
 
         let session = SessionStorage {
             fpf_key: None,
@@ -228,10 +227,7 @@ impl Source {
                     sk: mlkem_decaps,
                     pk: mlkem_encaps,
                 },
-                KeyPair {
-                    sk: xwing_decaps,
-                    pk: xwing_encaps,
-                },
+                metadata_kp,
             ),
             passphrase: passphrase.to_vec(),
             session,
@@ -305,18 +301,18 @@ mod tests {
 
         // Metadata keys
         assert_eq!(
-            source1.message_keys.xwing_md.pk.as_bytes(),
-            source2.message_keys.xwing_md.pk.as_bytes(),
+            source1.message_keys.metadata_kp.public_key().as_bytes(),
+            source2.message_keys.metadata_kp.public_key().as_bytes(),
             "XWING Encaps Key should be identical"
         );
         assert_eq!(
-            source1.message_keys.xwing_md.sk.as_bytes(),
-            source2.message_keys.xwing_md.sk.as_bytes(),
+            source1.message_keys.metadata_kp.private_key().as_bytes(),
+            source2.message_keys.metadata_kp.private_key().as_bytes(),
             "XWING Decaps Key should be identical"
         );
         assert_ne!(
-            *source1.message_keys.xwing_md.sk.as_bytes(),
-            [0u8; LEN_XWING_DECAPS_KEY]
+            source1.message_keys.metadata_kp.private_key().as_bytes(),
+            &[0u8; LEN_XWING_DECAPS_KEY]
         );
     }
 }

--- a/securedrop-protocol/protocol-minimal/src/traits.rs
+++ b/securedrop-protocol/protocol-minimal/src/traits.rs
@@ -1,10 +1,10 @@
 use crate::VerifyingKey;
+use crate::metadata::MetadataPublicKey;
 use crate::primitives::dh_akem::DhAkemPrivateKey;
 use crate::primitives::dh_akem::DhAkemPublicKey;
 use crate::primitives::mlkem::MLKEM768PublicKey;
 use crate::primitives::x25519::DHPrivateKey;
 use crate::primitives::x25519::DHPublicKey;
-use crate::primitives::xwing::XWingPublicKey;
 use crate::sign::{JournalistEphemeralKey, JournalistLongTermKey, Signature};
 use alloc::vec::Vec;
 
@@ -34,7 +34,7 @@ pub trait UserPublic {
     fn fetch_pk(&self) -> &DHPublicKey;
     fn message_auth_pk(&self) -> &DhAkemPublicKey;
     fn message_psk_pk(&self) -> &MLKEM768PublicKey;
-    fn message_metadata_pk(&self) -> &XWingPublicKey;
+    fn message_metadata_pk(&self) -> &MetadataPublicKey;
     fn message_enc_pk(&self) -> &DhAkemPublicKey;
 }
 


### PR DESCRIPTION
Stacked on #209 

Closes #206 

The idea of this is to make encrypt/decrypt easier to follow and compare with the spec.

I debated getting rid of `primitive/xwing.rs`, but decided to keep the `primitive` module types as a libcrux adapter. They're a dependency isolation boundary, wrapping the raw bytes that libcrux provides as keys. I made (almost) everything in the XWing file as `pub(crate)`. The higher level protocol should use the abstractions we define in the spec, not the raw XWing keys. If we in the future were to switch one of the dependencies we use, e.g. XWing not from libcrux, we would only need to modify `primitives/xwing.rs` and potentially `metadata.rs`. 