### PR TITLE
docs: pin v0.3 to manuscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 |                                   | Version           |
 | --------------------------------- | ----------------- |
-| [Proof-of-concept implementation] | 0.3               |
-| [Specification]                   | 0.3 ([changelog]) |
+| [Proof-of-concept implementation] | 0.4               |
+| [Specification]                   | 0.4 ([changelog]) |
 | [Tamarin models]                  | 0.3               |
 
 [changelog]: ./docs/protocol.md#changelog
@@ -17,7 +17,8 @@
 > This repository contains proof-of-concept code and is not intended for production use. The protocol details are not yet finalized.
 
 **March 2026:** A manuscript, specifying and proving [version 0.3][v0.3] of the
-protocol and its [Tamarin models], is under peer review.
+protocol and its [Tamarin models], is under peer review. An eprint is
+forthcoming.
 
 **January 2025:** A formal analysis was performed by
 [Luca Maier](https://github.com/lumaier) in ["A Formal Analysis of the

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 |                                   | Version               |
 | --------------------------------- | --------------------- |
-| [Proof-of-concept implementation] | 0.3 ([documentation]) |
-| [Specification]                   | 0.3 ([changelog])     |
+| [Proof-of-concept implementation] | 0.4 ([documentation]) |
+| [Specification]                   | 0.4 ([changelog])     |
 | [Tamarin models]                  | 0.3                   |
 
 [changelog]: ./docs/protocol.md#changelog
@@ -18,7 +18,8 @@
 > This repository contains proof-of-concept code and is not intended for production use. The protocol details are not yet finalized.
 
 **March 2026:** A manuscript, specifying and proving [version 0.3][v0.3] of the
-protocol and its [Tamarin models], is under peer review.
+protocol and its [Tamarin models], is under peer review. An eprint is
+forthcoming.
 
 **January 2025:** A formal analysis was performed by
 [Luca Maier](https://github.com/lumaier) in ["A Formal Analysis of the

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -2,7 +2,7 @@
 
 | Version |
 | ------- |
-| 0.3     |
+| 0.4     |
 
 > [!NOTE]
 > The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT,
@@ -574,9 +574,13 @@ Initial proof of concept.
 As analyzed in Maier (2025), ["A Formal Analysis of the SecureDrop
 Protocol"][maier2025], using modified $`\text{HPKE}^{pq}_{auth}`$.
 
-### 0.3
+### [0.3]
 
 Using standard HPKE modes `Base` and `AuthPSK`.
+
+<!-- TODO: ...as formalized in... -->
+
+## 0.4
 
 <!--
 ## Footnotes
@@ -615,8 +619,9 @@ insertion order.
     single byte, and $m$ is the preimage bytes. Tags MUST contain only ASCII
     characters and MUST be at most 255 bytes.
 
-[0.1]: https://github.com/freedomofpress/securedrop-protocol/blob/ffc07fd85d1d43dc2796e3b63aca91298adb018e/docs/protocol.md
+[0.1]: https://github.com/freedomofpress/securedrop-protocol/blob/v0.1/README.md#parties
 [0.2]: https://github.com/freedomofpress/securedrop-protocol/blob/9e6c165673c03e9821725f72b3df4d8292b8cabf/docs/protocol.md
+[0.3]: https://github.com/freedomofpress/securedrop-protocol/blob/v0.3/docs/protocol.md
 [#127]: https://github.com/freedomofpress/securedrop-protocol/issues/127
 [alwen2020]: https://eprint.iacr.org/2020/1499
 [alwen2023]: https://eprint.iacr.org/2023/1480

--- a/securedrop-protocol/Cargo.lock
+++ b/securedrop-protocol/Cargo.lock
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "securedrop-protocol-bench"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.1",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "securedrop-protocol-minimal"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "argon2",

--- a/securedrop-protocol/Cargo.toml
+++ b/securedrop-protocol/Cargo.toml
@@ -4,7 +4,7 @@ members = ["protocol-minimal", "bench"]
 
 [workspace.package]
 name = "securedrop-protocol"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["SecureDrop Team <securedrop@freedom.press>"]
 license = "GPL-3.0"

--- a/securedrop-protocol/protocol-minimal/Cargo.toml
+++ b/securedrop-protocol/protocol-minimal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "securedrop-protocol-minimal"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["SecureDrop Team <securedrop@freedom.press>"]
 description = "A wip impl of the securedrop protocol"


### PR DESCRIPTION
See inline re: the proposed commit to tag as `v0.3`.

After merge, I'll reorganize the milestones:
- [v0.3](https://github.com/freedomofpress/securedrop-protocol/milestone/1)
- [v0.4](https://github.com/freedomofpress/securedrop-protocol/milestone/3)