### PR TITLE
build(hax): extract almost-upstream libcrux (mod hax v0.3.7)

### DIFF
--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up hax
         uses: hacspec/hax-actions@6c734302f9a0434cf590e0ba18c9dd9b28fc6659
         with:
-          fstar: v2025.12.15 # keep in sync with "securedrop-protocol/protocol-minimal/Makefile"
+          fstar: v2026.03.24 # keep in sync with "securedrop-protocol/protocol-minimal/Makefile"
           hax_reference: cargo-hax-v0.3.7 # keep in sync with "securedrop-protocol/protocol-minimal/Cargo.toml"
 
       - name: Extract F*

--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -20,7 +20,7 @@ jobs:
         uses: hacspec/hax-actions@6c734302f9a0434cf590e0ba18c9dd9b28fc6659
         with:
           fstar: v2025.12.15 # keep in sync with "securedrop-protocol/protocol-minimal/Makefile"
-          hax_reference: cargo-hax-v0.3.6 # keep in sync with "securedrop-protocol/protocol-minimal/Cargo.toml"
+          hax_reference: cargo-hax-v0.3.7 # keep in sync with "securedrop-protocol/protocol-minimal/Cargo.toml"
 
       - name: Extract F*
         run: make clean extract

--- a/securedrop-protocol/Cargo.lock
+++ b/securedrop-protocol/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn",
 ]
 
@@ -143,12 +143,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -1127,8 +1127,8 @@ dependencies = [
  "getrandom 0.4.2",
  "hashbrown 0.14.5",
  "js-sys",
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
  "securedrop-protocol-minimal",
  "serde",
  "serde_json",
@@ -1156,7 +1156,7 @@ dependencies = [
  "libcrux-sha2",
  "libcrux-traits",
  "proptest",
- "rand_chacha 0.9.0",
+ "rand_chacha 0.10.0",
  "rand_core 0.10.1",
  "serde",
  "serde_json",
@@ -1219,6 +1219,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,9 +1283,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"
@@ -1301,9 +1307,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -1313,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "uuid-rng-internal"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1409d2323564d9b8d01192a77a0604a46bf29eb42e9b535aca34dec65482652b"
+checksum = "58e332a80046a2cf8832852d3e747b6eb83d8f168c250044a9d3563ab8ae81d4"
 dependencies = [
  "getrandom 0.4.2",
 ]
@@ -1611,18 +1617,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/securedrop-protocol/Cargo.lock
+++ b/securedrop-protocol/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,9 +31,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "argon2"
@@ -34,7 +43,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -51,15 +60,35 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
 
 [[package]]
 name = "bit-set"
@@ -78,9 +107,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake2"
@@ -102,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cast"
@@ -114,12 +143,21 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.53"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -129,24 +167,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "core-models"
-version = "0.0.5"
+name = "chacha20"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "657f625ff361906f779745d08375ae3cc9fef87a35fba5f22874cf773010daf4"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
- "hax-lib",
- "pastey",
- "rand 0.9.4",
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
 name = "core-models"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.6"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "hax-lib",
  "pastey",
- "rand 0.9.4",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -156,6 +205,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crabgrind"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7459e07732f6de74001fcf73a3fdfbb0f368e4fd8e2392f4a2206a065e6e95"
+dependencies = [
+ "bindgen",
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -180,6 +249,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,15 +272,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -262,26 +337,32 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "rand_core 0.10.0",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -304,15 +385,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hax-lib"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "543f93241d32b3f00569201bfce9d7a93c92c6421b23c77864ac929dc947b9fc"
+checksum = "01a33cb227f97ee5c419064c31d7c55a7d895f28d8019ccdadc311cc036500c4"
 dependencies = [
  "hax-lib-macros",
  "num-bigint",
@@ -321,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8755751e760b11021765bb04cb4a6c4e24742688d9f3aa14c2079638f537b0f"
+checksum = "28da835a5f153e9f3d0cc1f42ee605a1cfa9093c93348193793d60a1b0908b51"
 dependencies = [
  "hax-lib-macros-types",
  "proc-macro-error2",
@@ -334,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros-types"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f177c9ae8ea456e2f71ff3c1ea47bf4464f772a05133fcbba56cd5ba169035a2"
+checksum = "eed327e9a28d6ee018a4a9ba842d4ee27e378c8a591d2beb6f42f32b24a02fcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -353,41 +434,40 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hpke-rs"
-version = "0.6.0"
-source = "git+https://github.com/cfm/hpke-rs?rev=9325551537d642d308edc60f3b271742b3a25b00#9325551537d642d308edc60f3b271742b3a25b00"
+version = "0.6.1"
+source = "git+https://github.com/cryspen/hpke-rs?rev=634caf8#634caf8df609bc232d3396f82cc6b8cc12053779"
 dependencies = [
  "hpke-rs-crypto",
  "hpke-rs-libcrux",
- "libcrux-sha3 0.0.7",
+ "libcrux-sha3",
  "log",
- "rand_core 0.9.3",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "hpke-rs-crypto"
-version = "0.6.0"
-source = "git+https://github.com/cfm/hpke-rs?rev=9325551537d642d308edc60f3b271742b3a25b00#9325551537d642d308edc60f3b271742b3a25b00"
+version = "0.6.1"
+source = "git+https://github.com/cryspen/hpke-rs?rev=634caf8#634caf8df609bc232d3396f82cc6b8cc12053779"
 dependencies = [
- "rand_core 0.9.3",
+ "rand 0.10.1",
  "zeroize",
 ]
 
 [[package]]
 name = "hpke-rs-libcrux"
-version = "0.6.0"
-source = "git+https://github.com/cfm/hpke-rs?rev=9325551537d642d308edc60f3b271742b3a25b00#9325551537d642d308edc60f3b271742b3a25b00"
+version = "0.6.1"
+source = "git+https://github.com/cryspen/hpke-rs?rev=634caf8#634caf8df609bc232d3396f82cc6b8cc12053779"
 dependencies = [
  "hpke-rs-crypto",
  "libcrux-aead",
  "libcrux-ecdh",
  "libcrux-hkdf",
  "libcrux-kem",
- "libcrux-traits 0.0.5",
- "rand 0.10.0",
+ "libcrux-traits",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 
@@ -399,27 +479,36 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.15"
+name = "itertools"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -435,141 +524,132 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libcrux-aead"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.8"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "libcrux-aesgcm",
  "libcrux-chacha20poly1305",
- "libcrux-secrets 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "libcrux-traits 0.0.5",
+ "libcrux-secrets",
+ "libcrux-traits",
 ]
 
 [[package]]
 name = "libcrux-aesgcm"
-version = "0.0.6"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.8"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
- "libcrux-intrinsics 0.0.5",
- "libcrux-platform 0.0.3 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "libcrux-secrets 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "libcrux-traits 0.0.5",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-secrets",
+ "libcrux-traits",
 ]
 
 [[package]]
 name = "libcrux-chacha20poly1305"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.8"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
  "libcrux-poly1305",
- "libcrux-secrets 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "libcrux-traits 0.0.5",
+ "libcrux-secrets",
+ "libcrux-traits",
 ]
 
 [[package]]
 name = "libcrux-curve25519"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.7"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
- "libcrux-secrets 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "libcrux-traits 0.0.5",
+ "libcrux-secrets",
+ "libcrux-traits",
 ]
 
 [[package]]
 name = "libcrux-ecdh"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.7"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "libcrux-curve25519",
  "libcrux-p256",
- "rand 0.9.4",
+ "rand 0.10.1",
 ]
 
 [[package]]
 name = "libcrux-ed25519"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.8"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
  "libcrux-sha2",
- "rand_core 0.9.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "libcrux-hacl-rs"
-version = "0.0.4"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.5"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "libcrux-macros",
 ]
 
 [[package]]
 name = "libcrux-hkdf"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.7"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-hmac",
- "libcrux-secrets 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
+ "libcrux-secrets",
 ]
 
 [[package]]
 name = "libcrux-hmac"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.7"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
  "libcrux-sha2",
+ "libcrux-traits",
 ]
 
 [[package]]
 name = "libcrux-intrinsics"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.7"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
- "core-models 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "hax-lib",
-]
-
-[[package]]
-name = "libcrux-intrinsics"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b5db005ff8001e026b73a6842ee81bbef8ec5ff0e1915a67ae65fd2a9fafa5"
-dependencies = [
- "core-models 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-models",
  "hax-lib",
 ]
 
 [[package]]
 name = "libcrux-kem"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.8"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "libcrux-curve25519",
  "libcrux-ecdh",
  "libcrux-ml-kem",
  "libcrux-p256",
- "libcrux-sha3 0.0.6",
- "libcrux-traits 0.0.5",
- "rand 0.9.4",
+ "libcrux-sha3",
+ "libcrux-traits",
+ "rand 0.10.1",
 ]
 
 [[package]]
 name = "libcrux-macros"
 version = "0.0.3"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "quote",
  "syn",
@@ -577,52 +657,43 @@ dependencies = [
 
 [[package]]
 name = "libcrux-ml-kem"
-version = "0.0.6"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.9"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "hax-lib",
- "libcrux-intrinsics 0.0.5",
- "libcrux-platform 0.0.3 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "libcrux-secrets 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "libcrux-sha3 0.0.6",
- "libcrux-traits 0.0.5",
- "rand 0.9.4",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-secrets",
+ "libcrux-sha3",
+ "libcrux-traits",
+ "rand 0.10.1",
  "tls_codec",
 ]
 
 [[package]]
 name = "libcrux-p256"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.7"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
- "libcrux-secrets 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
+ "libcrux-secrets",
  "libcrux-sha2",
- "libcrux-traits 0.0.5",
+ "libcrux-traits",
 ]
 
 [[package]]
 name = "libcrux-platform"
 version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9e21d7ed31a92ac539bd69a8c970b183ee883872d2d19ce27036e24cb8ecc4"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "libcrux-platform"
-version = "0.0.3"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libcrux-poly1305"
-version = "0.0.4"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.6"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -631,95 +702,75 @@ dependencies = [
 [[package]]
 name = "libcrux-secrets"
 version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce650f3041b44ba40d4263852347d007cd2cd9d1cc856a6f6c8b2e10c3fd40b"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
- "hax-lib",
-]
-
-[[package]]
-name = "libcrux-secrets"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
-dependencies = [
+ "crabgrind",
  "hax-lib",
 ]
 
 [[package]]
 name = "libcrux-sha2"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.7"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
- "libcrux-traits 0.0.5",
+ "libcrux-traits",
 ]
 
 [[package]]
 name = "libcrux-sha3"
-version = "0.0.6"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
+version = "0.0.9"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
  "hax-lib",
- "libcrux-intrinsics 0.0.5",
- "libcrux-platform 0.0.3 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "libcrux-traits 0.0.5",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-traits",
 ]
 
 [[package]]
-name = "libcrux-sha3"
+name = "libcrux-traits"
 version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c50f6e04a184511b782c5cc1eb6a227c6d36f2c935e93d698655a93a99696b5"
+source = "git+https://github.com/cfm/libcrux?rev=3cd1843b0f029b2c8499d1af4234670ad04341bf#3cd1843b0f029b2c8499d1af4234670ad04341bf"
 dependencies = [
- "hax-lib",
- "libcrux-intrinsics 0.0.6",
- "libcrux-platform 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libcrux-traits 0.0.6",
+ "libcrux-secrets",
+ "rand 0.10.1",
 ]
 
 [[package]]
-name = "libcrux-traits"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
-dependencies = [
- "libcrux-secrets 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "rand 0.9.4",
-]
-
-[[package]]
-name = "libcrux-traits"
-version = "0.0.6"
+name = "libloading"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e4fa89f3f5e34b47f928b22b1b78395a0d4ec23b1f583db635f128159d65f"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "libcrux-secrets 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.9.4",
+ "cfg-if",
+ "windows-link",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "minicov"
@@ -729,6 +780,22 @@ checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
  "cc",
  "walkdir",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -771,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"
@@ -794,15 +861,21 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "ppv-lite86"
@@ -847,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -881,9 +954,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -895,23 +968,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "getrandom 0.4.1",
- "rand_core 0.10.0",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -921,7 +1001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -931,7 +1011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -942,18 +1022,18 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -961,20 +1041,49 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1002,12 +1111,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,11 +1124,11 @@ name = "securedrop-protocol-bench"
 version = "0.4.0"
 dependencies = [
  "getrandom 0.3.4",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "hashbrown 0.14.5",
  "js-sys",
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
  "securedrop-protocol-minimal",
  "serde",
  "serde_json",
@@ -1051,10 +1154,10 @@ dependencies = [
  "libcrux-kem",
  "libcrux-ml-kem",
  "libcrux-sha2",
- "libcrux-traits 0.0.5",
+ "libcrux-traits",
  "proptest",
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.10.1",
  "serde",
  "serde_json",
  "uuid",
@@ -1062,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1098,15 +1201,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1129,9 +1232,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1140,12 +1243,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1174,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -1186,9 +1289,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
@@ -1198,11 +1301,11 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "uuid-rng-internal",
  "wasm-bindgen",
@@ -1210,11 +1313,11 @@ dependencies = [
 
 [[package]]
 name = "uuid-rng-internal"
-version = "1.19.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d0021aebf9af0cbec73af2f884a2cd0a41d984c00e42f27baa11856ab480e2c"
+checksum = "1409d2323564d9b8d01192a77a0604a46bf29eb42e9b535aca34dec65482652b"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
 ]
 
 [[package]]
@@ -1244,11 +1347,11 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.46.0",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1262,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1275,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1285,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1295,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1308,18 +1411,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af5ec93229ad9ccd0a545a516dec76dc276613f278f6a91aa6b463d5b33d42d0"
+checksum = "74fde991ccdc895cb7fbaa14b137d62af74d9011be67b71c694bfc40edd3119c"
 dependencies = [
  "async-trait",
  "cast",
@@ -1339,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c81b9fef827e575e0e54431736d1baa0d700315d8c62cfef1f61fa3aad0cbeb"
+checksum = "e925354648d2a4d1bf205412e36d520a800280622eef4719678d268e5d40e978"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1350,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4d8ae7ad5440360e9799dfd42857d126454a88441ddf72d288ef83fa47f527"
+checksum = "684365b586a9a6256c1cc3544eee8680de48d6041142f581776ec7b139622ae9"
 
 [[package]]
 name = "wasm-encoder"
@@ -1414,18 +1517,18 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -1508,18 +1611,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1537,11 +1640,17 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/securedrop-protocol/Cargo.lock
+++ b/securedrop-protocol/Cargo.lock
@@ -506,9 +506,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1371,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1384,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1394,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1404,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1417,18 +1417,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.72"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fde991ccdc895cb7fbaa14b137d62af74d9011be67b71c694bfc40edd3119c"
+checksum = "af5ec93229ad9ccd0a545a516dec76dc276613f278f6a91aa6b463d5b33d42d0"
 dependencies = [
  "async-trait",
  "cast",
@@ -1448,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.72"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e925354648d2a4d1bf205412e36d520a800280622eef4719678d268e5d40e978"
+checksum = "3c81b9fef827e575e0e54431736d1baa0d700315d8c62cfef1f61fa3aad0cbeb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1459,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.122"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684365b586a9a6256c1cc3544eee8680de48d6041142f581776ec7b139622ae9"
+checksum = "4f4d8ae7ad5440360e9799dfd42857d126454a88441ddf72d288ef83fa47f527"
 
 [[package]]
 name = "wasm-encoder"

--- a/securedrop-protocol/Cargo.toml
+++ b/securedrop-protocol/Cargo.toml
@@ -2,6 +2,15 @@
 resolver = "2"
 members = ["protocol-minimal", "bench"]
 
+[patch.crates-io]
+# Force hpke-rs to use our libcrux patched to hax 0.3.7 (pending cryspen/libcrux#1478):
+libcrux-aead = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-ecdh = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-hkdf = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-kem = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-sha3 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-traits = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+
 [workspace.package]
 name = "securedrop-protocol"
 version = "0.4.0"

--- a/securedrop-protocol/bench/Cargo.toml
+++ b/securedrop-protocol/bench/Cargo.toml
@@ -20,8 +20,8 @@ getrandom04 = { package = "getrandom", version = "0.4", default-features = false
 js-sys = "0.3"
 # Previously, rand_chacha was pinned to 0.9.0 to resolve incompatibility with older wasm-bindgen.
 # Check rand_chacha version compat if wasm builds or browser tests spuriously fail
-rand_chacha = { version = "0.9", default-features = false }
-rand_core = { version = "0.9.3" }
+rand_chacha = { version = "0.10.0", default-features = false }
+rand_core = { version = "0.10" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 hashbrown = { version = "0.14", features = ["raw"] }

--- a/securedrop-protocol/bench/Cargo.toml
+++ b/securedrop-protocol/bench/Cargo.toml
@@ -32,7 +32,7 @@ uuid = { version = "1.0", default-features = false, features = ["v4", "rng-getra
 wasm-bindgen = "0.2.121"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.71"
+wasm-bindgen-test = "=0.3.71"  # exact to avoid forced updates to wasm-bindgen above
 
 [features]
 default = []

--- a/securedrop-protocol/bench/benches/manual.rs
+++ b/securedrop-protocol/bench/benches/manual.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::time::{Duration, Instant};
 
 use rand_chacha::ChaCha20Rng;
-use rand_core::{RngCore, SeedableRng};
+use rand_core::{Rng, SeedableRng};
 use serde::Serialize;
 use uuid::Uuid;
 

--- a/securedrop-protocol/protocol-minimal/Cargo.toml
+++ b/securedrop-protocol/protocol-minimal/Cargo.toml
@@ -9,7 +9,9 @@ license = "GPL-3.0"
 [lib]
 
 [dependencies]
-# crypto stack, pinned to cryspen/libcrux#1312
+# Keep versions in sync with "proofs/fstar/models/Makefile".
+
+# crypto stack, pinned to cryspen/libcrux#1312 until it's released
 libcrux-ed25519 = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f", features = ["rand"] }
 libcrux-curve25519 = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f" }
 libcrux-chacha20poly1305 = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f" }
@@ -18,7 +20,7 @@ libcrux-kem = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1
 libcrux-ml-kem = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f" }
 libcrux-sha2 = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f" }
 
-# fork of cryspen/hpke-rs, transitively pinned to cryspen/libcrux#1312
+# fork of cryspen/hpke-rs, transitively pinned to cryspen/libcrux#1312 until it's released
 hpke-rs = { git = "https://github.com/cfm/hpke-rs", rev = "9325551537d642d308edc60f3b271742b3a25b00", features = ["libcrux"] }
 
 rand_core = { version = "0.9" }

--- a/securedrop-protocol/protocol-minimal/Cargo.toml
+++ b/securedrop-protocol/protocol-minimal/Cargo.toml
@@ -17,19 +17,21 @@ license = "GPL-3.0"
 # https://github.com/freedomofpress/securedrop-protocol/wiki/Verification#how-are-f-interfaces-extracted-from-our-dependencies
 
 # no rand/getrandom in core library!
-# crypto stack, pinned to cryspen/libcrux#1312
-libcrux-ed25519 = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f", features = ["rand"] }
-libcrux-curve25519 = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f" }
-libcrux-chacha20poly1305 = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f" }
-libcrux-traits = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f" }
-libcrux-kem = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f" }
-libcrux-ml-kem = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f" }
-libcrux-sha2 = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f" }
 
-# fork of cryspen/hpke-rs, transitively pinned to cryspen/libcrux#1312
-hpke-rs = { git = "https://github.com/cfm/hpke-rs", rev = "9325551537d642d308edc60f3b271742b3a25b00", features = ["libcrux"] }
+# Crypto stack, pinned to cfm/libcrux@hax-lib-0.3.7 pending cryspen/libcrux#1478:
+libcrux-ed25519 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf", features = ["rand"] }
+libcrux-curve25519 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-chacha20poly1305 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-traits = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-kem = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-ml-kem = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-sha2 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
 
-rand_core = { version = "0.9" }
+# See workspace-level `Cargo.toml` for patching to enforce hax-lib 0.3.7.
+# Pinned here until published crates use hax-lib 0.3.7 and libcrux-sha3 0.0.9.
+hpke-rs = { git = "https://github.com/cryspen/hpke-rs", rev = "634caf8", features = ["libcrux"] }
+
+rand_core = { version = "0.10" }
 
 anyhow = "1.0"
 hashbrown = { version = "0.14", features = ["raw"] }
@@ -54,4 +56,4 @@ panic = "abort"
 strip = true
 
 [target."cfg(hax)".dependencies]
-hax-lib = { version = "0.3.6" }
+hax-lib = { version = "0.3.7" }

--- a/securedrop-protocol/protocol-minimal/Cargo.toml
+++ b/securedrop-protocol/protocol-minimal/Cargo.toml
@@ -39,7 +39,8 @@ uuid = { version = "1.0", default-features = false, features = ["v4", "js"] }
 argon2 = "0.5"
 blake2 = "0.10"
 
-rand_chacha = {  version = "0.9", default-features = false  }
+# pin an exact version to resolve wasm-bindgen schema compatibility issue
+rand_chacha = {  version = "0.10.0", default-features = false  }
 
 [dev-dependencies]
 proptest = "1.11"

--- a/securedrop-protocol/protocol-minimal/Makefile
+++ b/securedrop-protocol/protocol-minimal/Makefile
@@ -44,9 +44,9 @@ verify:  # Internal/CI: Type-check and verify extracted proofs.
 	# Verify:
 	$(MAKE) -C $(PROOF_DIR)
 
-.PHONY: hax-lib-version
-hax-lib-version:  # Internal: Query Cargo for the hax-lib version.
-	@cargo pkgid hax-lib 2>/dev/null | sed 's/.*@//'
+.PHONY: version
+version:  # Internal: "PACKAGE=foo make version" queries Cargo for the installed version of the crate foo.
+	@cargo pkgid $(PACKAGE) 2>/dev/null | sed 's/.*@//'
 
 .PHONY: help
 help: ## Print this message.

--- a/securedrop-protocol/protocol-minimal/Makefile
+++ b/securedrop-protocol/protocol-minimal/Makefile
@@ -35,7 +35,7 @@ clean:  ## Clean the Cargo and F* caches, and reset extracted F* modules.
 compat: compat-fstar  ## Check that hax dependencies are at the right versions.
 
 # Keep in sync with ".github/workflows/hax.yml":
-FSTAR_EXPECTED_VERSION = F* 2025.12.15
+FSTAR_EXPECTED_VERSION = F* 2026.03.24
 FSTAR_ACTUAL_VERSION   = $(shell fstar.exe --version 2>/dev/null | head -1)
 .PHONY: compat-fstar
 compat-fstar:  # Internal: Check F* version.

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Ciphertext.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Ciphertext.fst
@@ -70,11 +70,7 @@ let impl_Plaintext__to_bytes (self: t_Plaintext) : Alloc.Vec.t_Vec u8 Alloc.Allo
     Alloc.Vec.impl_2__extend_from_slice #u8
       #Alloc.Alloc.t_Global
       buf
-      (Core_models.Ops.Deref.f_deref #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
-          #FStar.Tactics.Typeclasses.solve
-          self.f_msg
-        <:
-        t_Slice u8)
+      (Alloc.Vec.impl_1__as_slice self.f_msg <: t_Slice u8)
   in
   buf
 

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Message.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Message.fst
@@ -481,14 +481,14 @@ let auth_enc
       | Core_models.Result.Result_Ok (c1_vec, cp) ->
         let (c1: t_Array u8 (mk_usize 32)):t_Array u8 (mk_usize 32) =
           Core_models.Result.impl__expect #(t_Array u8 (mk_usize 32))
-            #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
-            (Core_models.Convert.f_try_into #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+            #Core_models.Array.t_TryFromSliceError
+            (Core_models.Convert.f_try_into #(t_Slice u8)
                 #(t_Array u8 (mk_usize 32))
                 #FStar.Tactics.Typeclasses.solve
-                c1_vec
+                (Alloc.Vec.impl_1__as_slice #u8 #Alloc.Alloc.t_Global c1_vec <: t_Slice u8)
               <:
               Core_models.Result.t_Result (t_Array u8 (mk_usize 32))
-                (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
+                Core_models.Array.t_TryFromSliceError)
             "DHKEM(X25519) encapsulation output has unexpected length"
         in
         let hax_temp_output:Core_models.Result.t_Result t_MessageCiphertext Anyhow.t_Error =

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Message.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Message.fst
@@ -356,6 +356,7 @@ let auth_enc
     Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 32) & t_Array u8 (mk_usize 1088))
       #Libcrux_traits.Kem.Arrayref.t_EncapsError
       #Anyhow.t_Error
+      #(Libcrux_traits.Kem.Arrayref.t_EncapsError -> Anyhow.t_Error)
       (Libcrux_traits.Kem.Owned.f_encaps #Libcrux_ml_kem.Mlkem768.t_MlKem768 #(mk_usize 1184)
           #(mk_usize 2400) #(mk_usize 1088) #(mk_usize 32) #(mk_usize 64) #(mk_usize 32)
           #FStar.Tactics.Typeclasses.solve
@@ -432,11 +433,7 @@ let auth_enc
       Hpke_rs.impl_7__seal #Hpke_rs_libcrux.t_HpkeLibcrux
         hpke
         pkr1
-        (Core_models.Ops.Deref.f_deref #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
-            #FStar.Tactics.Typeclasses.solve
-            full_info
-          <:
-          t_Slice u8)
+        (Alloc.Vec.impl_1__as_slice full_info <: t_Slice u8)
         ad
         m
         (Core_models.Option.Option_Some (k2 <: t_Slice u8)
@@ -452,6 +449,7 @@ let auth_enc
             Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
           #Hpke_rs.t_HpkeError
           #Anyhow.t_Error
+          #(Hpke_rs.t_HpkeError -> Anyhow.t_Error)
           out
           (fun e ->
               let e:Hpke_rs.t_HpkeError = e in
@@ -540,6 +538,7 @@ let auth_dec
     Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 32))
       #Libcrux_traits.Kem.Arrayref.t_DecapsError
       #Anyhow.t_Error
+      #(Libcrux_traits.Kem.Arrayref.t_DecapsError -> Anyhow.t_Error)
       (Libcrux_traits.Kem.Owned.f_decaps #Libcrux_ml_kem.Mlkem768.t_MlKem768 #(mk_usize 1184)
           #(mk_usize 2400) #(mk_usize 1088) #(mk_usize 32) #(mk_usize 64) #(mk_usize 32)
           #FStar.Tactics.Typeclasses.solve ct.f_c2
@@ -612,17 +611,10 @@ let auth_dec
     Core_models.Result.impl__map_err #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
       #Hpke_rs.t_HpkeError
       #Anyhow.t_Error
+      #(Hpke_rs.t_HpkeError -> Anyhow.t_Error)
       (Hpke_rs.impl_7__open #Hpke_rs_libcrux.t_HpkeLibcrux hpke (ct.f_c1 <: t_Slice u8) skr1
-          (Core_models.Ops.Deref.f_deref #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
-              #FStar.Tactics.Typeclasses.solve
-              full_info
-            <:
-            t_Slice u8) ad
-          (Core_models.Ops.Deref.f_deref #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
-              #FStar.Tactics.Typeclasses.solve
-              ct.f_cp
-            <:
-            t_Slice u8)
+          (Alloc.Vec.impl_1__as_slice full_info <: t_Slice u8) ad
+          (Alloc.Vec.impl_1__as_slice ct.f_cp <: t_Slice u8)
           (Core_models.Option.Option_Some (k2 <: t_Slice u8)
             <:
             Core_models.Option.t_Option (t_Slice u8))

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Metadata.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Metadata.fst
@@ -238,6 +238,7 @@ let decrypt (sk_r: t_MetadataPrivateKey) (ct: t_MetadataCiphertext)
   Core_models.Result.impl__map_err #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
     #Hpke_rs.t_HpkeError
     #Anyhow.t_Error
+    #(Hpke_rs.t_HpkeError -> Anyhow.t_Error)
     (Hpke_rs.impl_7__open #Hpke_rs_libcrux.t_HpkeLibcrux hpke (ct.f_c <: t_Slice u8) sk_r_hpke
         ((let list:Prims.list u8 = [] in
             FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 0);
@@ -248,12 +249,8 @@ let decrypt (sk_r: t_MetadataPrivateKey) (ct: t_MetadataCiphertext)
             FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 0);
             Rust_primitives.Hax.array_of_list 0 list)
           <:
-          t_Slice u8)
-        (Core_models.Ops.Deref.f_deref #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
-            #FStar.Tactics.Typeclasses.solve
-            ct.f_cp
-          <:
-          t_Slice u8) (Core_models.Option.Option_None <: Core_models.Option.t_Option (t_Slice u8))
+          t_Slice u8) (Alloc.Vec.impl_1__as_slice ct.f_cp <: t_Slice u8)
+        (Core_models.Option.Option_None <: Core_models.Option.t_Option (t_Slice u8))
         (Core_models.Option.Option_None <: Core_models.Option.t_Option (t_Slice u8))
         (Core_models.Option.Option_None <: Core_models.Option.t_Option Hpke_rs.t_HpkePublicKey)
       <:

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Metadata.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Metadata.fst
@@ -201,14 +201,14 @@ let encrypt (pk_r: t_MetadataPublicKey) (m: t_Slice u8) : t_MetadataCiphertext =
   in
   let (c: t_Array u8 (mk_usize 1120)):t_Array u8 (mk_usize 1120) =
     Core_models.Result.impl__expect #(t_Array u8 (mk_usize 1120))
-      #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
-      (Core_models.Convert.f_try_into #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+      #Core_models.Array.t_TryFromSliceError
+      (Core_models.Convert.f_try_into #(t_Slice u8)
           #(t_Array u8 (mk_usize 1120))
           #FStar.Tactics.Typeclasses.solve
-          c_vec
+          (Alloc.Vec.impl_1__as_slice #u8 #Alloc.Alloc.t_Global c_vec <: t_Slice u8)
         <:
         Core_models.Result.t_Result (t_Array u8 (mk_usize 1120))
-          (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
+          Core_models.Array.t_TryFromSliceError)
       "X-Wing encapsulation output has unexpected length"
   in
   { f_c = c; f_cp = cp } <: t_MetadataCiphertext

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Dh_akem.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Dh_akem.fst
@@ -143,6 +143,7 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
       Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 32))
         #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
         #Anyhow.t_Error
+        #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global -> Anyhow.t_Error)
         (Core_models.Convert.f_try_into #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
             #(t_Array u8 (mk_usize 32))
             #FStar.Tactics.Typeclasses.solve
@@ -170,6 +171,7 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
           Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 32))
             #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
             #Anyhow.t_Error
+            #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global -> Anyhow.t_Error)
             (Core_models.Convert.f_try_into #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
                 #(t_Array u8 (mk_usize 32))
                 #FStar.Tactics.Typeclasses.solve
@@ -222,6 +224,7 @@ let deterministic_keygen (randomness: t_Array u8 (mk_usize 32))
     Core_models.Result.impl__map_err #(Libcrux_kem.t_PrivateKey & Libcrux_kem.t_PublicKey)
       #Libcrux_kem.t_Error
       #Anyhow.t_Error
+      #(Libcrux_kem.t_Error -> Anyhow.t_Error)
       (Libcrux_kem.key_gen_derand (Libcrux_kem.Algorithm_X25519 <: Libcrux_kem.t_Algorithm)
           (clamped_randomness <: t_Slice u8)
         <:
@@ -277,6 +280,7 @@ let generate_dh_akem_keypair
     Core_models.Result.impl__map_err #(Libcrux_kem.t_PrivateKey & Libcrux_kem.t_PublicKey)
       #Libcrux_kem.t_Error
       #Anyhow.t_Error
+      #(Libcrux_kem.t_Error -> Anyhow.t_Error)
       out
       (fun e ->
           let e:Libcrux_kem.t_Error = e in

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Dh_akem.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Dh_akem.fst
@@ -141,18 +141,18 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
   else
     match
       Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 32))
-        #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+        #Core_models.Array.t_TryFromSliceError
         #Anyhow.t_Error
-        #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global -> Anyhow.t_Error)
-        (Core_models.Convert.f_try_into #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+        #(Core_models.Array.t_TryFromSliceError -> Anyhow.t_Error)
+        (Core_models.Convert.f_try_into #(t_Slice u8)
             #(t_Array u8 (mk_usize 32))
             #FStar.Tactics.Typeclasses.solve
-            private_key_bytes
+            (Alloc.Vec.impl_1__as_slice #u8 #Alloc.Alloc.t_Global private_key_bytes <: t_Slice u8)
           <:
           Core_models.Result.t_Result (t_Array u8 (mk_usize 32))
-            (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
+            Core_models.Array.t_TryFromSliceError)
         (fun temp_0_ ->
-            let _:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = temp_0_ in
+            let _:Core_models.Array.t_TryFromSliceError = temp_0_ in
             let error:Anyhow.t_Error =
               Anyhow.__private.format_err (Core_models.Fmt.Rt.impl_1__new_const (mk_usize 1)
                     (let list = ["Failed to convert private key bytes"] in
@@ -169,18 +169,19 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
       let private_key:t_DhAkemPrivateKey = impl_DhAkemPrivateKey__from_bytes hoist2 in
       (match
           Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 32))
-            #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+            #Core_models.Array.t_TryFromSliceError
             #Anyhow.t_Error
-            #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global -> Anyhow.t_Error)
-            (Core_models.Convert.f_try_into #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+            #(Core_models.Array.t_TryFromSliceError -> Anyhow.t_Error)
+            (Core_models.Convert.f_try_into #(t_Slice u8)
                 #(t_Array u8 (mk_usize 32))
                 #FStar.Tactics.Typeclasses.solve
-                public_key_bytes
+                (Alloc.Vec.impl_1__as_slice #u8 #Alloc.Alloc.t_Global public_key_bytes <: t_Slice u8
+                )
               <:
               Core_models.Result.t_Result (t_Array u8 (mk_usize 32))
-                (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
+                Core_models.Array.t_TryFromSliceError)
             (fun temp_0_ ->
-                let _:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = temp_0_ in
+                let _:Core_models.Array.t_TryFromSliceError = temp_0_ in
                 let error:Anyhow.t_Error =
                   Anyhow.__private.format_err (Core_models.Fmt.Rt.impl_1__new_const (mk_usize 1)
                         (let list = ["Failed to convert public key bytes"] in

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Mlkem.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Mlkem.fst
@@ -88,6 +88,7 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
       Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 2400))
         #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
         #Anyhow.t_Error
+        #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global -> Anyhow.t_Error)
         (Core_models.Convert.f_try_into #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
             #(t_Array u8 (mk_usize 2400))
             #FStar.Tactics.Typeclasses.solve
@@ -115,6 +116,7 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
           Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 1184))
             #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
             #Anyhow.t_Error
+            #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global -> Anyhow.t_Error)
             (Core_models.Convert.f_try_into #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
                 #(t_Array u8 (mk_usize 1184))
                 #FStar.Tactics.Typeclasses.solve
@@ -161,6 +163,7 @@ let deterministic_keygen (randomness: t_Array u8 (mk_usize 64))
     Core_models.Result.impl__map_err #(Libcrux_kem.t_PrivateKey & Libcrux_kem.t_PublicKey)
       #Libcrux_kem.t_Error
       #Anyhow.t_Error
+      #(Libcrux_kem.t_Error -> Anyhow.t_Error)
       (Libcrux_kem.key_gen_derand (Libcrux_kem.Algorithm_MlKem768 <: Libcrux_kem.t_Algorithm)
           (randomness <: t_Slice u8)
         <:
@@ -217,6 +220,7 @@ let generate_mlkem768_keypair
     Core_models.Result.impl__map_err #(Libcrux_kem.t_PrivateKey & Libcrux_kem.t_PublicKey)
       #Libcrux_kem.t_Error
       #Anyhow.t_Error
+      #(Libcrux_kem.t_Error -> Anyhow.t_Error)
       out
       (fun e ->
           let e:Libcrux_kem.t_Error = e in

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Mlkem.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Mlkem.fst
@@ -86,18 +86,18 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
   else
     match
       Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 2400))
-        #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+        #Core_models.Array.t_TryFromSliceError
         #Anyhow.t_Error
-        #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global -> Anyhow.t_Error)
-        (Core_models.Convert.f_try_into #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+        #(Core_models.Array.t_TryFromSliceError -> Anyhow.t_Error)
+        (Core_models.Convert.f_try_into #(t_Slice u8)
             #(t_Array u8 (mk_usize 2400))
             #FStar.Tactics.Typeclasses.solve
-            private_key_bytes
+            (Alloc.Vec.impl_1__as_slice #u8 #Alloc.Alloc.t_Global private_key_bytes <: t_Slice u8)
           <:
           Core_models.Result.t_Result (t_Array u8 (mk_usize 2400))
-            (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
+            Core_models.Array.t_TryFromSliceError)
         (fun temp_0_ ->
-            let _:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = temp_0_ in
+            let _:Core_models.Array.t_TryFromSliceError = temp_0_ in
             let error:Anyhow.t_Error =
               Anyhow.__private.format_err (Core_models.Fmt.Rt.impl_1__new_const (mk_usize 1)
                     (let list = ["Failed to convert private key bytes"] in
@@ -114,18 +114,19 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
       let private_key:t_MLKEM768PrivateKey = impl_MLKEM768PrivateKey__from_bytes hoist7 in
       (match
           Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 1184))
-            #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+            #Core_models.Array.t_TryFromSliceError
             #Anyhow.t_Error
-            #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global -> Anyhow.t_Error)
-            (Core_models.Convert.f_try_into #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+            #(Core_models.Array.t_TryFromSliceError -> Anyhow.t_Error)
+            (Core_models.Convert.f_try_into #(t_Slice u8)
                 #(t_Array u8 (mk_usize 1184))
                 #FStar.Tactics.Typeclasses.solve
-                public_key_bytes
+                (Alloc.Vec.impl_1__as_slice #u8 #Alloc.Alloc.t_Global public_key_bytes <: t_Slice u8
+                )
               <:
               Core_models.Result.t_Result (t_Array u8 (mk_usize 1184))
-                (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
+                Core_models.Array.t_TryFromSliceError)
             (fun temp_0_ ->
-                let _:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = temp_0_ in
+                let _:Core_models.Array.t_TryFromSliceError = temp_0_ in
                 let error:Anyhow.t_Error =
                   Anyhow.__private.format_err (Core_models.Fmt.Rt.impl_1__new_const (mk_usize 1)
                         (let list = ["Failed to convert public key bytes"] in

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Xwing.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Xwing.fst
@@ -125,6 +125,7 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
       Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 32))
         #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
         #Anyhow.t_Error
+        #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global -> Anyhow.t_Error)
         (Core_models.Convert.f_try_into #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
             #(t_Array u8 (mk_usize 32))
             #FStar.Tactics.Typeclasses.solve
@@ -152,6 +153,7 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
           Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 1216))
             #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
             #Anyhow.t_Error
+            #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global -> Anyhow.t_Error)
             (Core_models.Convert.f_try_into #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
                 #(t_Array u8 (mk_usize 1216))
                 #FStar.Tactics.Typeclasses.solve
@@ -198,6 +200,7 @@ let deterministic_keygen (randomness: t_Array u8 (mk_usize 32))
     Core_models.Result.impl__map_err #(Libcrux_kem.t_PrivateKey & Libcrux_kem.t_PublicKey)
       #Libcrux_kem.t_Error
       #Anyhow.t_Error
+      #(Libcrux_kem.t_Error -> Anyhow.t_Error)
       (Libcrux_kem.key_gen_derand (Libcrux_kem.Algorithm_XWingKemDraft06 <: Libcrux_kem.t_Algorithm)
           (randomness <: t_Slice u8)
         <:
@@ -253,6 +256,7 @@ let generate_xwing_keypair
     Core_models.Result.impl__map_err #(Libcrux_kem.t_PrivateKey & Libcrux_kem.t_PublicKey)
       #Libcrux_kem.t_Error
       #Anyhow.t_Error
+      #(Libcrux_kem.t_Error -> Anyhow.t_Error)
       out
       (fun e ->
           let e:Libcrux_kem.t_Error = e in

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Xwing.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Xwing.fst
@@ -123,18 +123,18 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
   else
     match
       Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 32))
-        #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+        #Core_models.Array.t_TryFromSliceError
         #Anyhow.t_Error
-        #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global -> Anyhow.t_Error)
-        (Core_models.Convert.f_try_into #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+        #(Core_models.Array.t_TryFromSliceError -> Anyhow.t_Error)
+        (Core_models.Convert.f_try_into #(t_Slice u8)
             #(t_Array u8 (mk_usize 32))
             #FStar.Tactics.Typeclasses.solve
-            private_key_bytes
+            (Alloc.Vec.impl_1__as_slice #u8 #Alloc.Alloc.t_Global private_key_bytes <: t_Slice u8)
           <:
           Core_models.Result.t_Result (t_Array u8 (mk_usize 32))
-            (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
+            Core_models.Array.t_TryFromSliceError)
         (fun temp_0_ ->
-            let _:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = temp_0_ in
+            let _:Core_models.Array.t_TryFromSliceError = temp_0_ in
             let error:Anyhow.t_Error =
               Anyhow.__private.format_err (Core_models.Fmt.Rt.impl_1__new_const (mk_usize 1)
                     (let list = ["Failed to convert private key bytes"] in
@@ -151,18 +151,19 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
       let private_key:t_XWingPrivateKey = impl_XWingPrivateKey__from_bytes hoist12 in
       (match
           Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 1216))
-            #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+            #Core_models.Array.t_TryFromSliceError
             #Anyhow.t_Error
-            #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global -> Anyhow.t_Error)
-            (Core_models.Convert.f_try_into #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+            #(Core_models.Array.t_TryFromSliceError -> Anyhow.t_Error)
+            (Core_models.Convert.f_try_into #(t_Slice u8)
                 #(t_Array u8 (mk_usize 1216))
                 #FStar.Tactics.Typeclasses.solve
-                public_key_bytes
+                (Alloc.Vec.impl_1__as_slice #u8 #Alloc.Alloc.t_Global public_key_bytes <: t_Slice u8
+                )
               <:
               Core_models.Result.t_Result (t_Array u8 (mk_usize 1216))
-                (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
+                Core_models.Array.t_TryFromSliceError)
             (fun temp_0_ ->
-                let _:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = temp_0_ in
+                let _:Core_models.Array.t_TryFromSliceError = temp_0_ in
                 let error:Anyhow.t_Error =
                   Anyhow.__private.format_err (Core_models.Fmt.Rt.impl_1__new_const (mk_usize 1)
                         (let list = ["Failed to convert public key bytes"] in

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/models/Libcrux_ecdh.fsti
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/models/Libcrux_ecdh.fsti
@@ -14,3 +14,14 @@ type t_Error =
   | Error_KeyGenError : t_Error
   | Error_Custom : Alloc.String.t_String -> t_Error
   | Error_Wrap : t_LowLevelError -> t_Error
+
+/// ECDH algorithm.
+type t_Algorithm =
+  | Algorithm_X25519 : t_Algorithm
+  | Algorithm_X448 : t_Algorithm
+  | Algorithm_P256 : t_Algorithm
+  | Algorithm_P384 : t_Algorithm
+  | Algorithm_P521 : t_Algorithm
+
+val t_Algorithm_cast_to_repr (x: t_Algorithm)
+    : Prims.Pure isize Prims.l_True (fun _ -> Prims.l_True)

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/models/Libcrux_kem.fsti
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/models/Libcrux_kem.fsti
@@ -30,6 +30,21 @@ type t_Algorithm =
 val t_Algorithm_cast_to_repr (x: t_Algorithm)
     : Prims.Pure isize Prims.l_True (fun _ -> Prims.l_True)
 
+let impl_13: Core_models.Clone.t_Clone t_Algorithm =
+  { f_clone = (fun x -> x); f_clone_pre = (fun _ -> True); f_clone_post = (fun _ _ -> True) }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_14:Core_models.Marker.t_Copy t_Algorithm
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_15:Core_models.Marker.t_StructuralPartialEq t_Algorithm
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_16:Core_models.Cmp.t_PartialEq t_Algorithm t_Algorithm
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_17:Core_models.Fmt.t_Debug t_Algorithm
+
 type t_Error =
   | Error_EcDhError : Libcrux_ecdh.t_Error -> t_Error
   | Error_KeyGen : t_Error
@@ -39,6 +54,68 @@ type t_Error =
   | Error_InvalidPrivateKey : t_Error
   | Error_InvalidPublicKey : t_Error
   | Error_InvalidCiphertext : t_Error
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_18:Core_models.Fmt.t_Debug t_Error
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_19:Core_models.Marker.t_StructuralPartialEq t_Error
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_20:Core_models.Cmp.t_PartialEq t_Error t_Error
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_21:Core_models.Cmp.t_Eq t_Error
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl: Core_models.Convert.t_TryFrom Libcrux_ecdh.t_Algorithm t_Algorithm =
+  {
+    f_Error = string;
+    f_try_from_pre = (fun (value: t_Algorithm) -> true);
+    f_try_from_post
+    =
+    (fun (value: t_Algorithm) (out: Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string) ->
+        true);
+    f_try_from
+    =
+    fun (value: t_Algorithm) ->
+      match value <: t_Algorithm with
+      | Algorithm_X25519  ->
+        Core_models.Result.Result_Ok (Libcrux_ecdh.Algorithm_X25519 <: Libcrux_ecdh.t_Algorithm)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string
+      | Algorithm_X448  ->
+        Core_models.Result.Result_Ok (Libcrux_ecdh.Algorithm_X448 <: Libcrux_ecdh.t_Algorithm)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string
+      | Algorithm_Secp256r1  ->
+        Core_models.Result.Result_Ok (Libcrux_ecdh.Algorithm_P256 <: Libcrux_ecdh.t_Algorithm)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string
+      | Algorithm_Secp384r1  ->
+        Core_models.Result.Result_Ok (Libcrux_ecdh.Algorithm_P384 <: Libcrux_ecdh.t_Algorithm)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string
+      | Algorithm_Secp521r1  ->
+        Core_models.Result.Result_Ok (Libcrux_ecdh.Algorithm_P521 <: Libcrux_ecdh.t_Algorithm)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string
+      | Algorithm_X25519MlKem768Draft00  ->
+        Core_models.Result.Result_Ok (Libcrux_ecdh.Algorithm_X25519 <: Libcrux_ecdh.t_Algorithm)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string
+      | Algorithm_XWingKemDraft06  ->
+        Core_models.Result.Result_Ok (Libcrux_ecdh.Algorithm_X25519 <: Libcrux_ecdh.t_Algorithm)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string
+      | _ ->
+        Core_models.Result.Result_Err "provided algorithm is not an ECDH algorithm"
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_1:Core_models.Convert.t_From t_Error Libcrux_ecdh.t_Error
 
 /// An ML-KEM768-x25519 private key.
 type t_X25519MlKem768Draft00PrivateKey = {
@@ -108,39 +185,35 @@ type t_Ss =
   | Ss_XWingKemDraft06 : Libcrux_kem.Xwing.t_XWingSharedSecret -> t_Ss
   | Ss_MlKem1024 : t_Array u8 (mk_usize 32) -> t_Ss
 
-/// Encode a private key.
-val impl_PrivateKey__encode (self: t_PrivateKey)
-    : Prims.Pure (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Prims.l_True (fun _ -> Prims.l_True)
-
-/// Decode a private key.
-val impl_PrivateKey__decode (alg: t_Algorithm) (bytes: t_Slice u8)
-    : Prims.Pure (Core_models.Result.t_Result t_PrivateKey t_Error)
+/// Compute the public key for a private key of the given [`Algorithm`].
+/// Applicable only to X25519 and secp256r1.
+val secret_to_public
+      (#iimpl_677085834_: Type0)
+      {| i0: Core_models.Convert.t_AsRef iimpl_677085834_ (t_Slice u8) |}
+      (alg: t_Algorithm)
+      (sk: iimpl_677085834_)
+    : Prims.Pure (Core_models.Result.t_Result (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) t_Error)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-/// Encapsulate a shared secret to the provided `pk` and return the `(Key, Enc)` tuple.
-val impl_PublicKey__encapsulate
+val random_array
+      (v_L: usize)
       (#iimpl_447424039_: Type0)
       {| i0: Rand_core.t_CryptoRng iimpl_447424039_ |}
-      (self: t_PublicKey)
       (rng: iimpl_447424039_)
-    : Prims.Pure (iimpl_447424039_ & Core_models.Result.t_Result (t_Ss & t_Ct) t_Error)
+    : Prims.Pure (iimpl_447424039_ & Core_models.Result.t_Result (t_Array u8 v_L) t_Error)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
-/// Encapsulate a shared secret to the provided `pk` and return the `(Key, Enc)` tuple.
-val impl_PublicKey__encapsulate_derand (self: t_PublicKey) (seed: t_Slice u8)
-    : Prims.Pure (Core_models.Result.t_Result (t_Ss & t_Ct) t_Error)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-/// Encode public key.
-val impl_PublicKey__encode (self: t_PublicKey)
-    : Prims.Pure (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Prims.l_True (fun _ -> Prims.l_True)
-
-/// Decode a public key.
-val impl_PublicKey__decode (alg: t_Algorithm) (bytes: t_Slice u8)
-    : Prims.Pure (Core_models.Result.t_Result t_PublicKey t_Error)
+val gen_mlkem768
+      (#iimpl_447424039_: Type0)
+      {| i0: Rand_core.t_CryptoRng iimpl_447424039_ |}
+      (rng: iimpl_447424039_)
+    : Prims.Pure
+      (iimpl_447424039_ &
+        Core_models.Result.t_Result
+          (Libcrux_ml_kem.Types.t_MlKemPrivateKey (mk_usize 2400) &
+            Libcrux_ml_kem.Types.t_MlKemPublicKey (mk_usize 1184)) t_Error)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
@@ -166,3 +239,63 @@ val key_gen_derand (alg: t_Algorithm) (seed: t_Slice u8)
     : Prims.Pure (Core_models.Result.t_Result (t_PrivateKey & t_PublicKey) t_Error)
       Prims.l_True
       (fun _ -> Prims.l_True)
+
+val mlkem_rand
+      (#iimpl_447424039_: Type0)
+      {| i0: Rand_core.t_CryptoRng iimpl_447424039_ |}
+      (rng: iimpl_447424039_)
+    : Prims.Pure (iimpl_447424039_ & Core_models.Result.t_Result (t_Array u8 (mk_usize 32)) t_Error)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_11: Core_models.Convert.t_TryInto t_PublicKey Libcrux_ecdh.X25519.t_PublicKey =
+  {
+    f_Error = Libcrux_ecdh.t_Error;
+    f_try_into_pre = (fun (self: t_PublicKey) -> true);
+    f_try_into_post
+    =
+    (fun
+        (self: t_PublicKey)
+        (out: Core_models.Result.t_Result Libcrux_ecdh.X25519.t_PublicKey Libcrux_ecdh.t_Error)
+        ->
+        true);
+    f_try_into
+    =
+    fun (self: t_PublicKey) ->
+      match self <: t_PublicKey with
+      | PublicKey_X25519 k ->
+        Core_models.Result.Result_Ok k
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.X25519.t_PublicKey Libcrux_ecdh.t_Error
+      | _ ->
+        Core_models.Result.Result_Err (Libcrux_ecdh.Error_InvalidPoint <: Libcrux_ecdh.t_Error)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.X25519.t_PublicKey Libcrux_ecdh.t_Error
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_12: Core_models.Convert.t_TryInto t_PrivateKey Libcrux_ecdh.X25519.t_PrivateKey =
+  {
+    f_Error = Libcrux_ecdh.t_Error;
+    f_try_into_pre = (fun (self: t_PrivateKey) -> true);
+    f_try_into_post
+    =
+    (fun
+        (self: t_PrivateKey)
+        (out: Core_models.Result.t_Result Libcrux_ecdh.X25519.t_PrivateKey Libcrux_ecdh.t_Error)
+        ->
+        true);
+    f_try_into
+    =
+    fun (self: t_PrivateKey) ->
+      match self <: t_PrivateKey with
+      | PrivateKey_X25519 k ->
+        Core_models.Result.Result_Ok k
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.X25519.t_PrivateKey Libcrux_ecdh.t_Error
+      | _ ->
+        Core_models.Result.Result_Err (Libcrux_ecdh.Error_InvalidPoint <: Libcrux_ecdh.t_Error)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.X25519.t_PrivateKey Libcrux_ecdh.t_Error
+  }

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/models/Libcrux_kem.fsti
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/models/Libcrux_kem.fsti
@@ -9,7 +9,6 @@ let _ =
   let open Libcrux_ecdh.P256_internal in
   let open Libcrux_ecdh.X25519 in
   let open Libcrux_ml_kem.Types in
-  let open Rand.Rng in
   let open Rand_core in
   ()
 
@@ -30,6 +29,21 @@ type t_Algorithm =
 val t_Algorithm_cast_to_repr (x: t_Algorithm)
     : Prims.Pure isize Prims.l_True (fun _ -> Prims.l_True)
 
+let impl_13: Core_models.Clone.t_Clone t_Algorithm =
+  { f_clone = (fun x -> x); f_clone_pre = (fun _ -> True); f_clone_post = (fun _ _ -> True) }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_14:Core_models.Marker.t_Copy t_Algorithm
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_15:Core_models.Marker.t_StructuralPartialEq t_Algorithm
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_16:Core_models.Cmp.t_PartialEq t_Algorithm t_Algorithm
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_17:Core_models.Fmt.t_Debug t_Algorithm
+
 type t_Error =
   | Error_EcDhError : Libcrux_ecdh.t_Error -> t_Error
   | Error_KeyGen : t_Error
@@ -40,14 +54,92 @@ type t_Error =
   | Error_InvalidPublicKey : t_Error
   | Error_InvalidCiphertext : t_Error
 
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_18:Core_models.Fmt.t_Debug t_Error
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_19:Core_models.Marker.t_StructuralPartialEq t_Error
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_20:Core_models.Cmp.t_PartialEq t_Error t_Error
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_21:Core_models.Cmp.t_Eq t_Error
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl: Core_models.Convert.t_TryFrom Libcrux_ecdh.t_Algorithm t_Algorithm =
+  {
+    f_Error = string;
+    f_try_from_pre = (fun (value: t_Algorithm) -> true);
+    f_try_from_post
+    =
+    (fun (value: t_Algorithm) (out: Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string) ->
+        true);
+    f_try_from
+    =
+    fun (value: t_Algorithm) ->
+      match value <: t_Algorithm with
+      | Algorithm_X25519  ->
+        Core_models.Result.Result_Ok (Libcrux_ecdh.Algorithm_X25519 <: Libcrux_ecdh.t_Algorithm)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string
+      | Algorithm_X448  ->
+        Core_models.Result.Result_Ok (Libcrux_ecdh.Algorithm_X448 <: Libcrux_ecdh.t_Algorithm)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string
+      | Algorithm_Secp256r1  ->
+        Core_models.Result.Result_Ok (Libcrux_ecdh.Algorithm_P256 <: Libcrux_ecdh.t_Algorithm)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string
+      | Algorithm_Secp384r1  ->
+        Core_models.Result.Result_Ok (Libcrux_ecdh.Algorithm_P384 <: Libcrux_ecdh.t_Algorithm)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string
+      | Algorithm_Secp521r1  ->
+        Core_models.Result.Result_Ok (Libcrux_ecdh.Algorithm_P521 <: Libcrux_ecdh.t_Algorithm)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string
+      | Algorithm_X25519MlKem768Draft00  ->
+        Core_models.Result.Result_Ok (Libcrux_ecdh.Algorithm_X25519 <: Libcrux_ecdh.t_Algorithm)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string
+      | Algorithm_XWingKemDraft06  ->
+        Core_models.Result.Result_Ok (Libcrux_ecdh.Algorithm_X25519 <: Libcrux_ecdh.t_Algorithm)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string
+      | _ ->
+        Core_models.Result.Result_Err "provided algorithm is not an ECDH algorithm"
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.t_Algorithm string
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_1:Core_models.Convert.t_From t_Error Libcrux_ecdh.t_Error
+
 /// An ML-KEM768-x25519 private key.
 type t_X25519MlKem768Draft00PrivateKey = {
   f_mlkem:Libcrux_ml_kem.Types.t_MlKemPrivateKey (mk_usize 2400);
   f_x25519:Libcrux_ecdh.X25519.t_PrivateKey
 }
 
+val impl_X25519MlKem768Draft00PrivateKey__decode (bytes: t_Slice u8)
+    : Prims.Pure (Core_models.Result.t_Result t_X25519MlKem768Draft00PrivateKey t_Error)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_X25519MlKem768Draft00PrivateKey__encode (self: t_X25519MlKem768Draft00PrivateKey)
+    : Prims.Pure (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Prims.l_True (fun _ -> Prims.l_True)
+
 /// An X-Wing private key.
 type t_XWingKemDraft06PrivateKey = { f_seed:t_Array u8 (mk_usize 32) }
+
+val impl_XWingKemDraft06PrivateKey__decode (bytes: t_Slice u8)
+    : Prims.Pure (Core_models.Result.t_Result t_XWingKemDraft06PrivateKey t_Error)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_XWingKemDraft06PrivateKey__encode (self: t_XWingKemDraft06PrivateKey)
+    : Prims.Pure (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Prims.l_True (fun _ -> Prims.l_True)
 
 /// A KEM private key.
 type t_PrivateKey =
@@ -65,11 +157,27 @@ type t_X25519MlKem768Draft00PublicKey = {
   f_x25519:Libcrux_ecdh.X25519.t_PublicKey
 }
 
+val impl_X25519MlKem768Draft00PublicKey__decode (bytes: t_Slice u8)
+    : Prims.Pure (Core_models.Result.t_Result t_X25519MlKem768Draft00PublicKey t_Error)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_X25519MlKem768Draft00PublicKey__encode (self: t_X25519MlKem768Draft00PublicKey)
+    : Prims.Pure (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Prims.l_True (fun _ -> Prims.l_True)
+
 /// An X-Wing public key.
 type t_XWingKemDraft06PublicKey = {
   f_pk_m:Libcrux_ml_kem.Types.t_MlKemPublicKey (mk_usize 1184);
   f_pk_x:Libcrux_ecdh.X25519.t_PublicKey
 }
+
+val impl_XWingKemDraft06PublicKey__decode (bytes: t_Slice u8)
+    : Prims.Pure (Core_models.Result.t_Result t_XWingKemDraft06PublicKey t_Error)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_XWingKemDraft06PublicKey__encode (self: t_XWingKemDraft06PublicKey)
+    : Prims.Pure (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Prims.l_True (fun _ -> Prims.l_True)
 
 /// A KEM public key.
 type t_PublicKey =
@@ -119,16 +227,6 @@ val impl_PrivateKey__decode (alg: t_Algorithm) (bytes: t_Slice u8)
       (fun _ -> Prims.l_True)
 
 /// Encapsulate a shared secret to the provided `pk` and return the `(Key, Enc)` tuple.
-val impl_PublicKey__encapsulate
-      (#iimpl_447424039_: Type0)
-      {| i0: Rand_core.t_CryptoRng iimpl_447424039_ |}
-      (self: t_PublicKey)
-      (rng: iimpl_447424039_)
-    : Prims.Pure (iimpl_447424039_ & Core_models.Result.t_Result (t_Ss & t_Ct) t_Error)
-      Prims.l_True
-      (fun _ -> Prims.l_True)
-
-/// Encapsulate a shared secret to the provided `pk` and return the `(Key, Enc)` tuple.
 val impl_PublicKey__encapsulate_derand (self: t_PublicKey) (seed: t_Slice u8)
     : Prims.Pure (Core_models.Result.t_Result (t_Ss & t_Ct) t_Error)
       Prims.l_True
@@ -141,6 +239,50 @@ val impl_PublicKey__encode (self: t_PublicKey)
 /// Decode a public key.
 val impl_PublicKey__decode (alg: t_Algorithm) (bytes: t_Slice u8)
     : Prims.Pure (Core_models.Result.t_Result t_PublicKey t_Error)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Encode a shared secret.
+val impl_Ss__encode (self: t_Ss)
+    : Prims.Pure (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Encode a ciphertext.
+val impl_Ct__encode (self: t_Ct)
+    : Prims.Pure (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Decode a ciphertext.
+val impl_Ct__decode (alg: t_Algorithm) (bytes: t_Slice u8)
+    : Prims.Pure (Core_models.Result.t_Result t_Ct t_Error) Prims.l_True (fun _ -> Prims.l_True)
+
+/// Compute the public key for a private key of the given [`Algorithm`].
+/// Applicable only to X25519 and secp256r1.
+val secret_to_public
+      (#iimpl_677085834_: Type0)
+      {| i0: Core_models.Convert.t_AsRef iimpl_677085834_ (t_Slice u8) |}
+      (alg: t_Algorithm)
+      (sk: iimpl_677085834_)
+    : Prims.Pure (Core_models.Result.t_Result (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) t_Error)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val random_array
+      (v_L: usize)
+      (#iimpl_447424039_: Type0)
+      {| i0: Rand_core.t_CryptoRng iimpl_447424039_ |}
+      (rng: iimpl_447424039_)
+    : Prims.Pure (iimpl_447424039_ & Core_models.Result.t_Result (t_Array u8 v_L) t_Error)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val gen_mlkem768
+      (#iimpl_447424039_: Type0)
+      {| i0: Rand_core.t_CryptoRng iimpl_447424039_ |}
+      (rng: iimpl_447424039_)
+    : Prims.Pure
+      (iimpl_447424039_ &
+        Core_models.Result.t_Result
+          (Libcrux_ml_kem.Types.t_MlKemPrivateKey (mk_usize 2400) &
+            Libcrux_ml_kem.Types.t_MlKemPublicKey (mk_usize 1184)) t_Error)
       Prims.l_True
       (fun _ -> Prims.l_True)
 
@@ -166,3 +308,73 @@ val key_gen_derand (alg: t_Algorithm) (seed: t_Slice u8)
     : Prims.Pure (Core_models.Result.t_Result (t_PrivateKey & t_PublicKey) t_Error)
       Prims.l_True
       (fun _ -> Prims.l_True)
+
+val mlkem_rand
+      (#iimpl_447424039_: Type0)
+      {| i0: Rand_core.t_CryptoRng iimpl_447424039_ |}
+      (rng: iimpl_447424039_)
+    : Prims.Pure (iimpl_447424039_ & Core_models.Result.t_Result (t_Array u8 (mk_usize 32)) t_Error)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+/// Encapsulate a shared secret to the provided `pk` and return the `(Key, Enc)` tuple.
+val impl_PublicKey__encapsulate
+      (#iimpl_447424039_: Type0)
+      {| i0: Rand_core.t_CryptoRng iimpl_447424039_ |}
+      (self: t_PublicKey)
+      (rng: iimpl_447424039_)
+    : Prims.Pure (iimpl_447424039_ & Core_models.Result.t_Result (t_Ss & t_Ct) t_Error)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_11: Core_models.Convert.t_TryInto t_PublicKey Libcrux_ecdh.X25519.t_PublicKey =
+  {
+    f_Error = Libcrux_ecdh.t_Error;
+    f_try_into_pre = (fun (self: t_PublicKey) -> true);
+    f_try_into_post
+    =
+    (fun
+        (self: t_PublicKey)
+        (out: Core_models.Result.t_Result Libcrux_ecdh.X25519.t_PublicKey Libcrux_ecdh.t_Error)
+        ->
+        true);
+    f_try_into
+    =
+    fun (self: t_PublicKey) ->
+      match self <: t_PublicKey with
+      | PublicKey_X25519 k ->
+        Core_models.Result.Result_Ok k
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.X25519.t_PublicKey Libcrux_ecdh.t_Error
+      | _ ->
+        Core_models.Result.Result_Err (Libcrux_ecdh.Error_InvalidPoint <: Libcrux_ecdh.t_Error)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.X25519.t_PublicKey Libcrux_ecdh.t_Error
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_12: Core_models.Convert.t_TryInto t_PrivateKey Libcrux_ecdh.X25519.t_PrivateKey =
+  {
+    f_Error = Libcrux_ecdh.t_Error;
+    f_try_into_pre = (fun (self: t_PrivateKey) -> true);
+    f_try_into_post
+    =
+    (fun
+        (self: t_PrivateKey)
+        (out: Core_models.Result.t_Result Libcrux_ecdh.X25519.t_PrivateKey Libcrux_ecdh.t_Error)
+        ->
+        true);
+    f_try_into
+    =
+    fun (self: t_PrivateKey) ->
+      match self <: t_PrivateKey with
+      | PrivateKey_X25519 k ->
+        Core_models.Result.Result_Ok k
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.X25519.t_PrivateKey Libcrux_ecdh.t_Error
+      | _ ->
+        Core_models.Result.Result_Err (Libcrux_ecdh.Error_InvalidPoint <: Libcrux_ecdh.t_Error)
+        <:
+        Core_models.Result.t_Result Libcrux_ecdh.X25519.t_PrivateKey Libcrux_ecdh.t_Error
+  }

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/models/Makefile
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/models/Makefile
@@ -2,7 +2,7 @@
 #
 # include pattern modifiers (e.g. `+`, `+!`, `+:`) are documented
 # in `cargo hax into --help`
-HAX_LIB_VERSION=$(shell make -C ../../.. -s hax-lib-version)  # TODO: Can we generalize this so it's automatic?
+HAX_LIB_VERSION=$(shell PACKAGE=hax-lib make -C ../../.. -s version)
 
 LIBCRUX_VERSION=c1e75990cbcf1bf476199fb1367df680c6de570f
 

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/models/Makefile
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/models/Makefile
@@ -2,23 +2,19 @@ HAX_LIB_VERSION=$(shell make -C ../../.. -s hax-lib-version)
 
 # include pattern modifiers (e.g. `+`, `+!`, `+:`) are documented
 # in `cargo hax into --help`
-LIBCRUX_VERSION=41e1b3d57f8f6c2e49f3fb1e6c33dbb92279023d  # FIXME: cfm/libcrux@41e1b3d
+LIBCRUX_VERSION=c1e75990cbcf1bf476199fb1367df680c6de570f
+
 LIBCRUX_ECDH_TARGETS := -**
+LIBCRUX_ECDH_TARGETS += +libcrux_ecdh::Algorithm
 LIBCRUX_ECDH_TARGETS += +libcrux_ecdh::Error
 LIBCRUX_ECDH_TARGETS += +libcrux_ecdh::*::PrivateKey
 LIBCRUX_ECDH_TARGETS += +libcrux_ecdh::*::PublicKey
 LIBCRUX_ECDH_TARGETS += +libcrux_ecdh::*::SharedSecret
 LIBCRUX_KEM_TARGETS := -**
-LIBCRUX_KEM_TARGETS += +libcrux_kem::Algorithm
-LIBCRUX_KEM_TARGETS += +libcrux_kem::Error
-LIBCRUX_KEM_TARGETS += +libcrux_kem::PrivateKey
-LIBCRUX_KEM_TARGETS += +libcrux_kem::PublicKey
-LIBCRUX_KEM_TARGETS += +libcrux_kem::Ct
-LIBCRUX_KEM_TARGETS += +libcrux_kem::Ss
 # `+!` (no transitive deps): plain `+` pulls in items that cross the
 # `Libcrux_kem.Xwing` submodule boundary
-LIBCRUX_KEM_TARGETS += +!libcrux_kem::key_gen
-LIBCRUX_KEM_TARGETS += +!libcrux_kem::key_gen_derand
+LIBCRUX_KEM_TARGETS += +!libcrux_kem::*
+
 LIBCRUX_ML_KEM_TARGETS := -**
 LIBCRUX_ML_KEM_TARGETS += +libcrux_ml_kem::types::MlKemPrivateKey
 LIBCRUX_ML_KEM_TARGETS += +libcrux_ml_kem::types::MlKemPublicKey
@@ -33,7 +29,7 @@ LIBCRUX_TRAITS_TARGETS += +libcrux_traits::kem::owned::Kem
 .PHONY: libcrux
 libcrux:
 	rm -rf $@
-	git clone https://github.com/cfm/libcrux  # FIXME: cfm/libcrux@41e1b3d
+	git clone https://github.com/cryspen/libcrux
 	cd $@ && git checkout $(LIBCRUX_VERSION)
 
 	cd $@/libcrux-ecdh && cargo add --target 'cfg(hax)' hax-lib@$(HAX_LIB_VERSION)

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/models/Makefile
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/models/Makefile
@@ -1,7 +1,9 @@
-HAX_LIB_VERSION=$(shell make -C ../../.. -s hax-lib-version)
-
+# Keep versions in this file in sync with protocol-minimal's "Cargo.toml".
+#
 # include pattern modifiers (e.g. `+`, `+!`, `+:`) are documented
 # in `cargo hax into --help`
+HAX_LIB_VERSION=$(shell make -C ../../.. -s hax-lib-version)  # TODO: Can we generalize this so it's automatic?
+
 LIBCRUX_VERSION=c1e75990cbcf1bf476199fb1367df680c6de570f
 
 LIBCRUX_ECDH_TARGETS := -**
@@ -10,6 +12,7 @@ LIBCRUX_ECDH_TARGETS += +libcrux_ecdh::Error
 LIBCRUX_ECDH_TARGETS += +libcrux_ecdh::*::PrivateKey
 LIBCRUX_ECDH_TARGETS += +libcrux_ecdh::*::PublicKey
 LIBCRUX_ECDH_TARGETS += +libcrux_ecdh::*::SharedSecret
+
 LIBCRUX_KEM_TARGETS := -**
 # `+!` (no transitive deps): plain `+` pulls in items that cross the
 # `Libcrux_kem.Xwing` submodule boundary
@@ -20,12 +23,14 @@ LIBCRUX_ML_KEM_TARGETS += +libcrux_ml_kem::types::MlKemPrivateKey
 LIBCRUX_ML_KEM_TARGETS += +libcrux_ml_kem::types::MlKemPublicKey
 LIBCRUX_ML_KEM_TARGETS += +libcrux_ml_kem::types::MlKemCiphertext
 LIBCRUX_ML_KEM_TARGETS += +libcrux_ml_kem::mlkem768::MlKem768
+
 LIBCRUX_TRAITS_TARGETS := -**
 LIBCRUX_TRAITS_TARGETS += +libcrux_traits::kem::arrayref::Kem
 LIBCRUX_TRAITS_TARGETS += +libcrux_traits::kem::arrayref::KeyGenError
 LIBCRUX_TRAITS_TARGETS += +libcrux_traits::kem::arrayref::EncapsError
 LIBCRUX_TRAITS_TARGETS += +libcrux_traits::kem::arrayref::DecapsError
 LIBCRUX_TRAITS_TARGETS += +libcrux_traits::kem::owned::Kem
+
 .PHONY: libcrux
 libcrux:
 	rm -rf $@

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/models/Makefile
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/models/Makefile
@@ -6,23 +6,23 @@ HAX_LIB_VERSION=$(shell make -C ../../.. -s hax-lib-version)
 
 # include pattern modifiers (e.g. `+`, `+!`, `+:`) are documented
 # in `cargo hax into --help`
-LIBCRUX_VERSION=41e1b3d57f8f6c2e49f3fb1e6c33dbb92279023d  # FIXME: cfm/libcrux@41e1b3d
+LIBCRUX_VERSION=3cd1843b0f029b2c8499d1af4234670ad04341bf  # cfm/libcrux@hax-lib-0.3.7 pending cryspen/libcrux#1478
 LIBCRUX_ECDH_TARGETS := -**
+LIBCRUX_ECDH_TARGETS += +libcrux_ecdh::Algorithm
 LIBCRUX_ECDH_TARGETS += +libcrux_ecdh::Error
 LIBCRUX_ECDH_TARGETS += +libcrux_ecdh::*::PrivateKey
 LIBCRUX_ECDH_TARGETS += +libcrux_ecdh::*::PublicKey
 LIBCRUX_ECDH_TARGETS += +libcrux_ecdh::*::SharedSecret
 LIBCRUX_KEM_TARGETS := -**
-LIBCRUX_KEM_TARGETS += +libcrux_kem::Algorithm
-LIBCRUX_KEM_TARGETS += +libcrux_kem::Error
-LIBCRUX_KEM_TARGETS += +libcrux_kem::PrivateKey
-LIBCRUX_KEM_TARGETS += +libcrux_kem::PublicKey
-LIBCRUX_KEM_TARGETS += +libcrux_kem::Ct
-LIBCRUX_KEM_TARGETS += +libcrux_kem::Ss
 # `+!` (no transitive deps): plain `+` pulls in items that cross the
 # `Libcrux_kem.Xwing` submodule boundary
-LIBCRUX_KEM_TARGETS += +!libcrux_kem::key_gen
-LIBCRUX_KEM_TARGETS += +!libcrux_kem::key_gen_derand
+LIBCRUX_KEM_TARGETS += +!libcrux_kem::*
+# `+!libcrux_kem::*` doesn't reach into inherent-impl blocks; explicitly specify
+# the methods whose implementations we need:
+LIBCRUX_KEM_TARGETS += +!**::encode
+LIBCRUX_KEM_TARGETS += +!**::decode
+LIBCRUX_KEM_TARGETS += +!**::encapsulate
+LIBCRUX_KEM_TARGETS += +!**::encapsulate_derand
 LIBCRUX_ML_KEM_TARGETS := -**
 LIBCRUX_ML_KEM_TARGETS += +libcrux_ml_kem::types::MlKemPrivateKey
 LIBCRUX_ML_KEM_TARGETS += +libcrux_ml_kem::types::MlKemPublicKey
@@ -45,7 +45,7 @@ LIBCRUX_CHACHA20POLY1305_TARGETS += +libcrux_chacha20poly1305::NONCE_LEN
 .PHONY: libcrux
 libcrux:
 	rm -rf $@
-	git clone https://github.com/cfm/libcrux  # FIXME: cfm/libcrux@41e1b3d
+	git clone https://github.com/cfm/libcrux # cfm/libcrux@hax-lib-0.3.7 pending cryspen/libcrux#1478
 	cd $@ && git checkout $(LIBCRUX_VERSION)
 
 	cd $@/libcrux-ecdh && cargo add --target 'cfg(hax)' hax-lib@$(HAX_LIB_VERSION)

--- a/securedrop-protocol/protocol-minimal/src/message.rs
+++ b/securedrop-protocol/protocol-minimal/src/message.rs
@@ -232,6 +232,7 @@ pub fn auth_enc<R: RngCore + CryptoRng>(
 
     // c1 is always LEN_DHKEM_SHAREDSECRET_ENCAPS bytes for DHKEM(X25519)
     let c1: [u8; DH_AKEM_ENCAPS_SECRET_LEN] = c1_vec
+        .as_slice()
         .try_into()
         .expect("DHKEM(X25519) encapsulation output has unexpected length");
 

--- a/securedrop-protocol/protocol-minimal/src/metadata.rs
+++ b/securedrop-protocol/protocol-minimal/src/metadata.rs
@@ -127,6 +127,7 @@ pub fn encrypt(pk_r: &MetadataPublicKey, m: &[u8]) -> MetadataCiphertext {
 
     // XWing will always produce this length ciphertext, so this .expect is fine.
     let c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS] = c_vec
+        .as_slice()
         .try_into()
         .expect("X-Wing encapsulation output has unexpected length");
 

--- a/securedrop-protocol/protocol-minimal/src/primitives/dh_akem.rs
+++ b/securedrop-protocol/protocol-minimal/src/primitives/dh_akem.rs
@@ -122,11 +122,13 @@ fn typed(
 
     let private_key = DhAkemPrivateKey::from_bytes(
         private_key_bytes
+            .as_slice()
             .try_into()
             .map_err(|_| anyhow::anyhow!("Failed to convert private key bytes"))?,
     );
     let public_key = DhAkemPublicKey::from_bytes(
         public_key_bytes
+            .as_slice()
             .try_into()
             .map_err(|_| anyhow::anyhow!("Failed to convert public key bytes"))?,
     );

--- a/securedrop-protocol/protocol-minimal/src/primitives/mlkem.rs
+++ b/securedrop-protocol/protocol-minimal/src/primitives/mlkem.rs
@@ -97,11 +97,13 @@ fn typed(
 
     let private_key = MLKEM768PrivateKey::from_bytes(
         private_key_bytes
+            .as_slice()
             .try_into()
             .map_err(|_| anyhow::anyhow!("Failed to convert private key bytes"))?,
     );
     let public_key = MLKEM768PublicKey::from_bytes(
         public_key_bytes
+            .as_slice()
             .try_into()
             .map_err(|_| anyhow::anyhow!("Failed to convert public key bytes"))?,
     );

--- a/securedrop-protocol/protocol-minimal/src/primitives/xwing.rs
+++ b/securedrop-protocol/protocol-minimal/src/primitives/xwing.rs
@@ -98,11 +98,13 @@ fn typed(
 
     let private_key = XWingPrivateKey::from_bytes(
         private_key_bytes
+            .as_slice()
             .try_into()
             .map_err(|_| anyhow::anyhow!("Failed to convert private key bytes"))?,
     );
     let public_key = XWingPublicKey::from_bytes(
         public_key_bytes
+            .as_slice()
             .try_into()
             .map_err(|_| anyhow::anyhow!("Failed to convert public key bytes"))?,
     );

--- a/securedrop-protocol/protocol-minimal/src/source.rs
+++ b/securedrop-protocol/protocol-minimal/src/source.rs
@@ -229,7 +229,7 @@ mod tests {
     use super::*;
     use crate::primitives::xwing::XWING_PRIVATE_KEY_LEN;
     use rand_chacha::ChaCha20Rng;
-    use rand_core::SeedableRng;
+    use rand_core::{Rng, SeedableRng};
 
     #[test]
     fn test_initialize_with_passphrase() {


### PR DESCRIPTION
Fixes #258, after a bit of run-around: see <https://github.com/freedomofpress/securedrop-protocol/pull/238#issuecomment-4696138965>.
- [x] Depends on #278

Following up on <https://github.com/freedomofpress/securedrop-protocol/issues/222#issuecomment-4263017456> per <https://github.com/cryspen/libcrux/pull/1397#issuecomment-4357957534>.


## Test plan

In `securedrop-protocol/protocol-minimal`:

1. Make sure you are running:
    https://github.com/freedomofpress/securedrop-protocol/blob/f95d04b697c28438485377f09859a36d99322d46/.github/workflows/hax.yml#L22-L23
    - [ ] In particular, `cargo install --list | grep "hax" | grep " v"` shows only v0.3.7 installed, or `... | grep -v "0\.3\.7"` returns nothing.
2. [ ] `make clean extract` produces no diff.
3. [ ] `make verify` passes.
4. [ ] `make -C proofs/fstar/models libcrux` produces no diff.