### PR TITLE
Parameterize rng for uuid::v4 (message id) generation

### DIFF
--- a/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
+++ b/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
@@ -220,7 +220,7 @@ mod tests {
     use rand_chacha::ChaCha20Rng;
     use rand_core::SeedableRng;
 
-    use crate::{Journalist, Source};
+    use crate::{Journalist, Source, storage::ServerStorage};
 
     use super::*;
 
@@ -313,13 +313,12 @@ mod tests {
         let plaintext = build_message(&source.public(), msg.to_vec());
         let envelope = encrypt(&mut rng, &source, &plaintext, &journalist_public);
 
-        // On server. TODO: in helper function
-        let mut store = ServerMessageStore::new();
-        let message_id = uuid::Uuid::new_v4();
+        let mut store: ServerStorage = ServerStorage::new();
+        let message_id = store.deterministic_uuid(&mut rng);
 
-        store.insert(message_id, envelope);
+        store.add_message(message_id, envelope);
 
-        let challenges = compute_fetch_challenges(&mut rng, &store, 2);
+        let challenges = compute_fetch_challenges(&mut rng, &store.get_messages(), 2);
 
         let solved_ids = solve_fetch_challenges(&journalist, &challenges);
 
@@ -343,13 +342,12 @@ mod tests {
         let plaintext = build_message(&source.public(), msg.to_vec());
         let envelope = encrypt(&mut rng, &source, &plaintext, &journalist_public);
 
-        // On server. TODO: in helper function
-        let mut store = ServerMessageStore::new();
-        let message_id = uuid::Uuid::new_v4();
+        let mut store: ServerStorage = ServerStorage::new();
+        let message_id = store.deterministic_uuid(&mut rng);
 
-        store.insert(message_id, envelope);
+        store.add_message(message_id, envelope);
 
-        let challenges = compute_fetch_challenges(&mut rng, &store, 2);
+        let challenges = compute_fetch_challenges(&mut rng, &store.get_messages(), 2);
 
         let solved_ids = solve_fetch_challenges(&journalist, &challenges);
 

--- a/securedrop-protocol/protocol-minimal/src/server.rs
+++ b/securedrop-protocol/protocol-minimal/src/server.rs
@@ -238,9 +238,13 @@ impl Server {
     }
 
     /// Handle message submission (step 6 for sources, step 9 for journalists)
-    pub fn handle_message_submit(&mut self, message: Envelope) -> Result<Uuid, Error> {
+    pub fn handle_message_submit<R: RngCore + CryptoRng>(
+        &mut self,
+        message: Envelope,
+        rng: &mut R,
+    ) -> Result<Uuid, Error> {
         // Generate a random message ID
-        let message_id = Uuid::new_v4();
+        let message_id = self.storage.deterministic_uuid(rng);
 
         // Store the message with the generated ID
         self.storage.add_message(message_id, message);

--- a/securedrop-protocol/protocol-minimal/src/storage.rs
+++ b/securedrop-protocol/protocol-minimal/src/storage.rs
@@ -161,6 +161,13 @@ impl ServerStorage {
         None
     }
 
+    pub(crate) fn deterministic_uuid<R: RngCore + CryptoRng>(&mut self, rng: &mut R) -> Uuid {
+        let mut bytes = [0u8; 16];
+        rng.fill_bytes(&mut bytes);
+
+        uuid::Builder::from_random_bytes(bytes).into_uuid()
+    }
+
     /// Get all messages
     pub fn get_messages(&self) -> &HashMap<Uuid, Envelope> {
         &self.messages

--- a/securedrop-protocol/protocol-minimal/tests/core.rs
+++ b/securedrop-protocol/protocol-minimal/tests/core.rs
@@ -251,7 +251,7 @@ fn protocol_step_6_source_submits_message() {
 
     // Submit the message to the server
     let message_id = server_session
-        .handle_message_submit(message.clone())
+        .handle_message_submit(message.clone(), &mut rng)
         .expect("Can handle message submission");
 
     // Verify that the message was stored
@@ -339,7 +339,7 @@ fn protocol_step_7_message_id_fetch() {
         .expect("Can submit message");
 
     let message_id = server_session
-        .handle_message_submit(message.clone())
+        .handle_message_submit(message.clone(), &mut rng)
         .expect("Can handle message submission");
 
     // Step 7: Test message ID fetch from journalist perspective


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-protocol/issues/169

Use uuid::Builder's from_bytes, inject source of randomness via RngCore + CryptoRng 

Test plan: 
- Visual review
- Tests passing
