### PR TITLE
fix: Inject rng instead of calls to getrandom; configure clippy to deny common sources of hidden randomness.

### DIFF
--- a/securedrop-protocol/protocol-minimal/Cargo.toml
+++ b/securedrop-protocol/protocol-minimal/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-3.0"
 [lib]
 
 [dependencies]
+# no rand/getrandom in core library!
 # crypto stack, pinned to cryspen/libcrux#1312
 libcrux-ed25519 = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f", features = ["rand"] }
 libcrux-curve25519 = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f" }
@@ -22,11 +23,10 @@ libcrux-sha2 = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf
 hpke-rs = { git = "https://github.com/cfm/hpke-rs", rev = "9325551537d642d308edc60f3b271742b3a25b00", features = ["libcrux"] }
 
 rand_core = { version = "0.9" }
-getrandom = { version = "0.3", default-features = false }
+
 anyhow = "1.0"
 hashbrown = { version = "0.14", features = ["raw"] }
-# In theory, it should be possible to use v4 uuids with getrandom per https://docs.rs/uuid/1.18.1/uuid/#building-for-other-targets, but cargo nono complains vigorously
-uuid = { version = "1.0", default-features = false, features = ["v4", "rng-getrandom", "js"] }
+uuid = { version = "1.0", default-features = false, features = ["v4", "js"] }
 argon2 = "0.5"
 blake2 = "0.10"
 
@@ -35,7 +35,7 @@ rand_chacha = {  version = "0.9.0", default-features = false  }
 
 [dev-dependencies]
 proptest = "1.3"
-getrandom = "0.3"
+getrandom = { version = "0.3", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/securedrop-protocol/protocol-minimal/clippy.toml
+++ b/securedrop-protocol/protocol-minimal/clippy.toml
@@ -1,0 +1,9 @@
+disallowed-types = [
+    { path = "rand::rngs::OsRng",  reason = "hidden randomness source breaks hax, test vectors, benchmarks; rand breaks nostd wasm32 compat", replacement = "Use rand_core for nostd wasm32 compat; use parameterized <R: Rng+CryptoRng>, revisit before prod deploy." },
+]
+
+disallowed-methods = [
+    { path = "getrandom::getrandom", reason = "hidden randomness source breaks hax, test vectors, benchmarks", replacement = "Use parameterized <R: Rng+CryptoRng>, revisit before prod deploy." },
+    { path = "getrandom::fill", reason = "hidden randomness source breaks hax, test vectors, benchmarks", replacement = "Use parameterized <R: Rng+CryptoRng>, revisit before prod deploy." },
+    { path = "getrandom::u32", reason = "hidden randomness source breaks hax, test vectors, benchmarks", replacement = "Use parameterized <R: Rng+CryptoRng>, revisit before prod deploy." },
+]

--- a/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
+++ b/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
@@ -126,7 +126,7 @@ pub fn compute_fetch_challenges<R: RngCore + CryptoRng>(
         // 3-party DH yields shared_secret used to encrypt message_id
         let shared_secret = dh_shared_secret(&DHPublicKey::from_bytes(envelope.mgdh), eph_sk)
             .expect("Need 3-party dh shared secret");
-        let enc_mid = encrypt_message_id(&shared_secret.into_bytes(), message_id).unwrap();
+        let enc_mid = encrypt_message_id(&shared_secret.into_bytes(), message_id, rng).unwrap();
 
         let kmid = enc_mid
             .try_into()

--- a/securedrop-protocol/protocol-minimal/src/lib.rs
+++ b/securedrop-protocol/protocol-minimal/src/lib.rs
@@ -1,4 +1,11 @@
 #![no_std]
+// Deny direct access to system randomness except in tests.
+// See clippy.toml
+#![deny(clippy::disallowed_types)]
+#![deny(clippy::disallowed_methods)]
+#![cfg_attr(test, allow(clippy::disallowed_types))]
+#![cfg_attr(test, allow(clippy::disallowed_methods))]
+
 extern crate alloc;
 
 pub mod api;

--- a/securedrop-protocol/protocol-minimal/src/primitives.rs
+++ b/securedrop-protocol/protocol-minimal/src/primitives.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 use anyhow::Error;
-use getrandom;
+use rand_core::{CryptoRng, RngCore};
 
 pub(crate) mod dh_akem;
 pub(crate) mod mlkem;
@@ -18,16 +18,20 @@ pub const MESSAGE_ID_FETCH_SIZE: usize = 10;
 /// Symmetric encryption for message IDs using ChaCha20-Poly1305
 ///
 /// This is used in step 7 for encrypting message IDs with a shared secret
-pub fn encrypt_message_id(key: &[u8], message_id: &[u8]) -> Result<Vec<u8>, Error> {
+pub fn encrypt_message_id<R: RngCore + CryptoRng>(
+    key: &[u8],
+    message_id: &[u8],
+    rng: &mut R,
+) -> Result<Vec<u8>, Error> {
     use libcrux_chacha20poly1305::{KEY_LEN, NONCE_LEN, TAG_LEN};
 
     if key.len() != KEY_LEN {
         return Err(anyhow::anyhow!("Invalid key length"));
     }
 
-    // Generate a random nonce (use getrandom for cross target compatibility)
+    // Generate a random nonce with supplied rng
     let mut nonce = [0u8; NONCE_LEN];
-    getrandom::fill(&mut nonce).expect("Need randomness");
+    rng.fill_bytes(&mut nonce);
 
     // Prepare output buffer: nonce + ciphertext + tag
     let mut output = alloc::vec::Vec::new();

--- a/securedrop-protocol/protocol-minimal/src/storage.rs
+++ b/securedrop-protocol/protocol-minimal/src/storage.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use getrandom;
 use hashbrown::HashMap;
 use rand_core::{CryptoRng, RngCore};
 use uuid::Uuid;
@@ -67,7 +66,7 @@ impl ServerStorage {
             }
 
             // Select a "random" index (note: Modulo bias, Toy purposes only!)
-            let index = getrandom::u32().unwrap() as usize % keys.len();
+            let index = rng.next_u32() as usize % keys.len();
 
             // Remove and return the selected key set
             Some(keys.remove(index))


### PR DESCRIPTION
Towards #169 
~Stacked on: #239 ; #242 (bugfix); will rebase once those are merged~ done!
- Avoid hidden use of system randomness by `getrandom` when generating message ID or encrypting message ID
- Avoid future footguns:
  - Add a clippy.toml to the core library and use clippy to complain if the core library calls out to `getrandom::fill`, `getrandom::u32`, etc. (but allow during tests)
  - Move getrandom to specifically be a dev-only dependency. 
    - The core library probably shouldn't depend on getrandom, but eventual source/journo client libraries can. 

Sidenote: I noticed rand_core::RngCore is deprecated: https://docs.rs/rand_core/latest/rand_core/trait.RngCore.html will file separate followup 