### PR TITLE
Proposed `hpke-ng` replacement for `hpke-rs`

### DIFF
--- a/securedrop-protocol/Cargo.lock
+++ b/securedrop-protocol/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,7 +69,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -54,6 +89,18 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64ct"
@@ -88,7 +135,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -98,6 +145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -129,15 +185,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "core-models"
-version = "0.0.5"
+name = "chacha20"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "657f625ff361906f779745d08375ae3cc9fef87a35fba5f22874cf773010daf4"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
- "hax-lib",
- "pastey",
- "rand 0.9.4",
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
 ]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-models"
@@ -146,8 +244,14 @@ source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367
 dependencies = [
  "hax-lib",
  "pastey",
- "rand 0.9.4",
+ "rand",
 ]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -156,6 +260,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.0",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -169,14 +309,165 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.3.0",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
+]
+
+[[package]]
+name = "ed448-goldilocks"
+version = "0.14.0-pre.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f6a69850962cce143a2872dba18284ebc9117286f5a79c6a14f0ce7c95b9f6d"
+dependencies = [
+ "elliptic-curve 0.14.0-rc.32",
+ "hash2curve",
+ "rand_core 0.10.0",
+ "sha3 0.11.0",
+ "subtle",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "rand_core 0.6.4",
+ "sec1 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.0-rc.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda94f31325c4275e9706adecbb6f0650dee2f904c915a98e3d81adaaaa757aa"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.3",
+ "crypto-common 0.2.1",
+ "hybrid-array",
+ "pkcs8",
+ "rand_core 0.10.0",
+ "rustcrypto-ff",
+ "rustcrypto-group",
+ "sec1 0.8.1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -200,6 +491,28 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -227,6 +540,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -253,10 +567,40 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "rand_core 0.10.0",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "hash2curve"
+version = "0.14.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5e38a1358dfed60ae56c6d62b2d1466853d162d9a518da0673e3670d95fd10"
+dependencies = [
+ "digest 0.11.3",
+ "elliptic-curve 0.14.0-rc.32",
 ]
 
 [[package]]
@@ -328,42 +672,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hpke-rs"
-version = "0.6.0"
-source = "git+https://github.com/cfm/hpke-rs?rev=9325551537d642d308edc60f3b271742b3a25b00#9325551537d642d308edc60f3b271742b3a25b00"
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hpke-rs-crypto",
- "hpke-rs-libcrux",
- "libcrux-sha3 0.0.7",
- "log",
- "rand_core 0.9.3",
- "subtle",
- "zeroize",
+ "hmac",
 ]
 
 [[package]]
-name = "hpke-rs-crypto"
-version = "0.6.0"
-source = "git+https://github.com/cfm/hpke-rs?rev=9325551537d642d308edc60f3b271742b3a25b00#9325551537d642d308edc60f3b271742b3a25b00"
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "rand_core 0.9.3",
- "zeroize",
+ "digest 0.10.7",
 ]
 
 [[package]]
-name = "hpke-rs-libcrux"
-version = "0.6.0"
-source = "git+https://github.com/cfm/hpke-rs?rev=9325551537d642d308edc60f3b271742b3a25b00#9325551537d642d308edc60f3b271742b3a25b00"
+name = "hpke-ng"
+version = "0.1.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031300ec46a577e9eebbd0620a6a428d606a0084a1be0ad373888b5929fe6426"
 dependencies = [
- "hpke-rs-crypto",
- "libcrux-aead",
- "libcrux-ecdh",
- "libcrux-hkdf",
- "libcrux-kem",
- "libcrux-traits 0.0.5",
- "rand 0.10.0",
- "rand_chacha 0.10.0",
+ "aead",
+ "aes-gcm",
+ "chacha20poly1305",
+ "ed448-goldilocks",
+ "hkdf",
+ "k256",
+ "ml-kem",
+ "p256",
+ "p384",
+ "p521",
  "rand_core 0.10.0",
+ "rand_core 0.6.4",
+ "rand_core 0.9.3",
+ "sha2",
+ "sha3 0.10.9",
+ "subtle",
+ "x-wing",
+ "x25519-dalek 2.0.1",
+ "zeroize",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "ctutils",
+ "subtle",
+ "typenum",
  "zeroize",
 ]
 
@@ -386,6 +747,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +772,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "elliptic-curve 0.13.8",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.1",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,28 +823,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
-name = "libcrux-aead"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
-dependencies = [
- "libcrux-aesgcm",
- "libcrux-chacha20poly1305",
- "libcrux-secrets 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "libcrux-traits 0.0.5",
-]
-
-[[package]]
-name = "libcrux-aesgcm"
-version = "0.0.6"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
-dependencies = [
- "libcrux-intrinsics 0.0.5",
- "libcrux-platform 0.0.3 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "libcrux-secrets 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "libcrux-traits 0.0.5",
-]
-
-[[package]]
 name = "libcrux-chacha20poly1305"
 version = "0.0.5"
 source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
@@ -443,8 +830,8 @@ dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
  "libcrux-poly1305",
- "libcrux-secrets 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "libcrux-traits 0.0.5",
+ "libcrux-secrets",
+ "libcrux-traits",
 ]
 
 [[package]]
@@ -454,8 +841,8 @@ source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
- "libcrux-secrets 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "libcrux-traits 0.0.5",
+ "libcrux-secrets",
+ "libcrux-traits",
 ]
 
 [[package]]
@@ -465,7 +852,7 @@ source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367
 dependencies = [
  "libcrux-curve25519",
  "libcrux-p256",
- "rand 0.9.4",
+ "rand",
 ]
 
 [[package]]
@@ -488,41 +875,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "libcrux-hkdf"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
-dependencies = [
- "libcrux-hacl-rs",
- "libcrux-hmac",
- "libcrux-secrets 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
-]
-
-[[package]]
-name = "libcrux-hmac"
-version = "0.0.5"
-source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
-dependencies = [
- "libcrux-hacl-rs",
- "libcrux-macros",
- "libcrux-sha2",
-]
-
-[[package]]
 name = "libcrux-intrinsics"
 version = "0.0.5"
 source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
 dependencies = [
- "core-models 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "hax-lib",
-]
-
-[[package]]
-name = "libcrux-intrinsics"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b5db005ff8001e026b73a6842ee81bbef8ec5ff0e1915a67ae65fd2a9fafa5"
-dependencies = [
- "core-models 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-models",
  "hax-lib",
 ]
 
@@ -535,9 +892,9 @@ dependencies = [
  "libcrux-ecdh",
  "libcrux-ml-kem",
  "libcrux-p256",
- "libcrux-sha3 0.0.6",
- "libcrux-traits 0.0.5",
- "rand 0.9.4",
+ "libcrux-sha3",
+ "libcrux-traits",
+ "rand",
 ]
 
 [[package]]
@@ -555,12 +912,12 @@ version = "0.0.6"
 source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
 dependencies = [
  "hax-lib",
- "libcrux-intrinsics 0.0.5",
- "libcrux-platform 0.0.3 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "libcrux-secrets 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "libcrux-sha3 0.0.6",
- "libcrux-traits 0.0.5",
- "rand 0.9.4",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-secrets",
+ "libcrux-sha3",
+ "libcrux-traits",
+ "rand",
  "tls_codec",
 ]
 
@@ -571,18 +928,9 @@ source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
- "libcrux-secrets 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
+ "libcrux-secrets",
  "libcrux-sha2",
- "libcrux-traits 0.0.5",
-]
-
-[[package]]
-name = "libcrux-platform"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9e21d7ed31a92ac539bd69a8c970b183ee883872d2d19ce27036e24cb8ecc4"
-dependencies = [
- "libc",
+ "libcrux-traits",
 ]
 
 [[package]]
@@ -605,15 +953,6 @@ dependencies = [
 [[package]]
 name = "libcrux-secrets"
 version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce650f3041b44ba40d4263852347d007cd2cd9d1cc856a6f6c8b2e10c3fd40b"
-dependencies = [
- "hax-lib",
-]
-
-[[package]]
-name = "libcrux-secrets"
-version = "0.0.5"
 source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
 dependencies = [
  "hax-lib",
@@ -626,7 +965,7 @@ source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
- "libcrux-traits 0.0.5",
+ "libcrux-traits",
 ]
 
 [[package]]
@@ -635,21 +974,9 @@ version = "0.0.6"
 source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
 dependencies = [
  "hax-lib",
- "libcrux-intrinsics 0.0.5",
- "libcrux-platform 0.0.3 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "libcrux-traits 0.0.5",
-]
-
-[[package]]
-name = "libcrux-sha3"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c50f6e04a184511b782c5cc1eb6a227c6d36f2c935e93d698655a93a99696b5"
-dependencies = [
- "hax-lib",
- "libcrux-intrinsics 0.0.6",
- "libcrux-platform 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libcrux-traits 0.0.6",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-traits",
 ]
 
 [[package]]
@@ -657,18 +984,8 @@ name = "libcrux-traits"
 version = "0.0.5"
 source = "git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f#c1e75990cbcf1bf476199fb1367df680c6de570f"
 dependencies = [
- "libcrux-secrets 0.0.5 (git+https://github.com/cryspen/libcrux?rev=c1e75990cbcf1bf476199fb1367df680c6de570f)",
- "rand 0.9.4",
-]
-
-[[package]]
-name = "libcrux-traits"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e4fa89f3f5e34b47f928b22b1b78395a0d4ec23b1f583db635f128159d65f"
-dependencies = [
- "libcrux-secrets 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.9.4",
+ "libcrux-secrets",
+ "rand",
 ]
 
 [[package]]
@@ -703,6 +1020,32 @@ checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
  "cc",
  "walkdir",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c77d5ff6d755d09a0ef4d4d28c2b7e83658fe83e8c736d55e93d43e380d1cd"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "rand_core 0.10.0",
+ "sha3 0.11.0",
+ "zeroize",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc7c90d33a0dac244570c26461d761ffaeadb3bfc2b17cc625ae2185cafdffae"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+ "zeroize",
 ]
 
 [[package]]
@@ -756,6 +1099,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "elliptic-curve 0.13.8",
+ "primeorder",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "elliptic-curve 0.13.8",
+ "primeorder",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct 0.2.0",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+]
+
+[[package]]
 name = "password-hash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +1151,39 @@ name = "pastey"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.0",
+ "spki",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -789,6 +1202,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -832,8 +1254,8 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
+ "rand",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -868,18 +1290,8 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
-dependencies = [
- "getrandom 0.4.1",
- "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -890,16 +1302,6 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -937,6 +1339,36 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustcrypto-ff"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
+dependencies = [
+ "rand_core 0.10.0",
+ "subtle",
+]
+
+[[package]]
+name = "rustcrypto-group"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
+dependencies = [
+ "rand_core 0.10.0",
+ "rustcrypto-ff",
+ "subtle",
+]
 
 [[package]]
 name = "rustix"
@@ -985,6 +1417,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.10",
+ "generic-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.0",
+ "hybrid-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "securedrop-protocol-bench"
 version = "0.4.0"
 dependencies = [
@@ -992,7 +1451,7 @@ dependencies = [
  "getrandom 0.4.1",
  "hashbrown 0.14.5",
  "js-sys",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.3",
  "securedrop-protocol-minimal",
  "serde",
@@ -1012,16 +1471,16 @@ dependencies = [
  "getrandom 0.3.4",
  "hashbrown 0.14.5",
  "hax-lib",
- "hpke-rs",
+ "hpke-ng",
  "libcrux-chacha20poly1305",
  "libcrux-curve25519",
  "libcrux-ed25519",
  "libcrux-kem",
  "libcrux-ml-kem",
  "libcrux-sha2",
- "libcrux-traits 0.0.5",
+ "libcrux-traits",
  "proptest",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.3",
  "serde",
  "serde_json",
@@ -1078,10 +1537,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "der 0.8.0",
+]
 
 [[package]]
 name = "subtle"
@@ -1136,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -1157,6 +1656,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "uuid"
@@ -1472,6 +1981,42 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "x-wing"
+version = "0.1.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d0d5f4d1f26b9b9e7477af1d3bef960e1d1fb64edab7912fde472a8a8432e"
+dependencies = [
+ "kem",
+ "ml-kem",
+ "rand_core 0.10.0",
+ "sha3 0.11.0",
+ "x25519-dalek 3.0.0-pre.6",
+ "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d5d6ff67acd3945b933e592bfa7143db4fcbb2f871754b6b9fbd7847fc5aea"
+dependencies = [
+ "curve25519-dalek 5.0.0-pre.6",
+ "rand_core 0.10.0",
+ "zeroize",
 ]
 
 [[package]]

--- a/securedrop-protocol/protocol-minimal/Cargo.toml
+++ b/securedrop-protocol/protocol-minimal/Cargo.toml
@@ -19,8 +19,7 @@ libcrux-kem = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1
 libcrux-ml-kem = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f" }
 libcrux-sha2 = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f" }
 
-# fork of cryspen/hpke-rs, transitively pinned to cryspen/libcrux#1312
-hpke-rs = { git = "https://github.com/cfm/hpke-rs", rev = "9325551537d642d308edc60f3b271742b3a25b00", features = ["libcrux"] }
+hpke-ng = { version = "0.1.0-rc.2", features = ["pq"] }
 
 rand_core = { version = "0.9" }
 

--- a/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
+++ b/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
@@ -48,7 +48,7 @@ where
 
     // Hint (X, Z): X = g^x, Z = (pk_R^fetch)^x for a fresh ephemeral scalar x
     // spec: x (hint_esk), X (hint_epk)
-    let (hint_esk, hint_epk) = generate_dh_keypair(rng).expect("DH Keygen (hint) failed");
+    let (hint_esk, hint_epk) = generate_dh_keypair(&mut *rng).expect("DH Keygen (hint) failed");
     // spec: Z = (pk_R^fetch)^x
     let hint_sharedsecret: DHSharedSecret =
         dh_shared_secret(recipient.fetch_pk(), hint_esk.into_bytes())
@@ -58,7 +58,11 @@ where
     let sender_apke_bytes = sender.message_auth_pk().as_bytes();
 
     // spec: ct^PKE = SD-PKE.Enc(pk_R^PKE, pk_S^APKE)
-    let ct_pke = metadata::encrypt(recipient.message_metadata_pk(), &sender_apke_bytes);
+    let ct_pke = metadata::encrypt(
+        &mut *rng,
+        recipient.message_metadata_pk(),
+        &sender_apke_bytes,
+    );
 
     Envelope {
         ct_apke,                              // spec: ct^APKE

--- a/securedrop-protocol/protocol-minimal/src/message.rs
+++ b/securedrop-protocol/protocol-minimal/src/message.rs
@@ -22,14 +22,12 @@
 
 use alloc::vec::Vec;
 use anyhow::Error;
-use hpke_rs::{
-    Hpke, HpkePrivateKey, HpkePublicKey, Mode, hpke_types::AeadAlgorithm::Aes256Gcm,
-    hpke_types::KdfAlgorithm::HkdfSha256, hpke_types::KemAlgorithm::DhKem25519,
-    libcrux::HpkeLibcrux,
-};
+use hpke_ng::{Aes256Gcm, DhKemX25519HkdfSha256, HkdfSha256, Hpke, kem::Kem as _};
 use libcrux_kem::MlKem768;
 use libcrux_traits::kem::owned::Kem;
 use rand_core::{CryptoRng, RngCore};
+
+type MessageSuite = Hpke<DhKemX25519HkdfSha256, HkdfSha256, Aes256Gcm>;
 
 use crate::constants::{LEN_DHKEM_SHAREDSECRET_ENCAPS, LEN_MLKEM_SHAREDSECRET_ENCAPS};
 use crate::primitives::dh_akem::deterministic_keygen as dhakem_derand;
@@ -200,8 +198,6 @@ pub fn auth_enc<R: RngCore + CryptoRng>(
     ad: &[u8],
     info: &[u8],
 ) -> Result<MessageCiphertext, Error> {
-    let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::AuthPsk, DhKem25519, HkdfSha256, Aes256Gcm);
-
     let mut randomness = [0u8; LEN_MLKEM_ENCAPS_RAND];
     rng.fill_bytes(&mut randomness);
 
@@ -210,27 +206,21 @@ pub fn auth_enc<R: RngCore + CryptoRng>(
         .map_err(|e| anyhow::anyhow!("ML-KEM encapsulation failed: {:?}", e))?;
 
     // (c1, cp) = pskAEnc(skS=skS1, pkR=pkR1, psk=K2, m=m, ad=ad, info=c2+info)
-    let pkr1: HpkePublicKey = pk.dhakem.clone().into();
-    let sks1: HpkePrivateKey = sk.dhakem.clone().into();
+    let pkr1 = DhKemX25519HkdfSha256::pk_from_bytes(pk.dhakem.as_bytes())
+        .map_err(|e| anyhow::anyhow!("Invalid DH-AKEM recipient public key: {:?}", e))?;
+    let sks1 = DhKemX25519HkdfSha256::sk_from_bytes(sk.dhakem.as_bytes())
+        .map_err(|e| anyhow::anyhow!("Invalid DH-AKEM sender private key: {:?}", e))?;
 
     let mut full_info = Vec::new();
     full_info.extend_from_slice(&c2);
     full_info.extend_from_slice(info);
 
-    let (c1_vec, cp) = hpke
-        .seal(
-            &pkr1,
-            &full_info,
-            ad,
-            m,
-            Some(&k2),
-            Some(PSK_ID),
-            Some(&sks1),
-        )
+    let (enc, cp) = MessageSuite::seal_auth_psk(rng, &pkr1, &full_info, ad, m, &k2, PSK_ID, &sks1)
         .map_err(|e| anyhow::anyhow!("SD-APKE AuthEnc failed: {:?}", e))?;
 
     // c1 is always LEN_DHKEM_SHAREDSECRET_ENCAPS bytes for DHKEM(X25519)
-    let c1: [u8; LEN_DHKEM_SHAREDSECRET_ENCAPS] = c1_vec
+    let c1: [u8; LEN_DHKEM_SHAREDSECRET_ENCAPS] = enc
+        .as_ref()
         .try_into()
         .expect("DHKEM(X25519) encapsulation output has unexpected length");
 
@@ -254,31 +244,24 @@ pub fn auth_dec(
     ad: &[u8],
     info: &[u8],
 ) -> Result<Vec<u8>, Error> {
-    let hpke = Hpke::<HpkeLibcrux>::new(Mode::AuthPsk, DhKem25519, HkdfSha256, Aes256Gcm);
-
     // K2 = KEM_PQ.Decap(skR=skR2, enc=c2)
     let k2 = MlKem768::decaps(&ct.c2, sk.mlkem.as_bytes())
         .map_err(|e| anyhow::anyhow!("ML-KEM decapsulation failed: {:?}", e))?;
 
     // m = pskADec(pkS=pkS1, skR=skR1, psk=K2, c1=c1, cp=cp, ad=ad, info=c2+info)
-    let skr1: HpkePrivateKey = sk.dhakem.clone().into();
-    let pks1: HpkePublicKey = pk.dhakem.clone().into();
+    let skr1 = DhKemX25519HkdfSha256::sk_from_bytes(sk.dhakem.as_bytes())
+        .map_err(|e| anyhow::anyhow!("Invalid DH-AKEM recipient private key: {:?}", e))?;
+    let pks1 = DhKemX25519HkdfSha256::pk_from_bytes(pk.dhakem.as_bytes())
+        .map_err(|e| anyhow::anyhow!("Invalid DH-AKEM sender public key: {:?}", e))?;
+    let enc = DhKemX25519HkdfSha256::enc_from_bytes(&ct.c1)
+        .map_err(|e| anyhow::anyhow!("Invalid SD-APKE encapsulation: {:?}", e))?;
 
     let mut full_info = Vec::new();
     full_info.extend_from_slice(&ct.c2);
     full_info.extend_from_slice(info);
 
-    hpke.open(
-        &ct.c1,
-        &skr1,
-        &full_info,
-        ad,
-        &ct.cp,
-        Some(&k2),
-        Some(PSK_ID),
-        Some(&pks1),
-    )
-    .map_err(|e| anyhow::anyhow!("SD-APKE AuthDec failed: {:?}", e))
+    MessageSuite::open_auth_psk(&enc, &skr1, &full_info, ad, &ct.cp, &k2, PSK_ID, &pks1)
+        .map_err(|e| anyhow::anyhow!("SD-APKE AuthDec failed: {:?}", e))
 }
 
 #[cfg(test)]

--- a/securedrop-protocol/protocol-minimal/src/metadata.rs
+++ b/securedrop-protocol/protocol-minimal/src/metadata.rs
@@ -17,14 +17,13 @@
 
 use alloc::vec::Vec;
 use anyhow::Error;
-use hpke_rs::{
-    Hpke, Mode, hpke_types::AeadAlgorithm::Aes256Gcm, hpke_types::KdfAlgorithm::HkdfSha256,
-    hpke_types::KemAlgorithm::XWingDraft06, libcrux::HpkeLibcrux,
-};
+use hpke_ng::{Aes256Gcm, HkdfSha256, Hpke, XWingDraft06, kem::Kem as _};
 use rand_core::{CryptoRng, RngCore};
 
 use crate::constants::LEN_XWING_SHAREDSECRET_ENCAPS;
 use crate::primitives::xwing::{XWingPrivateKey, XWingPublicKey, generate_xwing_keypair};
+
+type MetadataSuite = Hpke<XWingDraft06, HkdfSha256, Aes256Gcm>;
 
 /// The recipient's metadata public key (`pk_R^PKE` in the spec).
 #[derive(Debug, Clone)]
@@ -116,17 +115,21 @@ impl MetadataPrivateKey {
 /// SD-PKE.Enc: encrypt message `m` to recipient key `pk_r`, returning `(c, c')`.
 ///
 /// `m` is the sender's serialized long-term APKE public key.
-pub fn encrypt(pk_r: &MetadataPublicKey, m: &[u8]) -> MetadataCiphertext {
-    let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
-    let pk_r_hpke = pk_r.0.clone().into();
+pub fn encrypt<R: RngCore + CryptoRng>(
+    rng: &mut R,
+    pk_r: &MetadataPublicKey,
+    m: &[u8],
+) -> MetadataCiphertext {
+    let pk_r_hpke = XWingDraft06::pk_from_bytes(pk_r.0.as_bytes())
+        .expect("MetadataPublicKey has invalid XWing wire bytes");
 
     // MetadataPublicKey always holds a valid XWing key, so seal cannot fail.
-    let (c_vec, cp) = hpke
-        .seal(&pk_r_hpke, b"", b"", m, None, None, None)
-        .expect("SD-PKE encryption failed");
+    let (enc, cp) =
+        MetadataSuite::seal_base(rng, &pk_r_hpke, b"", b"", m).expect("SD-PKE encryption failed");
 
     // XWing will always produce this length ciphertext, so this .expect is fine.
-    let c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS] = c_vec
+    let c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS] = enc
+        .as_ref()
         .try_into()
         .expect("X-Wing encapsulation output has unexpected length");
 
@@ -139,10 +142,12 @@ pub fn encrypt(pk_r: &MetadataPublicKey, m: &[u8]) -> MetadataCiphertext {
 ///
 /// Returns an error if HPKE decryption fails.
 pub fn decrypt(sk_r: &MetadataPrivateKey, ct: &MetadataCiphertext) -> Result<Vec<u8>, Error> {
-    let hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
-    let sk_r_hpke = sk_r.0.clone().into();
+    let sk_r_hpke = XWingDraft06::sk_from_bytes(sk_r.0.as_bytes())
+        .map_err(|e| anyhow::anyhow!("MetadataPrivateKey has invalid XWing wire bytes: {:?}", e))?;
+    let enc = XWingDraft06::enc_from_bytes(&ct.c)
+        .map_err(|e| anyhow::anyhow!("Invalid SD-PKE encapsulation: {:?}", e))?;
 
-    hpke.open(&ct.c, &sk_r_hpke, b"", b"", &ct.cp, None, None, None)
+    MetadataSuite::open_base(&enc, &sk_r_hpke, b"", b"", &ct.cp)
         .map_err(|e| anyhow::anyhow!("SD-PKE decryption failed: {:?}", e))
 }
 
@@ -165,7 +170,7 @@ mod tests {
             let mut rng = get_rng();
             let kp = keygen(&mut rng).expect("KGen failed");
 
-            let ct = encrypt(kp.public_key(), &m);
+            let ct = encrypt(&mut rng, kp.public_key(), &m);
             let decrypted = decrypt(kp.private_key(), &ct).expect("Decryption failed");
 
             prop_assert_eq!(m, decrypted);
@@ -178,7 +183,7 @@ mod tests {
         let kp = keygen(&mut rng).expect("KGen failed");
         let wrong_kp = keygen(&mut rng).expect("KGen failed");
 
-        let ct = encrypt(kp.public_key(), b"some sender apke key bytes");
+        let ct = encrypt(&mut rng, kp.public_key(), b"some sender apke key bytes");
         assert!(decrypt(wrong_kp.private_key(), &ct).is_err());
     }
 }

--- a/securedrop-protocol/protocol-minimal/src/primitives/dh_akem.rs
+++ b/securedrop-protocol/protocol-minimal/src/primitives/dh_akem.rs
@@ -1,4 +1,3 @@
-use hpke_rs::{HpkePrivateKey, HpkePublicKey};
 use libcrux_kem::{PrivateKey, PublicKey};
 use rand_core::{CryptoRng, RngCore};
 
@@ -75,18 +74,6 @@ pub(crate) fn deterministic_keygen(
         .map_err(|e| anyhow::anyhow!("DH-AKEM deterministic key generation failed: {:?}", e))?;
 
     typed(sk, pk)
-}
-
-impl From<DhAkemPrivateKey> for HpkePrivateKey {
-    fn from(sk: DhAkemPrivateKey) -> Self {
-        HpkePrivateKey::from(sk.0.to_vec())
-    }
-}
-
-impl From<DhAkemPublicKey> for HpkePublicKey {
-    fn from(pk: DhAkemPublicKey) -> Self {
-        HpkePublicKey::from(pk.0.to_vec())
-    }
 }
 
 #[cfg_attr(hax, hax_lib::requires(

--- a/securedrop-protocol/protocol-minimal/src/primitives/xwing.rs
+++ b/securedrop-protocol/protocol-minimal/src/primitives/xwing.rs
@@ -1,4 +1,3 @@
-use hpke_rs::{HpkePrivateKey, HpkePublicKey};
 use libcrux_kem::{PrivateKey, PublicKey};
 use rand_core::{CryptoRng, RngCore};
 
@@ -35,18 +34,6 @@ impl XWingPrivateKey {
     /// Create from bytes
     pub(crate) fn from_bytes(bytes: [u8; XWING_PRIVATE_KEY_LEN]) -> Self {
         Self(bytes)
-    }
-}
-
-impl From<XWingPrivateKey> for HpkePrivateKey {
-    fn from(sk: XWingPrivateKey) -> Self {
-        HpkePrivateKey::from(sk.0.to_vec())
-    }
-}
-
-impl From<XWingPublicKey> for HpkePublicKey {
-    fn from(pk: XWingPublicKey) -> Self {
-        HpkePublicKey::from(pk.0.to_vec())
     }
 }
 


### PR DESCRIPTION
This PR replaces the `hpke-rs` dependency in `securedrop-protocol-minimal` with [hpke-ng](https://github.com/symbolicsoft/hpke-ng). The two crates implement the same RFC 9180 specification with the same ciphersuites used in this protocol (DHKEM(X25519, HKDF-SHA256) for SD-APKE, X-Wing for SD-PKE, HKDF-SHA256, AES-256-GCM), so the change is internal: wire formats, key sizes, and protocol behavior are unchanged.

The diff is mechanical. `Hpke::<HpkeLibcrux>::new(Mode::AuthPsk, …)` is replaced by `type MessageSuite = Hpke<DhKemX25519HkdfSha256, HkdfSha256, Aes256Gcm>;` with calls to `seal_auth_psk` / `open_auth_psk`; `Mode::Base` calls become `seal_base` / `open_base`. The `From<…> for HpkePrivateKey/HpkePublicKey` impls in `primitives/dh_akem.rs` and `primitives/xwing.rs` are removed in favor of `Kem::pk_from_bytes` / `sk_from_bytes` / `enc_from_bytes`. `metadata::encrypt` now takes `rng: &mut R` because hpke-ng's caller-provided-RNG design no longer hides it inside the `Hpke` instance — the call site in `encrypt_decrypt::encrypt` already had an `rng` in scope.

## Why hpke-ng

[hpke-ng](https://github.com/symbolicsoft/hpke-ng) is a from-scratch RFC 9180 implementation released by Symbolic Software alongside [a detailed comparison](https://symbolic.software/blog/2026-05-08-hpke-ng/) with hpke-rs. Three reasons it's worth migrating to:

### 1. hpke-rs has been a source of problems for this project

The most immediate one is [#232](https://github.com/freedomofpress/securedrop-protocol/issues/232): hpke-rs (or rather your fork at `cfm/hpke-rs@9325551`) does not extract cleanly through hax to F*. The reasons documented in the issue — `Hpke::rng` returning `&mut self.prng`, trait default bodies being rejected, the workaround Makefile having to `perl`-strip default-method bodies and the `Zeroize` bound out of the trait — are not surface issues. They are consequences of design choices in hpke-rs (struct-owned PRNG, trait dispatch with default impls) that hpke-ng explicitly does not make.

hpke-ng's architecture — `Hpke<K, F, A>` is `PhantomData`, the configuration owns no state, no provider trait with default bodies — is a much closer fit for hax extraction. It still needs F* models written (the existing `proofs/fstar/models/Hpke_rs*.fsti` are now stale and need to be rewritten against the new API), but the underlying surface is one a hax-friendly model can actually be written against rather than worked around.

Beyond #232, hpke-rs has a recent history of severe security vulnerabilities:

- [RUSTSEC-2026-0071](https://rustsec.org/advisories/RUSTSEC-2026-0071.html): Nonce Reuse in HPKE Context
- [RUSTSEC-2026-0070](https://rustsec.org/advisories/RUSTSEC-2026-0070.html): Panic When Opening or Sealing on Export-Only Context

In addition, hpke-rs took more than a month to publish adequate security advisories for the above vulnerabilities, raising serious questions regarding the security posture and maintenance discipline of the dependency. Both classes of bug — context cloning aliasing the nonce counter; runtime errors on combinations the type system should have rejected — are structurally prevented in hpke-ng (`Context` is non-cloneable, `seal_*` / `open_*` are absent for `ExportOnly` AEADs).

### 2. Compile-time safety instead of runtime errors

hpke-ng dispatches on ciphersuite via type parameters where hpke-rs dispatches via runtime enums. Four categories of bugs that fail at runtime in hpke-rs become **compile errors** in hpke-ng:

| Bug class | hpke-rs | hpke-ng |
| --- | --- | --- |
| Auth-mode call on a KEM that doesn't support auth (e.g., X-Wing) | runtime `Error::UnsupportedKemOperation` | trait bound `K: AuthKem` fails to resolve |
| Invalid AEAD selection for sealing | runtime `HpkeError::InvalidConfig` | `seal_base` not in scope |
| KEM-mismatched key bytes | runtime mismatch error | type mismatch |
| Base-mode call with a PSK argument | runtime `HpkeError::UnnecessaryPsk` | no PSK parameter exists in the signature |

For securedrop-protocol specifically, this matters because SD-APKE composes `AuthPsk` over DHKEM(X25519) while SD-PKE composes `Base` over X-Wing. The two were previously distinguished by a `Mode` enum and `Option<&[u8]>` arguments threaded through one provider object; in this PR they are distinguished by their suite type aliases, and any future bug that would have mixed them up (e.g., passing an X-Wing key into an AuthPsk path) is now a compile error.

### 3. Performance and footprint

From the [published benchmarks](https://symbolic.software/blog/2026-05-08-hpke-ng/), the wins concentrated on operations this protocol exercises:

- **encap (X25519):** 29.88 µs vs 38.09 µs (−22 %)
- **decap (X25519):** 29.31 µs vs 36.96 µs (−21 %)
- **single-shot open, 64 B payload:** 33.87 µs vs 38.26 µs (−12 %)
- **X-Wing encap/decap:** 11–16 % faster
- **`sizeof(Context<K,F,A>)`:** 80 B vs 400 B (−80 %)
- **stripped binary:** 392 KB vs 561 KB (−30 %)

The binary-size delta matters for the `wasm32-unknown-unknown` target the bench crate ships to.

## Verification

| Check | Result |
| --- | --- |
| `cargo test --manifest-path securedrop-protocol/Cargo.toml` | **34 / 34 pass** (26 unit + 3 core integration + 5 setup integration) |
| `make build-wasm` (`wasm32-unknown-unknown`) | clean |
| `cargo clippy --workspace --all-targets --all-features` | no new errors; only pre-existing warnings |
| `Cargo.lock` audit | no `hpke-rs*` entries remain |

The proptest-backed roundtrip suites for SD-APKE (`message::tests::test_auth_enc_dec_roundtrip`) and SD-PKE (`metadata::tests::test_metadata_encrypt_decrypt_roundtrip`) pass, as do the negative-path tests (`test_auth_dec_wrong_recipient_fails`, `test_metadata_decrypt_wrong_key_fails`) — so AuthPsk authentication and Base-mode confidentiality are exercised end-to-end on the new backend.