### PR TITLE
demonstration: `SD-PKE` specified in hacspec

### DIFF
--- a/securedrop-protocol/Cargo.lock
+++ b/securedrop-protocol/Cargo.lock
@@ -1029,6 +1029,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "securedrop-protocol-spec"
+version = "0.4.0"
+dependencies = [
+ "hax-lib",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/securedrop-protocol/Cargo.toml
+++ b/securedrop-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["protocol-minimal", "bench"]
+members = ["protocol-minimal", "protocol-spec", "bench"]
 
 [workspace.package]
 name = "securedrop-protocol"

--- a/securedrop-protocol/protocol-spec/Cargo.toml
+++ b/securedrop-protocol/protocol-spec/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "securedrop-protocol-spec"
+version = "0.4.0"
+edition = "2024"
+authors = ["SecureDrop Team <securedrop@freedom.press>"]
+description = "Hacspec-style specification of the SecureDrop Protocol, mirroring docs/protocol.md"
+license = "GPL-3.0"
+
+[lib]
+
+[dependencies]
+
+[target."cfg(hax)".dependencies]
+hax-lib = { version = "0.3.6" }

--- a/securedrop-protocol/protocol-spec/proofs/fstar/refinement/SecureDrop.SdPke.Refinement.fst
+++ b/securedrop-protocol/protocol-spec/proofs/fstar/refinement/SecureDrop.SdPke.Refinement.fst
@@ -1,0 +1,277 @@
+module SecureDrop.SdPke.Refinement
+
+(* ============================================================================
+   Refinement of `Securedrop_protocol_minimal.Metadata` against
+   `Securedrop_protocol_spec.Sd_pke`.
+
+   STATUS: DRAFT.
+
+   The names below match the impl-side extraction at
+   `protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Metadata.fst`,
+   which already exists. The spec-side names (`Securedrop_protocol_spec.*`)
+   are predicted; this file will not check until the spec crate is
+   extracted via hax and added to the F* search path. The shape is
+   chosen to require minimal manual fixup once that extraction lands.
+
+   Lemma bodies are `admit ()`; the structure is the contract.
+   ============================================================================ *)
+
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+
+open FStar.Mul
+open Core_models
+
+module Spec      = Securedrop_protocol_spec.Sd_pke
+module SpecPrim  = Securedrop_protocol_spec.Primitives
+module Impl      = Securedrop_protocol_minimal.Metadata
+module ImplXwing = Securedrop_protocol_minimal.Primitives.Xwing
+module HpkeRs    = Hpke_rs
+
+(* ============================================================================
+   §1. Type translations.
+
+   Impl-side `t_MetadataPublicKey` wraps `t_XWingPublicKey` which wraps
+   `t_Array u8 1216`. The spec-side `t_SdPkePk` (predicted) wraps the same
+   1216-byte array directly, one newtype shallower.
+   ============================================================================ *)
+
+let pk_impl_to_spec (pk: Impl.t_MetadataPublicKey) : Spec.t_SdPkePk =
+  let MetadataPublicKey xpk = pk in
+  let XWingPublicKey bytes = xpk in
+  Spec.SdPkePk bytes
+
+let sk_impl_to_spec (sk: Impl.t_MetadataPrivateKey) : Spec.t_SdPkeSk =
+  let MetadataPrivateKey xsk = sk in
+  let XWingPrivateKey bytes = xsk in
+  Spec.SdPkeSk bytes
+
+(* The two ciphertext records are field-compatible:
+   impl `{ f_c: t_Array u8 1120; f_cp: Vec u8 }`
+   spec `{ f_c: t_Array u8 1120; f_cp: Vec u8 }` *)
+let ct_impl_to_spec (ct: Impl.t_MetadataCiphertext) : Spec.t_SdPkeCt =
+  { f_c = ct.f_c; f_cp = ct.f_cp }
+
+(* Project `Result T anyhow::Error` to `Option T` for refinement:
+   spec returns Option, impl returns Result-with-string-error. *)
+let result_to_option
+    (#t: Type0) (#e: Type0)
+    (r: Core_models.Result.t_Result t e)
+  : Core_models.Option.t_Option t
+  = match r with
+    | Core_models.Result.Result_Ok x   -> Core_models.Option.Option_Some x
+    | Core_models.Result.Result_Err _  -> Core_models.Option.Option_None
+
+(* ============================================================================
+   §2. The HPKE refinement axiom.
+
+   Both crates ultimately call out to HPKE-rs. The spec calls
+   `SpecPrim.hpke_seal_base` (an opaque function); the impl calls
+   `HpkeRs.impl_7__seal` in Mode_Base (also opaque, in the model file
+   `protocol-minimal/proofs/fstar/models/Hpke_rs.fsti`).
+
+   The axiom below states that, on Base mode with empty info/aad and no
+   PSK/auth, the two opaque functions agree modulo:
+     - representation of the X-Wing pubkey (raw bytes vs HpkePublicKey wrapper)
+     - representation of the encapsulation output (Vec<u8> vs [u8; 1120])
+     - randomness threading: the impl's HPKE state carries randomness,
+       which the spec receives as an explicit argument
+
+   This is a refinement claim about libcrux's HPKE implementation. It
+   would be discharged by Cryspen's HPKE proofs against RFC 9180; we
+   import it as an assumption here.
+   ============================================================================ *)
+
+(* The randomness encoded in an Hpke-rs state. Existential-style: there
+   exists some `r` such that calling seal advances the state by drawing r. *)
+assume
+val hpke_state_randomness:
+    #crypto: Type0
+  → state: HpkeRs.t_Hpke crypto
+  → SpecPrim.t_Array u8 96   (* the bytes the next seal call will consume *)
+
+(* Lifting an X-Wing pubkey-bytes to the HpkePublicKey wrapper.
+   In the impl extraction this is `Core_models.Convert.f_into` against
+   the typeclass instance `impl_3` defined in the X-Wing extraction. *)
+assume
+val xwing_pk_to_hpke:
+    SpecPrim.t_Array u8 1216 → HpkeRs.t_HpkePublicKey
+
+assume
+val xwing_sk_to_hpke:
+    SpecPrim.t_Array u8 32 → HpkeRs.t_HpkePrivateKey
+
+(* The core axiom: HPKE Base seal in the impl agrees with the spec. *)
+assume
+val hpke_seal_base_refines:
+    pk_bytes: SpecPrim.t_Array u8 1216
+  → m: Core_models.Slice.t_Slice u8
+  → state_in: HpkeRs.t_Hpke Hpke_rs_libcrux.t_HpkeLibcrux
+  → Lemma
+      (ensures (
+        let r = hpke_state_randomness state_in in
+        let (_, impl_out) =
+          HpkeRs.impl_7__seal #Hpke_rs_libcrux.t_HpkeLibcrux
+            state_in
+            (xwing_pk_to_hpke pk_bytes)
+            Core_models.Slice.empty
+            Core_models.Slice.empty
+            m
+            Core_models.Option.Option_None
+            Core_models.Option.Option_None
+            Core_models.Option.Option_None
+        in
+        let (c_spec, cp_spec) =
+          SpecPrim.hpke_seal_base pk_bytes
+            Core_models.Slice.empty Core_models.Slice.empty m r
+        in
+        match impl_out with
+        | Core_models.Result.Result_Ok (c_vec, cp_vec) ->
+            (* impl produces Vec; spec produces fixed-size array. They agree
+               under try_into. *)
+            cp_vec == cp_spec
+            /\ (Core_models.Convert.f_try_into c_vec ==
+                Core_models.Result.Result_Ok c_spec)
+        | Core_models.Result.Result_Err _ -> False
+            (* Base mode with valid X-Wing pubkey never errors. *)
+      ))
+
+(* Symmetric axiom for HPKE Open. *)
+assume
+val hpke_open_base_refines:
+    sk_bytes: SpecPrim.t_Array u8 32
+  → c: SpecPrim.t_Array u8 1120
+  → cp: Core_models.Slice.t_Slice u8
+  → state_in: HpkeRs.t_Hpke Hpke_rs_libcrux.t_HpkeLibcrux
+  → Lemma
+      (ensures (
+        let impl_out =
+          HpkeRs.impl_7__open #Hpke_rs_libcrux.t_HpkeLibcrux
+            state_in
+            (c <: Core_models.Slice.t_Slice u8)
+            (xwing_sk_to_hpke sk_bytes)
+            Core_models.Slice.empty
+            Core_models.Slice.empty
+            cp
+            Core_models.Option.Option_None
+            Core_models.Option.Option_None
+            Core_models.Option.Option_None
+        in
+        let spec_out =
+          SpecPrim.hpke_open_base sk_bytes c
+            Core_models.Slice.empty Core_models.Slice.empty cp
+        in
+        result_to_option impl_out == spec_out
+      ))
+
+(* ============================================================================
+   §3. Refinement lemmas for `Sd_pke.enc` / `Sd_pke.dec`.
+
+   Each lemma reduces to applying the corresponding HPKE axiom plus
+   pushing the `MetadataPublicKey` / `MetadataCiphertext` newtype
+   wrappers through the equality. The bodies should be discharged by
+   `hpke_seal_base_refines` / `hpke_open_base_refines` plus reflexivity.
+   ============================================================================ *)
+
+(* `Impl.encrypt` does not take randomness as an argument: it constructs
+   a fresh `Hpke` state internally on every call (see lines 152-158 of
+   the impl extraction). Refinement therefore quantifies over the
+   randomness that this implicit state will draw.
+
+   Concretely: for any randomness `r` that the impl's HPKE state could
+   yield, calling `Impl.encrypt pk_r m` agrees with `Spec.enc (pk pk_r) m r`. *)
+val enc_refines:
+    pk_r: Impl.t_MetadataPublicKey
+  → m: Core_models.Slice.t_Slice u8
+  → r: SpecPrim.t_Array u8 96
+  → Lemma
+      (requires (
+        (* The lemma is parameterised on the randomness the freshly
+           constructed Hpke state will consume. We pin that here. *)
+        forall (state: HpkeRs.t_Hpke Hpke_rs_libcrux.t_HpkeLibcrux).
+            hpke_state_randomness state == r
+      ))
+      (ensures (
+        ct_impl_to_spec (Impl.encrypt pk_r m)
+        == Spec.enc (pk_impl_to_spec pk_r) m r
+      ))
+let enc_refines pk_r m r =
+  (* Proof outline:
+     1. Unfold `Impl.encrypt`: it constructs `hpke = Hpke::new(Base, ...)`,
+        then calls `hpke.seal(pk_r_hpke, b"", b"", m, None, None, None)`,
+        unwraps the Result with `.expect(...)`, and packages `(c, cp)`.
+     2. Unfold `Spec.enc`: it calls `hpke_seal_base(pk_r.0, [], [], m, r)`
+        and packages `(c, cp)`.
+     3. By `hpke_seal_base_refines` applied to the Hpke state used by the
+        impl, the underlying seal calls produce equal `(c, cp)`.
+     4. Conclude by reflexivity on the wrapping. *)
+  admit ()
+
+val dec_refines:
+    sk_r: Impl.t_MetadataPrivateKey
+  → ct: Impl.t_MetadataCiphertext
+  → Lemma
+      (ensures (
+        result_to_option (Impl.decrypt sk_r ct)
+        == Spec.dec (sk_impl_to_spec sk_r) (ct_impl_to_spec ct)
+      ))
+let dec_refines sk_r ct =
+  (* Proof outline:
+     1. Unfold `Impl.decrypt`: constructs Hpke state, calls
+        `hpke.open(...)`, maps the error via `anyhow::anyhow!(...)`.
+     2. Unfold `Spec.dec`: calls `hpke_open_base(sk_r.0, ct.f_c, [], [], ct.f_cp)`.
+     3. By `hpke_open_base_refines`, the underlying calls agree under
+        `result_to_option`.
+     4. The error-message construction in the impl is irrelevant once
+        projected through `result_to_option`. *)
+  admit ()
+
+(* ============================================================================
+   §4. Round-trip correctness, derivable from §3 plus HPKE Base correctness.
+
+   This is what the existing `proptest!` round-trip in
+   `metadata.rs::tests::test_metadata_encrypt_decrypt_roundtrip` checks
+   probabilistically. The lemma below states it as a theorem, given the
+   HPKE-Base correctness assumption.
+   ============================================================================ *)
+
+assume
+val hpke_base_correct:
+    pk: SpecPrim.t_Array u8 1216
+  → sk: SpecPrim.t_Array u8 32
+  → m: Core_models.Slice.t_Slice u8
+  → r: SpecPrim.t_Array u8 96
+  → Lemma
+      (requires SpecPrim.is_xwing_keypair sk pk)
+      (ensures (
+        let (c, cp) = SpecPrim.hpke_seal_base pk
+                        Core_models.Slice.empty Core_models.Slice.empty m r in
+        SpecPrim.hpke_open_base sk c
+          Core_models.Slice.empty Core_models.Slice.empty cp
+        == Core_models.Option.Option_Some
+             (Alloc.Slice.impl__to_vec #u8 m)
+      ))
+
+val roundtrip_refines:
+    sk_r: Impl.t_MetadataPrivateKey
+  → pk_r: Impl.t_MetadataPublicKey
+  → m: Core_models.Slice.t_Slice u8
+  → r: SpecPrim.t_Array u8 96
+  → Lemma
+      (requires (
+        (* (sk_r, pk_r) is a valid X-Wing keypair *)
+        SpecPrim.is_xwing_keypair (sk_impl_to_spec sk_r)._0
+                                  (pk_impl_to_spec pk_r)._0
+        /\ (forall (state: HpkeRs.t_Hpke Hpke_rs_libcrux.t_HpkeLibcrux).
+              hpke_state_randomness state == r)
+      ))
+      (ensures (
+        result_to_option (Impl.decrypt sk_r (Impl.encrypt pk_r m))
+        == Core_models.Option.Option_Some
+             (Alloc.Slice.impl__to_vec #u8 m)
+      ))
+let roundtrip_refines sk_r pk_r m r =
+  enc_refines pk_r m r;
+  dec_refines sk_r (Impl.encrypt pk_r m);
+  hpke_base_correct (pk_impl_to_spec pk_r)._0
+                    (sk_impl_to_spec sk_r)._0
+                    m r

--- a/securedrop-protocol/protocol-spec/src/lib.rs
+++ b/securedrop-protocol/protocol-spec/src/lib.rs
@@ -1,0 +1,18 @@
+//! Hacspec-style specification of the SecureDrop Protocol.
+//!
+//! Mirrors `docs/protocol.md` v0.4. This proof-of-concept currently
+//! contains only §SD-PKE (lines 304-333 of the doc).
+//!
+//! The implementation crate `securedrop-protocol-minimal` is intended to
+//! be shown to refine this spec via hax + F*. See
+//! `proofs/SecureDrop.SdPke.Refinement.fst` for the lemma sketch.
+
+#![no_std]
+#![allow(clippy::too_many_arguments)]
+
+extern crate alloc;
+
+pub const PROTOCOL_VERSION: &str = "0.4";
+
+pub mod primitives;
+pub mod sd_pke;

--- a/securedrop-protocol/protocol-spec/src/primitives.rs
+++ b/securedrop-protocol/protocol-spec/src/primitives.rs
@@ -1,0 +1,66 @@
+//! Abstract cryptographic primitives.
+//!
+//! Each function here is an opaque boundary: ProVerif treats them as
+//! constructors with axiomatized properties; F* uses pre/postconditions
+//! for refinement. The implementation crate provides concrete bodies
+//! (libcrux, hpke-rs); this crate never inspects them.
+//!
+//! This proof-of-concept restricts the abstract primitive surface to
+//! exactly what §SD-PKE needs (X-Wing keygen + HPKE Base seal/open).
+
+use alloc::vec::Vec;
+
+// ===========================================================================
+// X-Wing(X25519, ML-KEM-768) (§Key Hierarchy line 142, §SD-PKE line 309)
+// ===========================================================================
+
+/// X-Wing decapsulation key length per the I-D's encoding (§docs/protocol.md
+/// line 18 of constants.rs in the impl).
+pub const XWING_SK_LEN: usize = 32;
+/// X-Wing encapsulation key length (§Wire formats, line 638).
+pub const XWING_PK_LEN: usize = 1216;
+/// X-Wing encapsulated shared-secret ciphertext length (§Wire formats line 656).
+pub const XWING_ENC_LEN: usize = 1120;
+
+pub type XwingSk = [u8; XWING_SK_LEN];
+pub type XwingPk = [u8; XWING_PK_LEN];
+pub type XwingEnc = [u8; XWING_ENC_LEN];
+
+/// X-Wing key generation (§KGen of SD-PKE, line 322).
+///
+/// Deterministic on `seed`; randomness is supplied by the caller.
+pub fn xwing_keygen(_seed: [u8; 32]) -> (XwingSk, XwingPk) {
+    unimplemented!()
+}
+
+// ===========================================================================
+// HPKE Base mode (RFC 9180 §5.1.1), used by §SD-PKE
+// ===========================================================================
+
+/// HPKE Base seal: `(enc, ct) = SealBase(pk_r, info, aad, pt)`, as cited
+/// at §SD-PKE line 327 with `info=None, aad=None`.
+///
+/// Randomness is supplied explicitly. RFC 9180's `Encap` consumes 32 bytes
+/// for X25519 plus the underlying KEM's randomness; X-Wing wraps both, so
+/// 96 bytes is sufficient.
+pub fn hpke_seal_base(
+    _pk_r: &XwingPk,
+    _info: &[u8],
+    _aad: &[u8],
+    _pt: &[u8],
+    _randomness: [u8; 96],
+) -> (XwingEnc, Vec<u8>) {
+    unimplemented!()
+}
+
+/// HPKE Base open: `pt = OpenBase(sk_r, enc, info, aad, ct)`, as cited
+/// at §SD-PKE line 331 with `info=None, aad=None`.
+pub fn hpke_open_base(
+    _sk_r: &XwingSk,
+    _enc: &XwingEnc,
+    _info: &[u8],
+    _aad: &[u8],
+    _ct: &[u8],
+) -> Option<Vec<u8>> {
+    unimplemented!()
+}

--- a/securedrop-protocol/protocol-spec/src/sd_pke.rs
+++ b/securedrop-protocol/protocol-spec/src/sd_pke.rs
@@ -1,0 +1,63 @@
+//! §SD-PKE: SecureDrop PKE (`docs/protocol.md` lines 304-333).
+//!
+//! Translates the Python pseudocode at lines 321-333 of the doc:
+//!
+//! ```text
+//! def KGen():
+//!     (skS, pkS) = KEM_H.KGen()
+//!     return (skS, pkS)
+//!
+//! def Enc(pkR, m):
+//!     c, cp = HPKE.SealBase(pkR=pkR, info=None, aad=None, pt=m)
+//!     return (c, cp)
+//!
+//! def Dec(skR, c, cp):
+//!     m = HPKE.OpenBase(enc=c, skR=skR, info=None, aad=None, ct=cp)
+//!     return m
+//! ```
+//!
+//! Per footnote 9 of the doc, `None` in the Python pseudocode and `-` in
+//! the mathematical syntax both denote the empty string; we encode them
+//! as `&[]`.
+//!
+//! `KEM_H = X-Wing` and `AEAD = AES-GCM` (§SD-PKE line 309). Those are
+//! parameters of the abstract HPKE primitive in `primitives` and not
+//! visible here.
+
+use crate::primitives::{XwingEnc, XwingPk, XwingSk, hpke_open_base, hpke_seal_base, xwing_keygen};
+use alloc::vec::Vec;
+
+/// SD-PKE recipient public key `pk_R^PKE` (§Key Hierarchy line 142).
+pub struct SdPkePk(pub XwingPk);
+
+/// SD-PKE recipient private key `sk_R^PKE` (§Key Hierarchy line 142).
+pub struct SdPkeSk(pub XwingSk);
+
+/// SD-PKE ciphertext `(c, c')` per §SD-PKE line 317.
+pub struct SdPkeCt {
+    /// Encapsulated X-Wing shared secret (`c` in the spec).
+    pub c: XwingEnc,
+    /// HPKE Base AEAD ciphertext (`c'` in the spec).
+    pub cp: Vec<u8>,
+}
+
+/// `KGen()` — §SD-PKE line 322.
+pub fn keygen(seed: [u8; 32]) -> (SdPkeSk, SdPkePk) {
+    let (sk, pk) = xwing_keygen(seed);
+    (SdPkeSk(sk), SdPkePk(pk))
+}
+
+/// `Enc(pkR, m)` — §SD-PKE line 326.
+///
+/// Randomness is supplied explicitly; the doc's `←$` is encoded as a
+/// caller-passed `[u8; 96]` (sufficient for X-Wing per RFC 9180 §4.1
+/// + the I-D for X-Wing).
+pub fn enc(pk_r: &SdPkePk, m: &[u8], randomness: [u8; 96]) -> SdPkeCt {
+    let (c, cp) = hpke_seal_base(&pk_r.0, &[], &[], m, randomness);
+    SdPkeCt { c, cp }
+}
+
+/// `Dec(skR, c, cp)` — §SD-PKE line 330.
+pub fn dec(sk_r: &SdPkeSk, ct: &SdPkeCt) -> Option<Vec<u8>> {
+    hpke_open_base(&sk_r.0, &ct.c, &[], &[], &ct.cp)
+}


### PR DESCRIPTION
This pull request is an exploration of what hacspec can (and can't) do for us,
based on:

- Merigoux et al. (2021), ["Hacspec: Succinct, Executable, Verifiable
  Specifications for High-Assurance Cryptography Embedded in Rust"][merigoux]
- [`cryspen/bertie`][bertie]: [`tls13handshake.rs`] (as discussed in
  Bhargavan et al. [2025], ["Formal Security and Functional Verification of
  Cryptographic Protocol Implementations in Rust"][bhargavan])
- hax's [`proverif-psk`] example


## Process

I had Claude translate the `protocol.md` specification into hacspec based on
Cryspen's examples.  It was able to do so cleanly, with the following
modifications:

1. Like the Tamarin model, the hacspec must be finer-grained than the logical
   protocol steps we've currently defined, in order to achieve injective
   construction: Each individual message on the wire (Tamarin fact) must be
   represented by a distinct type that's consumed by a distinct function
   (Tamarin rule).

2. Entropy must be provided to each pure function individually, rather than
   sampled within them.

3. State like the server `database`, sets of challenges, etc. must be
   represented as fixed-length arrays.

While it was useful to see that the entire protocol specification *could* be
translated into Rust-executable hacspec this way, it was also overwhelming, so
for demonstration here I've trimmed it down to just `SD-PKE`.  See #251 for
the full translation.


## Findings

### What would this get us?

**hacspec itself.**  The current specification is derived from the paper
manuscript and its mathematical notation.  It's appealingly programmer-friendly
to have a specification at the same level of rigor as the manuscript's
definitions but in the same language in which we'll be implementing it: in
particular, type-checked.  Compare:

- [The current specification of `SD-PKE`][sd-pke-spec]
- [The hacspec specification of `SD-PKE`][sd-pke-hacspec]
- [The current implementation of `SD-PKE`][metadata.rs] in
  `securedrop_protocol_minimal::metadata`

Basically, the pseudocode translates directly into Rust, and the commentary
could become accompanying Rustdoc.

**hacspec-based proofs.**  Once we have the specification in hacspec, it would
then be possible to prove that the implementation *refines* (correctly
implements) the specification.  For `SD-PKE`, that could look like:

- https://github.com/freedomofpress/securedrop-protocol/blob/e4cc1bbd0b2051b5e0aad3387fc15659d9dd1192/securedrop-protocol/protocol-spec/proofs/fstar/refinement/SecureDrop.SdPke.Refinement.fst#L72-L77
- https://github.com/freedomofpress/securedrop-protocol/blob/e4cc1bbd0b2051b5e0aad3387fc15659d9dd1192/securedrop-protocol/protocol-spec/proofs/fstar/refinement/SecureDrop.SdPke.Refinement.fst#L229-L234


### What's the catch?

We've previously decided that we shouldn't be writing F* (or Lean) proofs
ourselves, just hax annotations that are extracted to F* (and someday Lean) and
proven there based on the available [models and stubs].  This precludes the
"hacspec-based refinement proofs" strategy.


### What wouldn't this get us?

There's currently no mechanized way to prove that the hacspec (never mind the
full Rust implementation) refines the Tamarin model where the protocol's
security properties are proven.  Even `cargo hax into pro-verif` won't get us
that.  In addition to the limitations cited in
<https://github.com/freedomofpress/securedrop-protocol/issues/241#issuecomment-4385798370>,
Tamarin can export only SAPIC+ models to ProVerif, and our model relies heavily
on rule-based reasoning that can't be directly exported to SAPIC+ (as well as on
Tamarin's Diffie–Hellman equational theory).

For the goal of proving refinement of the Tamarin model, we'd need hax to have a
Tamarin back end.


## Next steps

For discussion on Slack.

(Like previous pull requests tagged `proof of concept`, this is opened for discussion and expected to be closed, not merged.)


[bertie]: https://github.com/cryspen/bertie
[bhargavan]: https://eprint.iacr.org/2025/980
[merigoux]: https://inria.hal.science/hal-03176482
[metadata.rs]: https://github.com/freedomofpress/securedrop-protocol/blob/948563031f6485a51e683390260f750f47e2819f/securedrop-protocol/protocol-minimal/src/metadata.rs
[models and stubs]: https://github.com/freedomofpress/securedrop-protocol/wiki/Verification#how-are-f-interfaces-extracted-from-our-dependencies
[`proverif-psk`]: https://github.com/cryspen/hax/blob/ad110bfa7a2589e4e744e751a8d8b144cfe53c40/examples/proverif-psk/src/lib.rs
[sd-pke-hacspec]: https://github.com/freedomofpress/securedrop-protocol/blob/hacspec-sd-pke/securedrop-protocol/protocol-spec/src/sd_pke.rs
[sd-pke-spec]: https://github.com/freedomofpress/securedrop-protocol/blob/948563031f6485a51e683390260f750f47e2819f/docs/protocol.md#metadata-protection-via-sd-pke-securedrop-pke-
[`tls13handshake.rs`]: https://github.com/cryspen/bertie/blob/main/src/tls13handshake.rs