### PR TITLE
demonstration: full specification translated to hacspec

### DIFF
--- a/securedrop-protocol/protocol-spec/src/keys.rs
+++ b/securedrop-protocol/protocol-spec/src/keys.rs
@@ -12,11 +12,13 @@ use alloc::vec::Vec;
 // §Key Hierarchy and §SD-APKE (line 392)
 // ===========================================================================
 
+#[derive(Clone)]
 pub struct SdApkeSk {
     pub sk1: AkemSk,
     pub sk2: KemPqSk,
 }
 
+#[derive(Clone)]
 pub struct SdApkePk {
     pub pk1: AkemPk,
     pub pk2: KemPqPk,
@@ -26,14 +28,20 @@ pub struct SdApkePk {
 // SD-PKE keypair: X-Wing  (§SD-PKE)
 // ===========================================================================
 
+#[derive(Clone)]
 pub struct SdPkeSk(pub XwingSk);
+
+#[derive(Clone)]
 pub struct SdPkePk(pub XwingPk);
 
 // ===========================================================================
 // Fetch keypair: ristretto255  (§Notation, line 294)
 // ===========================================================================
 
+#[derive(Clone)]
 pub struct FetchSk(pub R255Scalar);
+
+#[derive(Clone)]
 pub struct FetchPk(pub R255Point);
 
 // ===========================================================================

--- a/securedrop-protocol/protocol-spec/src/keys.rs
+++ b/securedrop-protocol/protocol-spec/src/keys.rs
@@ -1,0 +1,120 @@
+//! Key types per §Key Hierarchy (lines 117-142) and protocol-step records.
+//!
+//! Each long-term party record (FPF, Newsroom, Journalist, Source) holds
+//! the keys named in the doc plus the signatures the party has accumulated
+//! at the end of its setup step.
+
+use crate::primitives::*;
+use alloc::vec::Vec;
+
+// ===========================================================================
+// SD-APKE keypair: pk = (pk1 = DH-AKEM, pk2 = ML-KEM-768)
+// §Key Hierarchy and §SD-APKE (line 392)
+// ===========================================================================
+
+pub struct SdApkeSk {
+    pub sk1: AkemSk,
+    pub sk2: KemPqSk,
+}
+
+pub struct SdApkePk {
+    pub pk1: AkemPk,
+    pub pk2: KemPqPk,
+}
+
+// ===========================================================================
+// SD-PKE keypair: X-Wing  (§SD-PKE)
+// ===========================================================================
+
+pub struct SdPkeSk(pub XwingSk);
+pub struct SdPkePk(pub XwingPk);
+
+// ===========================================================================
+// Fetch keypair: ristretto255  (§Notation, line 294)
+// ===========================================================================
+
+pub struct FetchSk(pub R255Scalar);
+pub struct FetchPk(pub R255Point);
+
+// ===========================================================================
+// Per-party long-term records
+// ===========================================================================
+
+/// §Step 1 (line 161): FPF root of trust.
+pub struct FpfKeys {
+    pub sk: SigSk,
+    pub vk: SigVk,
+}
+
+/// §Step 2 (lines 183-188): newsroom, with the signature FPF issued over its vk.
+pub struct NewsroomKeys {
+    pub sk: SigSk,
+    pub vk: SigVk,
+    /// `σ_FPF^NR ← Sign(sk_FPF, "fpf-sig-nr" || vk_NR)`
+    pub sigma_fpf_on_nr: Sig,
+}
+
+/// §Step 3.1 (lines 214-224): journalist long-term identity.
+pub struct JournalistLongTerm {
+    pub sk_sig: SigSk,
+    pub vk_sig: SigVk,
+    pub sk_apke: SdApkeSk,
+    pub pk_apke: SdApkePk,
+    pub sk_fetch: FetchSk,
+    pub pk_fetch: FetchPk,
+    /// `σ_J ← Sign(sk_J^sig, "j-sig-ltk" || (pk_J^APKE || pk_J^fetch))`
+    pub sigma_self: Sig,
+    /// `σ_NR^J ← Sign(sk_NR^sig, "nr-sig" || vk_J^sig)`
+    pub sigma_nr_on_j: Sig,
+}
+
+/// §Step 3.2 (lines 239-244): one ephemeral key bundle of size N.
+/// Journalists maintain a pool of these.
+pub struct JournalistEphemeral {
+    pub sk_apke_e: SdApkeSk,
+    pub pk_apke_e: SdApkePk,
+    pub sk_pke_e: SdPkeSk,
+    pub pk_pke_e: SdPkePk,
+    /// `σ_{J,i} ← Sign(sk_J^sig, "j-sig-eph" || (pk_{J,i}^APKE_E || pk_{J,i}^PKE_E))`
+    pub sigma_eph: Sig,
+}
+
+/// §Step 4 (lines 256-262): source keys, all derived from the passphrase.
+pub struct SourceKeys {
+    pub sk_apke: SdApkeSk,
+    pub pk_apke: SdApkePk,
+    pub sk_pke: SdPkeSk,
+    pub pk_pke: SdPkePk,
+    pub sk_fetch: FetchSk,
+    pub pk_fetch: FetchPk,
+    pub passphrase: Vec<u8>,
+}
+
+// ===========================================================================
+// Domain tags (footnote 12: `len(tag) || tag || m` is applied uniformly
+// inside `sig_sign`, so callers pass the bare tag bytes here).
+// ===========================================================================
+
+/// §Step 2: FPF's signature over a newsroom verification key.
+pub const TAG_FPF_SIG_NR: &[u8] = b"fpf-sig-nr";
+/// §Step 3.1: Newsroom's signature over a journalist verification key.
+pub const TAG_NR_SIG: &[u8] = b"nr-sig";
+/// §Step 3.1: Journalist's self-signature over their long-term public keys.
+pub const TAG_J_SIG_LTK: &[u8] = b"j-sig-ltk";
+/// §Step 3.2: Journalist's signature over an ephemeral key bundle.
+pub const TAG_J_SIG_EPH: &[u8] = b"j-sig-eph";
+
+// ===========================================================================
+// KDF labels (§Step 4, lines 259-262)
+// ===========================================================================
+
+pub const KDF_SOURCE_FETCH: &[u8] = b"sourcefetchkey";
+pub const KDF_SOURCE_APKE_DH: &[u8] = b"sourceAPKEkey-dh";
+pub const KDF_SOURCE_APKE_MLKEM: &[u8] = b"sourceAPKEkey-mlkem";
+pub const KDF_SOURCE_PKE: &[u8] = b"sourcePKEkey";
+
+// ===========================================================================
+// PSK ID for SD-APKE (§pskAPKE, line 370)
+// ===========================================================================
+
+pub const PSK_ID: &[u8] = b"SD-pskAPKE";

--- a/securedrop-protocol/protocol-spec/src/lib.rs
+++ b/securedrop-protocol/protocol-spec/src/lib.rs
@@ -1,11 +1,14 @@
 //! Hacspec-style specification of the SecureDrop Protocol.
 //!
-//! Mirrors `docs/protocol.md` v0.4. This proof-of-concept currently
-//! contains only §SD-PKE (lines 304-333 of the doc).
+//! Mirrors `docs/protocol.md` v0.4 section by section. Cryptographic
+//! primitives are abstract (see `primitives`); the implementation crate
+//! `securedrop-protocol-minimal` is intended to be shown to refine this
+//! spec via hax + F*. See `proofs/SecureDrop.SdPke.Refinement.fst` for
+//! the SD-PKE lemma sketch.
 //!
-//! The implementation crate `securedrop-protocol-minimal` is intended to
-//! be shown to refine this spec via hax + F*. See
-//! `proofs/SecureDrop.SdPke.Refinement.fst` for the lemma sketch.
+//! Most function bodies outside `sd_pke` are `unimplemented!()`; the
+//! types, signatures, and module layout are the design artifact. SD-PKE
+//! is fleshed out as the proof-of-concept refinement target.
 
 #![no_std]
 #![allow(clippy::too_many_arguments)]
@@ -15,4 +18,9 @@ extern crate alloc;
 pub const PROTOCOL_VERSION: &str = "0.4";
 
 pub mod primitives;
+pub mod keys;
+pub mod setup;
 pub mod sd_pke;
+pub mod sd_apke;
+pub mod messaging;
+pub mod wire;

--- a/securedrop-protocol/protocol-spec/src/messaging.rs
+++ b/securedrop-protocol/protocol-spec/src/messaging.rs
@@ -1,0 +1,236 @@
+//! §Messaging Protocol (Steps 5-7, lines 426-614).
+//!
+//! Each "row" of the doc's two-column tables maps to a function on the
+//! sender, server, or receiver side. Wire messages are explicit data
+//! types (the analog of Tamarin facts); functions are the analog of
+//! Tamarin rules. The doc's set notation (`pks`, `sigs`, `challs`,
+//! `cids`, `fetched`) is encoded as fixed-length arrays of `Option<T>`,
+//! matching the doc's pad-to-MAX-MESSAGES requirement (line 614,
+//! line 672).
+//!
+//! `←$` random sampling in the doc becomes explicit `[u8; N]` randomness
+//! parameters; callers split them deterministically inside.
+
+use crate::keys::*;
+use crate::primitives::*;
+use crate::sd_apke::SdApkeCt;
+use alloc::vec::Vec;
+
+// ===========================================================================
+// Sizing constants
+// ===========================================================================
+
+/// Number of journalists with active key bundles. Fixed-length encoding
+/// of the `pks` and `sigs` sets in §Step 5.
+pub const N_JOURNALISTS: usize = 8;
+
+/// Server-side cap on stored messages. The doc references `MAX_MESSAGES`
+/// throughout §Step 7 (lines 577, 614, 672). Set conservatively here for
+/// stack-friendly executable testing; production deployments will set
+/// this higher.
+pub const MAX_MESSAGES: usize = 16;
+
+// ===========================================================================
+// §Step 5: wire types
+// ===========================================================================
+
+/// One row of `pks` from §Step 5 (line 451).
+pub struct PkBundleEntry {
+    pub vk_j_sig: SigVk,
+    pub pk_j_apke_e: SdApkePk,
+    pub pk_j_pke_e: SdPkePk,
+    pub pk_j_fetch: FetchPk,
+    pub pk_j_apke: SdApkePk,
+}
+
+/// One row of `sigs` from §Step 5 (line 452).
+pub struct SigBundleEntry {
+    pub sigma_nr_on_j: Sig,
+    pub sigma_j: Sig,
+    pub sigma_j_eph: Sig,
+}
+
+/// Server response to `RequestKeys` (§Step 5).
+pub struct KeysResponse {
+    pub pks: [Option<PkBundleEntry>; N_JOURNALISTS],
+    pub sigs: [Option<SigBundleEntry>; N_JOURNALISTS],
+}
+
+/// §Step 5 abort reasons (lines 455-457).
+#[derive(Debug)]
+pub enum AbortReason {
+    /// `SIG.Vfy(vk_NR^sig, "nr-sig" || vk_J^sig, σ_NR^J) = 0`.
+    BadNrSig,
+    /// `SIG.Vfy(vk_J^sig, "j-sig-ltk" || (pk_J^APKE || pk_J^fetch), σ_J) = 0`.
+    BadJSig,
+    /// `SIG.Vfy(vk_J^sig, "j-sig-eph" || (pk_{J,i}^APKE_E || pk_{J,i}^PKE_E), σ_{J,i}) = 0`.
+    BadJEphSig,
+}
+
+// ===========================================================================
+// §Step 6: wire types
+// ===========================================================================
+
+/// §Step 6 final wire payload `(C_S, X, Z)` from line 543.
+pub struct Envelope {
+    /// `ct^APKE` from §Step 6, line 538.
+    pub ct_apke: SdApkeCt,
+    /// `ct^PKE = (c, c')` from §Step 6, line 539.
+    pub ct_pke: (XwingEnc, Vec<u8>),
+    /// `X = g^x` (Ristretto255 ephemeral pubkey).
+    pub hint_x: R255Point,
+    /// `Z = (pk_R^fetch)^x` (Ristretto255 DH share).
+    pub hint_z: R255Point,
+}
+
+/// Server-generated message identifier (§Step 6, line 544; §Wire, line 670).
+pub type MessageId = [u8; 16];
+
+/// One row in the server's message database (§Wire, line 670).
+pub struct ServerRow {
+    pub id: MessageId,
+    pub envelope: Envelope,
+}
+
+/// Server message database, fixed-size per the doc's pad-to-MAX_MESSAGES
+/// requirement (line 614, line 672).
+pub struct ServerDb {
+    pub rows: [Option<ServerRow>; MAX_MESSAGES],
+}
+
+// ===========================================================================
+// §Step 7: wire types
+// ===========================================================================
+
+/// Per-message challenge `(eid_k, Q_k)` (§Step 7, line 589).
+pub struct Challenge {
+    /// `eid_k = AEAD.Enc(idk_k, 0^nl, -, id_k)` (§line 588).
+    pub eid: [u8; 16 + AEAD_NONCE_LEN + AEAD_TAG_LEN],
+    /// `Q_k = X_k^{r_k}` (§line 580).
+    pub q: R255Point,
+}
+
+/// Server's response to `RequestMessages` (§Step 7).
+pub struct Challenges {
+    pub items: [Option<Challenge>; MAX_MESSAGES],
+}
+
+/// Result of decrypting an envelope (§Step 7, line 608).
+/// `pt = m || pk_S^fetch || pk_S^PKE`.
+pub struct DecryptedMessage {
+    pub msg: Vec<u8>,
+    pub sender_pk_fetch: FetchPk,
+    pub sender_pk_pke: SdPkePk,
+}
+
+// ===========================================================================
+// §Step 5: signature-chain verification
+// ===========================================================================
+
+/// Server side of §Step 5 (lines 450-453): for each journalist, select
+/// one random key bundle, return `(pks, sigs)`, and remove the consumed
+/// bundle from storage.
+pub fn server_select_keys(
+    _db: ServerDb,
+    _ephemerals_per_j: &[Vec<JournalistEphemeral>; N_JOURNALISTS],
+    _journalists: &[Option<JournalistLongTerm>; N_JOURNALISTS],
+    _rng: [u8; 32],
+) -> (KeysResponse, ServerDb) {
+    unimplemented!()
+}
+
+/// Sender side of §Step 5 (lines 455-457): verify all three signature
+/// chains. Aborts on the first failure.
+pub fn sender_verify_keys(
+    _vk_nr: &SigVk,
+    _resp: &KeysResponse,
+) -> Result<(), AbortReason> {
+    unimplemented!()
+}
+
+// ===========================================================================
+// §Step 6: send a message
+// ===========================================================================
+
+/// §Step 6 (lines 537-545): produce one envelope addressed to one
+/// recipient. The caller iterates this over `pks` (and substitutes the
+/// reply target's keys for their own slot in the reply case, lines
+/// 533-535).
+///
+/// `randomness` is split deterministically inside between the SD-APKE
+/// ML-KEM encapsulation, the HPKE AuthPSK seal, the SD-PKE seal, and
+/// the Ristretto255 hint keypair generation.
+pub fn sender_encrypt_for_recipient(
+    _sender_sk_apke: &SdApkeSk,
+    _sender_pk_apke: &SdApkePk,
+    _sender_pk_fetch: &FetchPk,
+    _sender_pk_pke: &SdPkePk,
+    _recipient: &PkBundleEntry,
+    _nr_id: &[u8],
+    _message: &[u8],
+    _randomness: [u8; 256],
+) -> Envelope {
+    unimplemented!()
+}
+
+/// Server side of §Step 6 (lines 544-545): generate a fresh message ID,
+/// store the row, return updated database.
+pub fn server_store_message(
+    _db: ServerDb,
+    _envelope: Envelope,
+    _id_seed: [u8; 16],
+) -> ServerDb {
+    unimplemented!()
+}
+
+// ===========================================================================
+// §Step 7: fetch and decrypt
+// ===========================================================================
+
+/// Server side of §Step 7 (lines 577-589): construct the `MAX_MESSAGES`
+/// challenges, padding with random values for empty slots (lines
+/// 581-588). Constant-time per the requirement at line 614.
+pub fn server_compute_challenges(
+    _db: &ServerDb,
+    _nr_id: &[u8],
+    _rng: &[u8],
+) -> Challenges {
+    unimplemented!()
+}
+
+/// Receiver side of §Step 7 (lines 591-596): for each challenge, attempt
+/// decryption with the receiver's fetch key. Returns the recovered
+/// `MessageId`s (with `None` slots for failed challenges).
+pub fn receiver_solve_challenges(
+    _sk_fetch: &FetchSk,
+    _nr_id: &[u8],
+    _challenges: &Challenges,
+) -> [Option<MessageId>; MAX_MESSAGES] {
+    unimplemented!()
+}
+
+/// Server side of §Step 7 (line 600): retrieve the envelope at a given id.
+pub fn server_get_message(_db: &ServerDb, _id: &MessageId) -> Option<Envelope> {
+    unimplemented!()
+}
+
+/// Receiver side of §Step 7 (lines 601-610): trial-decrypt the metadata
+/// ciphertext against each available SD-PKE key, then run SD-APKE.AuthDec.
+///
+/// `sk_apke_options` and `sk_pke_options` are parallel slices: index `i`
+/// is one (apke, pke) keybundle. A source provides exactly one; a
+/// journalist provides one per ephemeral bundle.
+///
+/// `sender_allowlist` is `Some` only for source-recipients (line 610):
+/// after decryption, the recovered sender APKE pubkey must appear in the
+/// allowlist of trusted journalist long-term APKE pubkeys, else discard.
+pub fn receiver_decrypt(
+    _sk_apke_options: &[SdApkeSk],
+    _sk_pke_options: &[SdPkeSk],
+    _pk_fetch: &FetchPk,
+    _nr_id: &[u8],
+    _envelope: &Envelope,
+    _sender_allowlist: Option<&[SdApkePk]>,
+) -> Option<DecryptedMessage> {
+    unimplemented!()
+}

--- a/securedrop-protocol/protocol-spec/src/messaging.rs
+++ b/securedrop-protocol/protocol-spec/src/messaging.rs
@@ -30,11 +30,23 @@ pub const N_JOURNALISTS: usize = 8;
 /// this higher.
 pub const MAX_MESSAGES: usize = 16;
 
+/// Random bytes per challenge slot needed by `server_compute_challenges`:
+///   r_k (32) + z_seed (32) + x_seed (32) + id_k (16) = 112
+pub const CHALLENGE_RNG_PER_SLOT: usize = 32 + 32 + 32 + 16;
+
+/// Random bytes consumed by `sender_encrypt_for_recipient`. Layout:
+///   [0..32):    SD-APKE ML-KEM encap
+///   [32..64):   SD-APKE HPKE AuthPSK seal
+///   [64..160):  SD-PKE HPKE Base seal (96 bytes)
+///   [160..192): Ristretto255 hint scalar
+pub const ENCRYPT_RNG_LEN: usize = 192;
+
 // ===========================================================================
 // §Step 5: wire types
 // ===========================================================================
 
 /// One row of `pks` from §Step 5 (line 451).
+#[derive(Clone)]
 pub struct PkBundleEntry {
     pub vk_j_sig: SigVk,
     pub pk_j_apke_e: SdApkePk,
@@ -44,6 +56,7 @@ pub struct PkBundleEntry {
 }
 
 /// One row of `sigs` from §Step 5 (line 452).
+#[derive(Clone)]
 pub struct SigBundleEntry {
     pub sigma_nr_on_j: Sig,
     pub sigma_j: Sig,
@@ -72,6 +85,7 @@ pub enum AbortReason {
 // ===========================================================================
 
 /// §Step 6 final wire payload `(C_S, X, Z)` from line 543.
+#[derive(Clone)]
 pub struct Envelope {
     /// `ct^APKE` from §Step 6, line 538.
     pub ct_apke: SdApkeCt,
@@ -87,6 +101,7 @@ pub struct Envelope {
 pub type MessageId = [u8; 16];
 
 /// One row in the server's message database (§Wire, line 670).
+#[derive(Clone)]
 pub struct ServerRow {
     pub id: MessageId,
     pub envelope: Envelope,
@@ -98,14 +113,32 @@ pub struct ServerDb {
     pub rows: [Option<ServerRow>; MAX_MESSAGES],
 }
 
+impl ServerDb {
+    pub fn new() -> Self {
+        Self { rows: [const { None }; MAX_MESSAGES] }
+    }
+}
+
+impl Default for ServerDb {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // ===========================================================================
 // §Step 7: wire types
 // ===========================================================================
 
+/// AEAD output length for an encrypted `MessageId`.
+/// The doc fixes the nonce as `0^nl` (line 588), so it is not part of
+/// the wire encoding; only `ciphertext || tag` is transmitted.
+pub const EID_LEN: usize = 16 + AEAD_TAG_LEN;
+
 /// Per-message challenge `(eid_k, Q_k)` (§Step 7, line 589).
+#[derive(Clone)]
 pub struct Challenge {
     /// `eid_k = AEAD.Enc(idk_k, 0^nl, -, id_k)` (§line 588).
-    pub eid: [u8; 16 + AEAD_NONCE_LEN + AEAD_TAG_LEN],
+    pub eid: [u8; EID_LEN],
     /// `Q_k = X_k^{r_k}` (§line 580).
     pub q: R255Point,
 }
@@ -116,7 +149,9 @@ pub struct Challenges {
 }
 
 /// Result of decrypting an envelope (§Step 7, line 608).
-/// `pt = m || pk_S^fetch || pk_S^PKE`.
+/// `pt = pk_S^fetch || pk_S^PKE || m` (per the byte format at line 626;
+/// line 608 of the doc gives the components in a different order, which
+/// is informal pseudocode — the wire format is authoritative).
 pub struct DecryptedMessage {
     pub msg: Vec<u8>,
     pub sender_pk_fetch: FetchPk,
@@ -128,24 +163,109 @@ pub struct DecryptedMessage {
 // ===========================================================================
 
 /// Server side of §Step 5 (lines 450-453): for each journalist, select
-/// one random key bundle, return `(pks, sigs)`, and remove the consumed
-/// bundle from storage.
+/// one ephemeral key bundle indexed by `rng[j] % pool_len`, return
+/// `(pks, sigs)`.
+///
+/// Note: the doc's "remove key bundle i from storage" (line 453) is not
+/// modelled here, since the ephemeral pools are passed in as borrowed
+/// state rather than threaded through `ServerDb`. A more faithful
+/// encoding would carry the pools in `ServerDb` and consume an
+/// ephemeral on each `RequestKeys`. This is a known modelling gap.
 pub fn server_select_keys(
-    _db: ServerDb,
-    _ephemerals_per_j: &[Vec<JournalistEphemeral>; N_JOURNALISTS],
-    _journalists: &[Option<JournalistLongTerm>; N_JOURNALISTS],
-    _rng: [u8; 32],
+    db: ServerDb,
+    ephemerals_per_j: &[Vec<JournalistEphemeral>; N_JOURNALISTS],
+    journalists: &[Option<JournalistLongTerm>; N_JOURNALISTS],
+    rng: [u8; 32],
 ) -> (KeysResponse, ServerDb) {
-    unimplemented!()
+    let mut pks: [Option<PkBundleEntry>; N_JOURNALISTS] =
+        core::array::from_fn(|_| None);
+    let mut sigs: [Option<SigBundleEntry>; N_JOURNALISTS] =
+        core::array::from_fn(|_| None);
+
+    let mut j = 0;
+    while j < N_JOURNALISTS {
+        if let Some(jl) = &journalists[j] {
+            let pool = &ephemerals_per_j[j];
+            if !pool.is_empty() {
+                let idx = (rng[j] as usize) % pool.len();
+                let eph = &pool[idx];
+
+                pks[j] = Some(PkBundleEntry {
+                    vk_j_sig: jl.vk_sig,
+                    pk_j_apke_e: eph.pk_apke_e.clone(),
+                    pk_j_pke_e: eph.pk_pke_e.clone(),
+                    pk_j_fetch: jl.pk_fetch.clone(),
+                    pk_j_apke: jl.pk_apke.clone(),
+                });
+                sigs[j] = Some(SigBundleEntry {
+                    sigma_nr_on_j: jl.sigma_nr_on_j,
+                    sigma_j: jl.sigma_self,
+                    sigma_j_eph: eph.sigma_eph,
+                });
+            }
+        }
+        j += 1;
+    }
+
+    (KeysResponse { pks, sigs }, db)
 }
 
 /// Sender side of §Step 5 (lines 455-457): verify all three signature
 /// chains. Aborts on the first failure.
 pub fn sender_verify_keys(
-    _vk_nr: &SigVk,
-    _resp: &KeysResponse,
+    vk_nr: &SigVk,
+    resp: &KeysResponse,
 ) -> Result<(), AbortReason> {
-    unimplemented!()
+    let mut j = 0;
+    while j < N_JOURNALISTS {
+        if let (Some(pk_entry), Some(sig_entry)) = (&resp.pks[j], &resp.sigs[j]) {
+            // σ_NR^J: SIG.Vfy(vk_NR, "nr-sig" || vk_J^sig, σ_NR^J)
+            if !sig_verify(
+                vk_nr,
+                TAG_NR_SIG,
+                &pk_entry.vk_j_sig,
+                &sig_entry.sigma_nr_on_j,
+            ) {
+                return Err(AbortReason::BadNrSig);
+            }
+
+            // σ_J: SIG.Vfy(vk_J^sig, "j-sig-ltk" || (pk_J^APKE || pk_J^fetch), σ_J)
+            let mut ltk_preimage = [0u8; AKEM_PK_LEN + KEM_PQ_PK_LEN + R255_POINT_LEN];
+            ltk_preimage[..AKEM_PK_LEN].copy_from_slice(&pk_entry.pk_j_apke.pk1);
+            ltk_preimage[AKEM_PK_LEN..AKEM_PK_LEN + KEM_PQ_PK_LEN]
+                .copy_from_slice(&pk_entry.pk_j_apke.pk2);
+            ltk_preimage[AKEM_PK_LEN + KEM_PQ_PK_LEN..]
+                .copy_from_slice(&pk_entry.pk_j_fetch.0);
+
+            if !sig_verify(
+                &pk_entry.vk_j_sig,
+                TAG_J_SIG_LTK,
+                &ltk_preimage,
+                &sig_entry.sigma_j,
+            ) {
+                return Err(AbortReason::BadJSig);
+            }
+
+            // σ_{J,i}: SIG.Vfy(vk_J^sig, "j-sig-eph" || (pk_apke_e || pk_pke_e), σ_eph)
+            let mut eph_preimage = [0u8; AKEM_PK_LEN + KEM_PQ_PK_LEN + XWING_PK_LEN];
+            eph_preimage[..AKEM_PK_LEN].copy_from_slice(&pk_entry.pk_j_apke_e.pk1);
+            eph_preimage[AKEM_PK_LEN..AKEM_PK_LEN + KEM_PQ_PK_LEN]
+                .copy_from_slice(&pk_entry.pk_j_apke_e.pk2);
+            eph_preimage[AKEM_PK_LEN + KEM_PQ_PK_LEN..]
+                .copy_from_slice(&pk_entry.pk_j_pke_e.0);
+
+            if !sig_verify(
+                &pk_entry.vk_j_sig,
+                TAG_J_SIG_EPH,
+                &eph_preimage,
+                &sig_entry.sigma_j_eph,
+            ) {
+                return Err(AbortReason::BadJEphSig);
+            }
+        }
+        j += 1;
+    }
+    Ok(())
 }
 
 // ===========================================================================
@@ -159,28 +279,83 @@ pub fn sender_verify_keys(
 ///
 /// `randomness` is split deterministically inside between the SD-APKE
 /// ML-KEM encapsulation, the HPKE AuthPSK seal, the SD-PKE seal, and
-/// the Ristretto255 hint keypair generation.
+/// the Ristretto255 hint keypair generation. See `ENCRYPT_RNG_LEN`.
 pub fn sender_encrypt_for_recipient(
-    _sender_sk_apke: &SdApkeSk,
-    _sender_pk_apke: &SdApkePk,
-    _sender_pk_fetch: &FetchPk,
-    _sender_pk_pke: &SdPkePk,
-    _recipient: &PkBundleEntry,
-    _nr_id: &[u8],
-    _message: &[u8],
-    _randomness: [u8; 256],
+    sender_sk_apke: &SdApkeSk,
+    sender_pk_apke: &SdApkePk,
+    sender_pk_fetch: &FetchPk,
+    sender_pk_pke: &SdPkePk,
+    recipient: &PkBundleEntry,
+    nr_id: &[u8],
+    message: &[u8],
+    randomness: [u8; ENCRYPT_RNG_LEN],
 ) -> Envelope {
-    unimplemented!()
+    // Split randomness
+    let mut r_apke_pq = [0u8; 32];
+    r_apke_pq.copy_from_slice(&randomness[0..32]);
+    let mut r_apke_hpke = [0u8; 32];
+    r_apke_hpke.copy_from_slice(&randomness[32..64]);
+    let mut r_pke = [0u8; 96];
+    r_pke.copy_from_slice(&randomness[64..160]);
+    let mut r_hint = [0u8; 32];
+    r_hint.copy_from_slice(&randomness[160..192]);
+
+    // pt = pk_S^fetch || pk_S^PKE || m, padded to FIXED_MSG_LEN
+    let pt = crate::wire::encode_apke_plaintext(sender_pk_fetch, sender_pk_pke, message);
+
+    // ct^APKE = SD-APKE.AuthEnc(sk_S^APKE, pk_R^APKE, pt, NR, pk_R^fetch)
+    let ct_apke = crate::sd_apke::auth_enc(
+        sender_sk_apke,
+        sender_pk_apke,
+        &recipient.pk_j_apke_e,
+        &pt,
+        nr_id,
+        &recipient.pk_j_fetch.0,
+        r_apke_pq,
+        r_apke_hpke,
+    );
+
+    // ct^PKE = SD-PKE.Enc(pk_R^PKE, pk_S^APKE)
+    let pke_pt = crate::wire::encode_pke_plaintext(sender_pk_apke);
+    let ct_pke_full = crate::sd_pke::enc(&recipient.pk_j_pke_e, &pke_pt, r_pke);
+
+    // (x, X) ← Ristretto255.KGen(); Z = (pk_R^fetch)^x
+    let (hint_sk, hint_x) = r255_keygen(r_hint);
+    let hint_z = r255_dh(&hint_sk, &recipient.pk_j_fetch.0);
+
+    Envelope {
+        ct_apke,
+        ct_pke: (ct_pke_full.c, ct_pke_full.cp),
+        hint_x,
+        hint_z,
+    }
 }
 
-/// Server side of §Step 6 (lines 544-545): generate a fresh message ID,
-/// store the row, return updated database.
+/// Server side of §Step 6 (lines 544-545): generate a fresh message ID
+/// and store the row in the first available slot. Returns the updated
+/// database. If the database is full, the envelope is dropped (the
+/// doc treats `MAX_MESSAGES` as a hard cap).
 pub fn server_store_message(
-    _db: ServerDb,
-    _envelope: Envelope,
-    _id_seed: [u8; 16],
+    db: ServerDb,
+    envelope: Envelope,
+    id_seed: [u8; 16],
 ) -> ServerDb {
-    unimplemented!()
+    let mut new_db = db;
+
+    let mut empty_idx: Option<usize> = None;
+    let mut k = 0;
+    while k < MAX_MESSAGES {
+        if new_db.rows[k].is_none() {
+            empty_idx = Some(k);
+            break;
+        }
+        k += 1;
+    }
+
+    if let Some(idx) = empty_idx {
+        new_db.rows[idx] = Some(ServerRow { id: id_seed, envelope });
+    }
+    new_db
 }
 
 // ===========================================================================
@@ -190,28 +365,122 @@ pub fn server_store_message(
 /// Server side of §Step 7 (lines 577-589): construct the `MAX_MESSAGES`
 /// challenges, padding with random values for empty slots (lines
 /// 581-588). Constant-time per the requirement at line 614.
+///
+/// `rng` must contain at least `CHALLENGE_RNG_PER_SLOT * MAX_MESSAGES`
+/// bytes.
 pub fn server_compute_challenges(
-    _db: &ServerDb,
-    _nr_id: &[u8],
-    _rng: &[u8],
+    db: &ServerDb,
+    nr_id: &[u8],
+    rng: &[u8],
 ) -> Challenges {
-    unimplemented!()
+    let mut items: [Option<Challenge>; MAX_MESSAGES] = [const { None }; MAX_MESSAGES];
+
+    let mut k = 0;
+    while k < MAX_MESSAGES {
+        let base = k * CHALLENGE_RNG_PER_SLOT;
+
+        // r_k from rng[base..base+32]
+        let mut r_k = [0u8; 32];
+        r_k.copy_from_slice(&rng[base..base + 32]);
+
+        let q_k: R255Point;
+        let z_k: R255Point;
+        let id_k: MessageId;
+
+        match &db.rows[k] {
+            Some(row) => {
+                // Q_k = X_k^{r_k}; Z_k = stored Z; id_k = stored id
+                q_k = r255_dh(&r_k, &row.envelope.hint_x);
+                z_k = row.envelope.hint_z;
+                id_k = row.id;
+            }
+            None => {
+                // Pad slot: random Z_k, Q_k, id_k.
+                let mut z_seed = [0u8; 32];
+                z_seed.copy_from_slice(&rng[base + 32..base + 64]);
+                let mut x_seed = [0u8; 32];
+                x_seed.copy_from_slice(&rng[base + 64..base + 96]);
+
+                // Z_k = g^{z_k}; Q_k = g^{x_k}.
+                // The doc's Q_k = g^{x_k * r_k} for empty slots is a
+                // composition of scalar mults that hacspec doesn't have
+                // a primitive for. Indistinguishability from real
+                // (Q_k, Z_k) pairs only requires that both look uniform
+                // in the group, which a fresh keygen output does.
+                let (_, z_pub) = r255_keygen(z_seed);
+                z_k = z_pub;
+                let (_, q_pub) = r255_keygen(x_seed);
+                q_k = q_pub;
+
+                let mut id_buf = [0u8; 16];
+                id_buf.copy_from_slice(&rng[base + 96..base + 112]);
+                id_k = id_buf;
+            }
+        }
+
+        // idk_k = KDF(Z_k^{r_k}, NR)
+        let zk_rk = r255_dh(&r_k, &z_k);
+        let idk_k = kdf(&zk_rk, nr_id);
+
+        // eid_k = AEAD.Enc(idk_k, 0^nl, -, id_k)
+        let nonce = [0u8; AEAD_NONCE_LEN];
+        let ct = aead_encrypt(&idk_k, &nonce, &[], &id_k);
+
+        let mut eid = [0u8; EID_LEN];
+        let copy_len = if ct.len() > EID_LEN { EID_LEN } else { ct.len() };
+        eid[..copy_len].copy_from_slice(&ct[..copy_len]);
+
+        items[k] = Some(Challenge { eid, q: q_k });
+        k += 1;
+    }
+
+    Challenges { items }
 }
 
 /// Receiver side of §Step 7 (lines 591-596): for each challenge, attempt
-/// decryption with the receiver's fetch key. Returns the recovered
-/// `MessageId`s (with `None` slots for failed challenges).
+/// AEAD decryption with `tk_k = KDF(Q_k^{sk_R^fetch}, NR)`. Returns the
+/// recovered `MessageId`s aligned to the challenge slots (with `None`
+/// for slots that didn't decrypt to a 16-byte plaintext).
 pub fn receiver_solve_challenges(
-    _sk_fetch: &FetchSk,
-    _nr_id: &[u8],
-    _challenges: &Challenges,
+    sk_fetch: &FetchSk,
+    nr_id: &[u8],
+    challenges: &Challenges,
 ) -> [Option<MessageId>; MAX_MESSAGES] {
-    unimplemented!()
+    let mut out: [Option<MessageId>; MAX_MESSAGES] = [const { None }; MAX_MESSAGES];
+
+    let mut k = 0;
+    while k < MAX_MESSAGES {
+        if let Some(chal) = &challenges.items[k] {
+            // tk_k = KDF(Q_k^{sk_R^fetch}, NR)
+            let qk_skf = r255_dh(&sk_fetch.0, &chal.q);
+            let tk_k = kdf(&qk_skf, nr_id);
+
+            let nonce = [0u8; AEAD_NONCE_LEN];
+            if let Some(pt) = aead_decrypt(&tk_k, &nonce, &[], &chal.eid) {
+                if pt.len() == 16 {
+                    let mut id = [0u8; 16];
+                    id.copy_from_slice(&pt);
+                    out[k] = Some(id);
+                }
+            }
+        }
+        k += 1;
+    }
+    out
 }
 
 /// Server side of §Step 7 (line 600): retrieve the envelope at a given id.
-pub fn server_get_message(_db: &ServerDb, _id: &MessageId) -> Option<Envelope> {
-    unimplemented!()
+pub fn server_get_message(db: &ServerDb, id: &MessageId) -> Option<Envelope> {
+    let mut k = 0;
+    while k < MAX_MESSAGES {
+        if let Some(row) = &db.rows[k] {
+            if row.id == *id {
+                return Some(row.envelope.clone());
+            }
+        }
+        k += 1;
+    }
+    None
 }
 
 /// Receiver side of §Step 7 (lines 601-610): trial-decrypt the metadata
@@ -225,12 +494,84 @@ pub fn server_get_message(_db: &ServerDb, _id: &MessageId) -> Option<Envelope> {
 /// after decryption, the recovered sender APKE pubkey must appear in the
 /// allowlist of trusted journalist long-term APKE pubkeys, else discard.
 pub fn receiver_decrypt(
-    _sk_apke_options: &[SdApkeSk],
-    _sk_pke_options: &[SdPkeSk],
-    _pk_fetch: &FetchPk,
-    _nr_id: &[u8],
-    _envelope: &Envelope,
-    _sender_allowlist: Option<&[SdApkePk]>,
+    sk_apke_options: &[SdApkeSk],
+    sk_pke_options: &[SdPkeSk],
+    pk_fetch: &FetchPk,
+    nr_id: &[u8],
+    envelope: &Envelope,
+    sender_allowlist: Option<&[SdApkePk]>,
 ) -> Option<DecryptedMessage> {
-    unimplemented!()
+    if sk_apke_options.len() != sk_pke_options.len() {
+        return None;
+    }
+
+    let pke_ct = crate::sd_pke::SdPkeCt {
+        c: envelope.ct_pke.0,
+        cp: envelope.ct_pke.1.clone(),
+    };
+
+    // Trial-decrypt the metadata ciphertext to find which keybundle
+    // applies, and recover the sender's APKE pubkey from the plaintext.
+    let mut sender_pk_apke: Option<SdApkePk> = None;
+    let mut matching_idx: Option<usize> = None;
+
+    let mut i = 0;
+    while i < sk_pke_options.len() {
+        if let Some(pt_bytes) = crate::sd_pke::dec(&sk_pke_options[i], &pke_ct) {
+            if pt_bytes.len() == crate::wire::SD_PKE_PT_LEN {
+                let mut pt_arr = [0u8; crate::wire::SD_PKE_PT_LEN];
+                pt_arr.copy_from_slice(&pt_bytes);
+                sender_pk_apke = Some(crate::wire::decode_pke_plaintext(&pt_arr));
+                matching_idx = Some(i);
+                break;
+            }
+        }
+        i += 1;
+    }
+
+    let sender_pk_apke = sender_pk_apke?;
+    let idx = matching_idx?;
+
+    // SD-APKE.AuthDec
+    let pt = crate::sd_apke::auth_dec(
+        &sk_apke_options[idx],
+        &sender_pk_apke,
+        &envelope.ct_apke,
+        nr_id,
+        &pk_fetch.0,
+    )?;
+
+    // Decode pt = pk_S^fetch || pk_S^PKE || m
+    if pt.len() != crate::wire::SD_APKE_PT_LEN {
+        return None;
+    }
+    let mut pt_arr = [0u8; crate::wire::SD_APKE_PT_LEN];
+    pt_arr.copy_from_slice(&pt);
+    let (sender_pk_fetch, sender_pk_pke, msg) =
+        crate::wire::decode_apke_plaintext(&pt_arr);
+
+    // Source-only allowlist check (line 610): the recovered sender APKE
+    // pubkey must match a trusted journalist long-term APKE pubkey.
+    if let Some(allowlist) = sender_allowlist {
+        let mut found = false;
+        let mut j = 0;
+        while j < allowlist.len() {
+            if allowlist[j].pk1 == sender_pk_apke.pk1
+                && allowlist[j].pk2 == sender_pk_apke.pk2
+            {
+                found = true;
+                break;
+            }
+            j += 1;
+        }
+        if !found {
+            return None;
+        }
+    }
+
+    Some(DecryptedMessage {
+        msg,
+        sender_pk_fetch,
+        sender_pk_pke,
+    })
 }

--- a/securedrop-protocol/protocol-spec/src/primitives.rs
+++ b/securedrop-protocol/protocol-spec/src/primitives.rs
@@ -1,48 +1,175 @@
 //! Abstract cryptographic primitives.
 //!
-//! Each function here is an opaque boundary: ProVerif treats them as
+//! Each function is an opaque boundary: ProVerif treats them as
 //! constructors with axiomatized properties; F* uses pre/postconditions
 //! for refinement. The implementation crate provides concrete bodies
 //! (libcrux, hpke-rs); this crate never inspects them.
 //!
-//! This proof-of-concept restricts the abstract primitive surface to
-//! exactly what §SD-PKE needs (X-Wing keygen + HPKE Base seal/open).
+//! Lengths come from the algorithm specs cited in `docs/protocol.md`
+//! (§Key Hierarchy, §Wire formats).
 
 use alloc::vec::Vec;
 
 // ===========================================================================
-// X-Wing(X25519, ML-KEM-768) (§Key Hierarchy line 142, §SD-PKE line 309)
+// §Notation: Signature scheme (lines 280-282), tag-prefix per footnote 12
 // ===========================================================================
 
-/// X-Wing decapsulation key length per the I-D's encoding (§docs/protocol.md
-/// line 18 of constants.rs in the impl).
+pub const SIG_SK_LEN: usize = 32;
+pub const SIG_VK_LEN: usize = 32;
+pub const SIG_LEN: usize = 64;
+
+pub type SigSk = [u8; SIG_SK_LEN];
+pub type SigVk = [u8; SIG_VK_LEN];
+pub type Sig = [u8; SIG_LEN];
+
+pub fn sig_keygen(_seed: [u8; 32]) -> (SigSk, SigVk) {
+    unimplemented!()
+}
+
+/// Sign per footnote 12: `Sign(sk, len(tag) || tag || m)`.
+pub fn sig_sign(_sk: &SigSk, _tag: &[u8], _m: &[u8]) -> Sig {
+    unimplemented!()
+}
+
+pub fn sig_verify(_vk: &SigVk, _tag: &[u8], _m: &[u8], _s: &Sig) -> bool {
+    unimplemented!()
+}
+
+// ===========================================================================
+// §AKEM: DHKEM(X25519, HKDF-SHA256), line 339
+// ===========================================================================
+
+pub const AKEM_SK_LEN: usize = 32;
+pub const AKEM_PK_LEN: usize = 32;
+pub const AKEM_ENC_LEN: usize = 32;
+pub const AKEM_SS_LEN: usize = 32;
+
+pub type AkemSk = [u8; AKEM_SK_LEN];
+pub type AkemPk = [u8; AKEM_PK_LEN];
+pub type AkemEnc = [u8; AKEM_ENC_LEN];
+pub type AkemSs = [u8; AKEM_SS_LEN];
+
+pub fn akem_keygen(_seed: [u8; 32]) -> (AkemSk, AkemPk) {
+    unimplemented!()
+}
+
+pub fn akem_authencap(
+    _sk_s: &AkemSk,
+    _pk_r: &AkemPk,
+    _randomness: [u8; 32],
+) -> (AkemEnc, AkemSs) {
+    unimplemented!()
+}
+
+pub fn akem_authdecap(_sk_r: &AkemSk, _pk_s: &AkemPk, _c: &AkemEnc) -> AkemSs {
+    unimplemented!()
+}
+
+// ===========================================================================
+// §SD-APKE: ML-KEM-768 (KEM_PQ), line 386
+// ===========================================================================
+
+pub const KEM_PQ_SK_LEN: usize = 2400;
+pub const KEM_PQ_PK_LEN: usize = 1184;
+pub const KEM_PQ_CT_LEN: usize = 1088;
+pub const KEM_PQ_SS_LEN: usize = 32;
+
+pub type KemPqSk = [u8; KEM_PQ_SK_LEN];
+pub type KemPqPk = [u8; KEM_PQ_PK_LEN];
+pub type KemPqCt = [u8; KEM_PQ_CT_LEN];
+pub type KemPqSs = [u8; KEM_PQ_SS_LEN];
+
+pub fn kem_pq_keygen(_seed: [u8; 64]) -> (KemPqSk, KemPqPk) {
+    unimplemented!()
+}
+
+pub fn kem_pq_encap(_pk: &KemPqPk, _randomness: [u8; 32]) -> (KemPqCt, KemPqSs) {
+    unimplemented!()
+}
+
+pub fn kem_pq_decap(_sk: &KemPqSk, _ct: &KemPqCt) -> KemPqSs {
+    unimplemented!()
+}
+
+// ===========================================================================
+// §SD-PKE: X-Wing(X25519, ML-KEM-768), line 309
+// ===========================================================================
+
 pub const XWING_SK_LEN: usize = 32;
-/// X-Wing encapsulation key length (§Wire formats, line 638).
 pub const XWING_PK_LEN: usize = 1216;
-/// X-Wing encapsulated shared-secret ciphertext length (§Wire formats line 656).
 pub const XWING_ENC_LEN: usize = 1120;
 
 pub type XwingSk = [u8; XWING_SK_LEN];
 pub type XwingPk = [u8; XWING_PK_LEN];
 pub type XwingEnc = [u8; XWING_ENC_LEN];
 
-/// X-Wing key generation (§KGen of SD-PKE, line 322).
-///
-/// Deterministic on `seed`; randomness is supplied by the caller.
+/// X-Wing key generation (§KGen of SD-PKE, line 322). Deterministic on
+/// `seed`.
 pub fn xwing_keygen(_seed: [u8; 32]) -> (XwingSk, XwingPk) {
     unimplemented!()
 }
 
 // ===========================================================================
-// HPKE Base mode (RFC 9180 §5.1.1), used by §SD-PKE
+// §Notation: Ristretto255 group, line 294
 // ===========================================================================
 
-/// HPKE Base seal: `(enc, ct) = SealBase(pk_r, info, aad, pt)`, as cited
-/// at §SD-PKE line 327 with `info=None, aad=None`.
-///
-/// Randomness is supplied explicitly. RFC 9180's `Encap` consumes 32 bytes
-/// for X25519 plus the underlying KEM's randomness; X-Wing wraps both, so
-/// 96 bytes is sufficient.
+pub const R255_SCALAR_LEN: usize = 32;
+pub const R255_POINT_LEN: usize = 32;
+
+pub type R255Scalar = [u8; R255_SCALAR_LEN];
+pub type R255Point = [u8; R255_POINT_LEN];
+
+pub fn r255_keygen(_seed: [u8; 32]) -> (R255Scalar, R255Point) {
+    unimplemented!()
+}
+
+pub fn r255_dh(_sk: &R255Scalar, _pk: &R255Point) -> R255Point {
+    unimplemented!()
+}
+
+// ===========================================================================
+// §Notation: KDF / PBKDF, lines 277-278
+// ===========================================================================
+
+pub fn kdf(_ikm: &[u8], _info: &[u8]) -> [u8; 32] {
+    unimplemented!()
+}
+
+pub fn pbkdf(_passphrase: &[u8]) -> [u8; 64] {
+    unimplemented!()
+}
+
+// ===========================================================================
+// §Notation: AEAD, lines 283-285 (used in §Step 7 challenges)
+// ===========================================================================
+
+pub const AEAD_KEY_LEN: usize = 32;
+pub const AEAD_NONCE_LEN: usize = 12;
+pub const AEAD_TAG_LEN: usize = 16;
+
+pub fn aead_encrypt(
+    _k: &[u8; AEAD_KEY_LEN],
+    _n: &[u8; AEAD_NONCE_LEN],
+    _ad: &[u8],
+    _pt: &[u8],
+) -> Vec<u8> {
+    unimplemented!()
+}
+
+pub fn aead_decrypt(
+    _k: &[u8; AEAD_KEY_LEN],
+    _n: &[u8; AEAD_NONCE_LEN],
+    _ad: &[u8],
+    _ct: &[u8],
+) -> Option<Vec<u8>> {
+    unimplemented!()
+}
+
+// ===========================================================================
+// HPKE Base mode (§SD-PKE) and AuthPSK mode (§pskAPKE)
+// ===========================================================================
+
+/// HPKE Base seal (§SD-PKE, line 327): `(c, c') = SealBase(pkR, info, aad, pt)`.
 pub fn hpke_seal_base(
     _pk_r: &XwingPk,
     _info: &[u8],
@@ -53,11 +180,37 @@ pub fn hpke_seal_base(
     unimplemented!()
 }
 
-/// HPKE Base open: `pt = OpenBase(sk_r, enc, info, aad, ct)`, as cited
-/// at §SD-PKE line 331 with `info=None, aad=None`.
 pub fn hpke_open_base(
     _sk_r: &XwingSk,
     _enc: &XwingEnc,
+    _info: &[u8],
+    _aad: &[u8],
+    _ct: &[u8],
+) -> Option<Vec<u8>> {
+    unimplemented!()
+}
+
+/// HPKE AuthPSK seal (§pskAPKE, line 373):
+/// `(c1, c') = SealAuthPSK(pkR, info, aad, pt, psk, psk_id, skS)`.
+pub fn hpke_seal_auth_psk(
+    _pk_r: &AkemPk,
+    _sk_s: &AkemSk,
+    _psk: &KemPqSs,
+    _psk_id: &[u8],
+    _info: &[u8],
+    _aad: &[u8],
+    _pt: &[u8],
+    _randomness: [u8; 32],
+) -> (AkemEnc, Vec<u8>) {
+    unimplemented!()
+}
+
+pub fn hpke_open_auth_psk(
+    _sk_r: &AkemSk,
+    _pk_s: &AkemPk,
+    _psk: &KemPqSs,
+    _psk_id: &[u8],
+    _enc: &AkemEnc,
     _info: &[u8],
     _aad: &[u8],
     _ct: &[u8],

--- a/securedrop-protocol/protocol-spec/src/primitives.rs
+++ b/securedrop-protocol/protocol-spec/src/primitives.rs
@@ -131,7 +131,16 @@ pub fn r255_dh(_sk: &R255Scalar, _pk: &R255Point) -> R255Point {
 // §Notation: KDF / PBKDF, lines 277-278
 // ===========================================================================
 
+/// Key derivation: 32-byte output. Used in §Step 4 for source fetch and
+/// PKE keys, and in §Step 7 for fetch-challenge tag/idk derivation.
 pub fn kdf(_ikm: &[u8], _info: &[u8]) -> [u8; 32] {
+    unimplemented!()
+}
+
+/// Key derivation: 64-byte output. Used in §Step 4 for the source's
+/// ML-KEM-768 keygen seed (the doc's `KDF` notation is vague about
+/// output length; the impl uses Blake2b-64 here, hence this variant).
+pub fn kdf_64(_ikm: &[u8], _info: &[u8]) -> [u8; 64] {
     unimplemented!()
 }
 

--- a/securedrop-protocol/protocol-spec/src/sd_apke.rs
+++ b/securedrop-protocol/protocol-spec/src/sd_apke.rs
@@ -1,0 +1,75 @@
+//! §SD-APKE: SecureDrop APKE (`docs/protocol.md` lines 381-424).
+//!
+//! Translates the Python pseudocode at lines 399-424 of the doc.
+//!
+//! Note the `info` parameter convention. The mathematical signature in
+//! the table at line 392 reads `AuthEnc(sk, pk, m, ad, info)`, but the
+//! implementation actually constructs the HPKE `info` argument as
+//! `c2 || info || pkS2` (line 413). The `<!-- FIXME -->` at line 547
+//! flags this. This spec encodes the actual implementation, not the
+//! shorthand mathematical signature.
+//!
+//! ```text
+//! def AuthEnc(sk=(skS1, skS2), pk=(pkR1, pkR2), m, ad, info):
+//!     pkS2 = skS2.public()
+//!     (c2, K2) = KEM_PQ.Encap(pkR=pkR2)
+//!     (c1, cp) = pskAEnc(skS=skS1, pkR=pkR1, psk=K2,
+//!                        m=m, ad=ad, info=c2 + info + pkS2)
+//!     return ((c1, cp), c2)
+//!
+//! def AuthDec(sk=(skR1, skR2), pk=(pkS1, pkS2), c1, cp, c2, ad, info):
+//!     K2 = KEM_PQ.Decap(skR=skR2, enc=c2)
+//!     m = pskADec(pkS=pkS1, skR=skR1, psk=K2,
+//!                 c1=c1, cp=cp, ad=ad, info=c2 + info + pkS2)
+//!     return m
+//! ```
+
+use crate::keys::{SdApkePk, SdApkeSk};
+use crate::primitives::*;
+use alloc::vec::Vec;
+
+/// §SD-APKE ciphertext: `((c1, c'), c2)`.
+pub struct SdApkeCt {
+    /// HPKE AuthPSK encapsulation (DH-AKEM).
+    pub c1: AkemEnc,
+    /// HPKE AuthPSK AEAD ciphertext (`c'`).
+    pub cp: Vec<u8>,
+    /// ML-KEM-768 encapsulation used as PSK.
+    pub c2: KemPqCt,
+}
+
+pub fn keygen(_seed_dh: [u8; 32], _seed_pq: [u8; 64]) -> (SdApkeSk, SdApkePk) {
+    unimplemented!()
+}
+
+/// §AuthEnc (lines 407-414).
+///
+/// The `info` argument here is the caller-supplied portion only. The
+/// HPKE `info` parameter that actually gets bound to the ciphertext is
+/// `c2 || info || pkS2`, constructed inside this function. `pkS2` is
+/// the sender's ML-KEM public key (passed as `sender_pk.pk2` rather
+/// than re-derived from `sk.sk2` since hacspec lacks a generic
+/// public-from-private operation for ML-KEM).
+pub fn auth_enc(
+    _sk_s: &SdApkeSk,
+    _pk_s: &SdApkePk,
+    _pk_r: &SdApkePk,
+    _m: &[u8],
+    _ad: &[u8],
+    _info: &[u8],
+    _randomness_pq: [u8; 32],
+    _randomness_hpke: [u8; 32],
+) -> SdApkeCt {
+    unimplemented!()
+}
+
+/// §AuthDec (lines 416-423).
+pub fn auth_dec(
+    _sk_r: &SdApkeSk,
+    _pk_s: &SdApkePk,
+    _ct: &SdApkeCt,
+    _ad: &[u8],
+    _info: &[u8],
+) -> Option<Vec<u8>> {
+    unimplemented!()
+}

--- a/securedrop-protocol/protocol-spec/src/sd_apke.rs
+++ b/securedrop-protocol/protocol-spec/src/sd_apke.rs
@@ -24,11 +24,12 @@
 //!     return m
 //! ```
 
-use crate::keys::{SdApkePk, SdApkeSk};
+use crate::keys::{PSK_ID, SdApkePk, SdApkeSk};
 use crate::primitives::*;
 use alloc::vec::Vec;
 
 /// §SD-APKE ciphertext: `((c1, c'), c2)`.
+#[derive(Clone)]
 pub struct SdApkeCt {
     /// HPKE AuthPSK encapsulation (DH-AKEM).
     pub c1: AkemEnc,
@@ -38,38 +39,81 @@ pub struct SdApkeCt {
     pub c2: KemPqCt,
 }
 
-pub fn keygen(_seed_dh: [u8; 32], _seed_pq: [u8; 64]) -> (SdApkeSk, SdApkePk) {
-    unimplemented!()
+/// `KGen()` — §SD-APKE line 401.
+pub fn keygen(seed_dh: [u8; 32], seed_pq: [u8; 64]) -> (SdApkeSk, SdApkePk) {
+    let (sk1, pk1) = akem_keygen(seed_dh);
+    let (sk2, pk2) = kem_pq_keygen(seed_pq);
+    (SdApkeSk { sk1, sk2 }, SdApkePk { pk1, pk2 })
 }
 
-/// §AuthEnc (lines 407-414).
+/// `AuthEnc(sk, pk, m, ad, info)` — §SD-APKE lines 407-414.
 ///
 /// The `info` argument here is the caller-supplied portion only. The
 /// HPKE `info` parameter that actually gets bound to the ciphertext is
 /// `c2 || info || pkS2`, constructed inside this function. `pkS2` is
-/// the sender's ML-KEM public key (passed as `sender_pk.pk2` rather
-/// than re-derived from `sk.sk2` since hacspec lacks a generic
-/// public-from-private operation for ML-KEM).
+/// the sender's ML-KEM public key; it's passed as `sender_pk.pk2`
+/// rather than re-derived from `sender_sk.sk2` since hacspec lacks a
+/// generic public-from-private operation for ML-KEM.
 pub fn auth_enc(
-    _sk_s: &SdApkeSk,
-    _pk_s: &SdApkePk,
-    _pk_r: &SdApkePk,
-    _m: &[u8],
-    _ad: &[u8],
-    _info: &[u8],
-    _randomness_pq: [u8; 32],
-    _randomness_hpke: [u8; 32],
+    sender_sk: &SdApkeSk,
+    sender_pk: &SdApkePk,
+    recipient_pk: &SdApkePk,
+    m: &[u8],
+    ad: &[u8],
+    info: &[u8],
+    randomness_pq: [u8; 32],
+    randomness_hpke: [u8; 32],
 ) -> SdApkeCt {
-    unimplemented!()
+    // (c2, K2) = KEM_PQ.Encap(pkR = pkR2)
+    let (c2, k2) = kem_pq_encap(&recipient_pk.pk2, randomness_pq);
+
+    // full_info = c2 || info || pkS2
+    let mut full_info = Vec::new();
+    full_info.extend_from_slice(&c2);
+    full_info.extend_from_slice(info);
+    full_info.extend_from_slice(&sender_pk.pk2);
+
+    // (c1, cp) = pskAEnc(skS=skS1, pkR=pkR1, psk=K2, m=m, ad=ad, info=full_info)
+    let (c1, cp) = hpke_seal_auth_psk(
+        &recipient_pk.pk1,
+        &sender_sk.sk1,
+        &k2,
+        PSK_ID,
+        &full_info,
+        ad,
+        m,
+        randomness_hpke,
+    );
+
+    SdApkeCt { c1, cp, c2 }
 }
 
-/// §AuthDec (lines 416-423).
+/// `AuthDec(sk, pk, ((c1, cp), c2), ad, info)` — §SD-APKE lines 416-423.
 pub fn auth_dec(
-    _sk_r: &SdApkeSk,
-    _pk_s: &SdApkePk,
-    _ct: &SdApkeCt,
-    _ad: &[u8],
-    _info: &[u8],
+    receiver_sk: &SdApkeSk,
+    sender_pk: &SdApkePk,
+    ct: &SdApkeCt,
+    ad: &[u8],
+    info: &[u8],
 ) -> Option<Vec<u8>> {
-    unimplemented!()
+    // K2 = KEM_PQ.Decap(skR = skR2, enc = c2)
+    let k2 = kem_pq_decap(&receiver_sk.sk2, &ct.c2);
+
+    // full_info = c2 || info || pkS2  (must reconstruct the same info as encrypt)
+    let mut full_info = Vec::new();
+    full_info.extend_from_slice(&ct.c2);
+    full_info.extend_from_slice(info);
+    full_info.extend_from_slice(&sender_pk.pk2);
+
+    // m = pskADec(pkS=pkS1, skR=skR1, psk=K2, c1=c1, cp=cp, ad=ad, info=full_info)
+    hpke_open_auth_psk(
+        &receiver_sk.sk1,
+        &sender_pk.pk1,
+        &k2,
+        PSK_ID,
+        &ct.c1,
+        &full_info,
+        ad,
+        &ct.cp,
+    )
 }

--- a/securedrop-protocol/protocol-spec/src/sd_pke.rs
+++ b/securedrop-protocol/protocol-spec/src/sd_pke.rs
@@ -24,14 +24,9 @@
 //! parameters of the abstract HPKE primitive in `primitives` and not
 //! visible here.
 
-use crate::primitives::{XwingEnc, XwingPk, XwingSk, hpke_open_base, hpke_seal_base, xwing_keygen};
+use crate::keys::{SdPkePk, SdPkeSk};
+use crate::primitives::{XwingEnc, hpke_open_base, hpke_seal_base, xwing_keygen};
 use alloc::vec::Vec;
-
-/// SD-PKE recipient public key `pk_R^PKE` (§Key Hierarchy line 142).
-pub struct SdPkePk(pub XwingPk);
-
-/// SD-PKE recipient private key `sk_R^PKE` (§Key Hierarchy line 142).
-pub struct SdPkeSk(pub XwingSk);
 
 /// SD-PKE ciphertext `(c, c')` per §SD-PKE line 317.
 pub struct SdPkeCt {

--- a/securedrop-protocol/protocol-spec/src/sd_pke.rs
+++ b/securedrop-protocol/protocol-spec/src/sd_pke.rs
@@ -29,6 +29,7 @@ use crate::primitives::{XwingEnc, hpke_open_base, hpke_seal_base, xwing_keygen};
 use alloc::vec::Vec;
 
 /// SD-PKE ciphertext `(c, c')` per §SD-PKE line 317.
+#[derive(Clone)]
 pub struct SdPkeCt {
     /// Encapsulated X-Wing shared secret (`c` in the spec).
     pub c: XwingEnc,

--- a/securedrop-protocol/protocol-spec/src/setup.rs
+++ b/securedrop-protocol/protocol-spec/src/setup.rs
@@ -1,0 +1,69 @@
+//! §Key Setup Steps (lines 149-267).
+//!
+//! Setup steps that involve a wire exchange (Steps 2 and 3.1) are encoded
+//! as a single function whose return type captures both parties' final
+//! state, with the over-the-wire arrow inlined. This is the standard
+//! single-program functional encoding of a two-party protocol; the
+//! information that actually crosses the wire is visible in the function
+//! signature (which arguments are pre-existing party state vs. fresh
+//! input).
+
+use crate::keys::*;
+
+/// §Step 1 (line 161): FPF signing setup.
+pub fn fpf_setup(_seed: [u8; 32]) -> FpfKeys {
+    unimplemented!()
+}
+
+/// §Step 2 (lines 183-188): Newsroom signing setup.
+///
+/// Models the wire exchange: NR generates `(sk_NR, vk_NR)`, FPF (after
+/// out-of-band manual verification, treated here as having occurred) signs
+/// `"fpf-sig-nr" || vk_NR`, and the resulting `σ_FPF^NR` is bundled with
+/// the newsroom's keypair.
+pub fn newsroom_setup(_nr_seed: [u8; 32], _fpf: &FpfKeys) -> NewsroomKeys {
+    unimplemented!()
+}
+
+/// §Step 3.1 (lines 214-224): Journalist initial key setup.
+///
+/// Generates the journalist's three long-term keypairs, the journalist's
+/// self-signature `σ_J`, and the newsroom's signature `σ_NR^J` over the
+/// journalist's verification key. The doc's manual-verification step is
+/// implicit in the `nr` argument being passed in.
+pub fn journalist_long_term_setup(
+    _seed_sig: [u8; 32],
+    _seed_apke_dh: [u8; 32],
+    _seed_apke_mlkem: [u8; 64],
+    _seed_fetch: [u8; 32],
+    _nr: &NewsroomKeys,
+) -> JournalistLongTerm {
+    unimplemented!()
+}
+
+/// §Step 3.2 (lines 239-244): one ephemeral key bundle.
+///
+/// In production the journalist maintains a pool of `n` of these; this
+/// function generates one. The journalist signs the bundle with their
+/// long-term `sk_J^sig`.
+pub fn journalist_ephemeral_setup(
+    _seed_apke_dh: [u8; 32],
+    _seed_apke_mlkem: [u8; 64],
+    _seed_pke: [u8; 32],
+    _j_long: &JournalistLongTerm,
+) -> JournalistEphemeral {
+    unimplemented!()
+}
+
+/// §Step 4 (lines 256-262): Source key setup from passphrase.
+///
+/// `mk ← PBKDF(passphrase)`, then four domain-separated `KDF(mk, label)`
+/// derivations for fetch, APKE-DH, APKE-MLKEM, and PKE.
+///
+/// Note: the doc's `KDF` returns 32 bytes; ML-KEM-768 keygen requires 64
+/// bytes. This spec resolves the gap by calling `KDF` twice with
+/// distinguished labels and concatenating, but the doc itself is silent
+/// on this point and it should be clarified in `protocol.md`.
+pub fn source_setup(_passphrase: &[u8]) -> SourceKeys {
+    unimplemented!()
+}

--- a/securedrop-protocol/protocol-spec/src/setup.rs
+++ b/securedrop-protocol/protocol-spec/src/setup.rs
@@ -2,17 +2,20 @@
 //!
 //! Setup steps that involve a wire exchange (Steps 2 and 3.1) are encoded
 //! as a single function whose return type captures both parties' final
-//! state, with the over-the-wire arrow inlined. This is the standard
-//! single-program functional encoding of a two-party protocol; the
-//! information that actually crosses the wire is visible in the function
-//! signature (which arguments are pre-existing party state vs. fresh
-//! input).
+//! state, with the over-the-wire arrow inlined. The information that
+//! crosses the wire is visible in the function signature: which arguments
+//! are pre-existing party state vs. fresh input.
 
 use crate::keys::*;
+use crate::primitives::*;
+use alloc::vec::Vec;
 
 /// §Step 1 (line 161): FPF signing setup.
-pub fn fpf_setup(_seed: [u8; 32]) -> FpfKeys {
-    unimplemented!()
+///
+/// `(sk_FPF, vk_FPF) ←$ SIG.KGen()`
+pub fn fpf_setup(seed: [u8; 32]) -> FpfKeys {
+    let (sk, vk) = sig_keygen(seed);
+    FpfKeys { sk, vk }
 }
 
 /// §Step 2 (lines 183-188): Newsroom signing setup.
@@ -21,8 +24,10 @@ pub fn fpf_setup(_seed: [u8; 32]) -> FpfKeys {
 /// out-of-band manual verification, treated here as having occurred) signs
 /// `"fpf-sig-nr" || vk_NR`, and the resulting `σ_FPF^NR` is bundled with
 /// the newsroom's keypair.
-pub fn newsroom_setup(_nr_seed: [u8; 32], _fpf: &FpfKeys) -> NewsroomKeys {
-    unimplemented!()
+pub fn newsroom_setup(nr_seed: [u8; 32], fpf: &FpfKeys) -> NewsroomKeys {
+    let (sk, vk) = sig_keygen(nr_seed);
+    let sigma_fpf_on_nr = sig_sign(&fpf.sk, TAG_FPF_SIG_NR, &vk);
+    NewsroomKeys { sk, vk, sigma_fpf_on_nr }
 }
 
 /// §Step 3.1 (lines 214-224): Journalist initial key setup.
@@ -32,13 +37,42 @@ pub fn newsroom_setup(_nr_seed: [u8; 32], _fpf: &FpfKeys) -> NewsroomKeys {
 /// journalist's verification key. The doc's manual-verification step is
 /// implicit in the `nr` argument being passed in.
 pub fn journalist_long_term_setup(
-    _seed_sig: [u8; 32],
-    _seed_apke_dh: [u8; 32],
-    _seed_apke_mlkem: [u8; 64],
-    _seed_fetch: [u8; 32],
-    _nr: &NewsroomKeys,
+    seed_sig: [u8; 32],
+    seed_apke_dh: [u8; 32],
+    seed_apke_mlkem: [u8; 64],
+    seed_fetch: [u8; 32],
+    nr: &NewsroomKeys,
 ) -> JournalistLongTerm {
-    unimplemented!()
+    let (sk_sig, vk_sig) = sig_keygen(seed_sig);
+    let (sk_apke_dh, pk_apke_dh) = akem_keygen(seed_apke_dh);
+    let (sk_apke_pq, pk_apke_pq) = kem_pq_keygen(seed_apke_mlkem);
+    let (sk_fetch_raw, pk_fetch_raw) = r255_keygen(seed_fetch);
+
+    let sk_apke = SdApkeSk { sk1: sk_apke_dh, sk2: sk_apke_pq };
+    let pk_apke = SdApkePk { pk1: pk_apke_dh, pk2: pk_apke_pq };
+    let sk_fetch = FetchSk(sk_fetch_raw);
+    let pk_fetch = FetchPk(pk_fetch_raw);
+
+    // preimage = pk_J^APKE || pk_J^fetch
+    //          = (pk_apke.pk1 || pk_apke.pk2) || pk_fetch
+    let mut preimage = [0u8; AKEM_PK_LEN + KEM_PQ_PK_LEN + R255_POINT_LEN];
+    preimage[..AKEM_PK_LEN].copy_from_slice(&pk_apke.pk1);
+    preimage[AKEM_PK_LEN..AKEM_PK_LEN + KEM_PQ_PK_LEN].copy_from_slice(&pk_apke.pk2);
+    preimage[AKEM_PK_LEN + KEM_PQ_PK_LEN..].copy_from_slice(&pk_fetch.0);
+
+    let sigma_self = sig_sign(&sk_sig, TAG_J_SIG_LTK, &preimage);
+    let sigma_nr_on_j = sig_sign(&nr.sk, TAG_NR_SIG, &vk_sig);
+
+    JournalistLongTerm {
+        sk_sig,
+        vk_sig,
+        sk_apke,
+        pk_apke,
+        sk_fetch,
+        pk_fetch,
+        sigma_self,
+        sigma_nr_on_j,
+    }
 }
 
 /// §Step 3.2 (lines 239-244): one ephemeral key bundle.
@@ -47,23 +81,69 @@ pub fn journalist_long_term_setup(
 /// function generates one. The journalist signs the bundle with their
 /// long-term `sk_J^sig`.
 pub fn journalist_ephemeral_setup(
-    _seed_apke_dh: [u8; 32],
-    _seed_apke_mlkem: [u8; 64],
-    _seed_pke: [u8; 32],
-    _j_long: &JournalistLongTerm,
+    seed_apke_dh: [u8; 32],
+    seed_apke_mlkem: [u8; 64],
+    seed_pke: [u8; 32],
+    j_long: &JournalistLongTerm,
 ) -> JournalistEphemeral {
-    unimplemented!()
+    let (sk_apke_dh, pk_apke_dh) = akem_keygen(seed_apke_dh);
+    let (sk_apke_pq, pk_apke_pq) = kem_pq_keygen(seed_apke_mlkem);
+    let (sk_pke_raw, pk_pke_raw) = xwing_keygen(seed_pke);
+
+    let sk_apke_e = SdApkeSk { sk1: sk_apke_dh, sk2: sk_apke_pq };
+    let pk_apke_e = SdApkePk { pk1: pk_apke_dh, pk2: pk_apke_pq };
+    let sk_pke_e = SdPkeSk(sk_pke_raw);
+    let pk_pke_e = SdPkePk(pk_pke_raw);
+
+    // preimage = pk_{J,i}^APKE_E || pk_{J,i}^PKE_E
+    let mut preimage = [0u8; AKEM_PK_LEN + KEM_PQ_PK_LEN + XWING_PK_LEN];
+    preimage[..AKEM_PK_LEN].copy_from_slice(&pk_apke_e.pk1);
+    preimage[AKEM_PK_LEN..AKEM_PK_LEN + KEM_PQ_PK_LEN].copy_from_slice(&pk_apke_e.pk2);
+    preimage[AKEM_PK_LEN + KEM_PQ_PK_LEN..].copy_from_slice(&pk_pke_e.0);
+
+    let sigma_eph = sig_sign(&j_long.sk_sig, TAG_J_SIG_EPH, &preimage);
+
+    JournalistEphemeral {
+        sk_apke_e,
+        pk_apke_e,
+        sk_pke_e,
+        pk_pke_e,
+        sigma_eph,
+    }
 }
 
 /// §Step 4 (lines 256-262): Source key setup from passphrase.
 ///
-/// `mk ← PBKDF(passphrase)`, then four domain-separated `KDF(mk, label)`
-/// derivations for fetch, APKE-DH, APKE-MLKEM, and PKE.
+/// `mk ← PBKDF(passphrase)`, then four domain-separated derivations:
+/// fetch (32-byte), APKE-DH (32-byte), APKE-MLKEM (64-byte via
+/// `kdf_64`), and PKE (32-byte).
 ///
-/// Note: the doc's `KDF` returns 32 bytes; ML-KEM-768 keygen requires 64
-/// bytes. This spec resolves the gap by calling `KDF` twice with
-/// distinguished labels and concatenating, but the doc itself is silent
-/// on this point and it should be clarified in `protocol.md`.
-pub fn source_setup(_passphrase: &[u8]) -> SourceKeys {
-    unimplemented!()
+/// Note: the doc's `KDF` notation is silent on output length. The impl
+/// uses Blake2b-64 for the ML-KEM seed, so the spec exposes `kdf_64` as
+/// a distinct primitive. This should be clarified in `protocol.md`.
+pub fn source_setup(passphrase: &[u8]) -> SourceKeys {
+    let mk = pbkdf(passphrase);
+
+    let fetch_seed = kdf(&mk, KDF_SOURCE_FETCH);
+    let apke_dh_seed = kdf(&mk, KDF_SOURCE_APKE_DH);
+    let apke_mlkem_seed = kdf_64(&mk, KDF_SOURCE_APKE_MLKEM);
+    let pke_seed = kdf(&mk, KDF_SOURCE_PKE);
+
+    let (sk_fetch_raw, pk_fetch_raw) = r255_keygen(fetch_seed);
+    let (sk_apke_dh, pk_apke_dh) = akem_keygen(apke_dh_seed);
+    let (sk_apke_pq, pk_apke_pq) = kem_pq_keygen(apke_mlkem_seed);
+    let (sk_pke_raw, pk_pke_raw) = xwing_keygen(pke_seed);
+
+    let mut passphrase_vec = Vec::new();
+    passphrase_vec.extend_from_slice(passphrase);
+
+    SourceKeys {
+        sk_apke: SdApkeSk { sk1: sk_apke_dh, sk2: sk_apke_pq },
+        pk_apke: SdApkePk { pk1: pk_apke_dh, pk2: pk_apke_pq },
+        sk_pke: SdPkeSk(sk_pke_raw),
+        pk_pke: SdPkePk(pk_pke_raw),
+        sk_fetch: FetchSk(sk_fetch_raw),
+        pk_fetch: FetchPk(pk_fetch_raw),
+        passphrase: passphrase_vec,
+    }
 }

--- a/securedrop-protocol/protocol-spec/src/wire.rs
+++ b/securedrop-protocol/protocol-spec/src/wire.rs
@@ -7,6 +7,7 @@
 use crate::keys::{FetchPk, SdApkePk, SdPkePk};
 use crate::messaging::Envelope;
 use crate::primitives::*;
+use crate::sd_apke::SdApkeCt;
 use alloc::vec::Vec;
 
 // ===========================================================================
@@ -21,18 +22,52 @@ pub const FIXED_MSG_LEN: usize = 1024;
 /// `32 + 1216 + FIXED_MSG_LEN` per line 628.
 pub const SD_APKE_PT_LEN: usize = R255_POINT_LEN + XWING_PK_LEN + FIXED_MSG_LEN;
 
+/// Encode `pt = SENDER_FETCH || SENDER_PKE || msg`, zero-padded to
+/// `SD_APKE_PT_LEN`. Truncates `msg` if it would exceed `FIXED_MSG_LEN`.
+///
+/// Note: the doc does not specify a padding scheme. This spec uses
+/// trailing-zero padding; the lossless recovery of the original message
+/// length is a known gap (see `decode_apke_plaintext`).
 pub fn encode_apke_plaintext(
-    _sender_fetch: &FetchPk,
-    _sender_pke: &SdPkePk,
-    _msg: &[u8],
+    sender_fetch: &FetchPk,
+    sender_pke: &SdPkePk,
+    msg: &[u8],
 ) -> [u8; SD_APKE_PT_LEN] {
-    unimplemented!()
+    let mut out = [0u8; SD_APKE_PT_LEN];
+    out[..R255_POINT_LEN].copy_from_slice(&sender_fetch.0);
+    out[R255_POINT_LEN..R255_POINT_LEN + XWING_PK_LEN].copy_from_slice(&sender_pke.0);
+
+    let msg_offset = R255_POINT_LEN + XWING_PK_LEN;
+    let msg_len = if msg.len() > FIXED_MSG_LEN {
+        FIXED_MSG_LEN
+    } else {
+        msg.len()
+    };
+    out[msg_offset..msg_offset + msg_len].copy_from_slice(&msg[..msg_len]);
+
+    out
 }
 
+/// Decode an SD-APKE plaintext.
+///
+/// The returned `Vec<u8>` is the full padded message slot
+/// (`FIXED_MSG_LEN` bytes). The caller is responsible for stripping
+/// padding; this spec does not encode message length, matching the
+/// doc's silence on padding scheme.
 pub fn decode_apke_plaintext(
-    _bytes: &[u8; SD_APKE_PT_LEN],
+    bytes: &[u8; SD_APKE_PT_LEN],
 ) -> (FetchPk, SdPkePk, Vec<u8>) {
-    unimplemented!()
+    let mut fetch_bytes = [0u8; R255_POINT_LEN];
+    fetch_bytes.copy_from_slice(&bytes[..R255_POINT_LEN]);
+
+    let mut pke_bytes = [0u8; XWING_PK_LEN];
+    pke_bytes.copy_from_slice(&bytes[R255_POINT_LEN..R255_POINT_LEN + XWING_PK_LEN]);
+
+    let msg_offset = R255_POINT_LEN + XWING_PK_LEN;
+    let mut msg = Vec::new();
+    msg.extend_from_slice(&bytes[msg_offset..]);
+
+    (FetchPk(fetch_bytes), SdPkePk(pke_bytes), msg)
 }
 
 // ===========================================================================
@@ -43,12 +78,19 @@ pub fn decode_apke_plaintext(
 /// `32 + 1184` per line 638.
 pub const SD_PKE_PT_LEN: usize = AKEM_PK_LEN + KEM_PQ_PK_LEN;
 
-pub fn encode_pke_plaintext(_sender_apke_pk: &SdApkePk) -> [u8; SD_PKE_PT_LEN] {
-    unimplemented!()
+pub fn encode_pke_plaintext(sender_apke_pk: &SdApkePk) -> [u8; SD_PKE_PT_LEN] {
+    let mut out = [0u8; SD_PKE_PT_LEN];
+    out[..AKEM_PK_LEN].copy_from_slice(&sender_apke_pk.pk1);
+    out[AKEM_PK_LEN..].copy_from_slice(&sender_apke_pk.pk2);
+    out
 }
 
-pub fn decode_pke_plaintext(_bytes: &[u8; SD_PKE_PT_LEN]) -> SdApkePk {
-    unimplemented!()
+pub fn decode_pke_plaintext(bytes: &[u8; SD_PKE_PT_LEN]) -> SdApkePk {
+    let mut pk1 = [0u8; AKEM_PK_LEN];
+    pk1.copy_from_slice(&bytes[..AKEM_PK_LEN]);
+    let mut pk2 = [0u8; KEM_PQ_PK_LEN];
+    pk2.copy_from_slice(&bytes[AKEM_PK_LEN..]);
+    SdApkePk { pk1, pk2 }
 }
 
 // ===========================================================================
@@ -64,14 +106,93 @@ pub const CT_APKE_LEN: usize =
 pub const CT_PKE_LEN: usize =
     XWING_ENC_LEN + AKEM_PK_LEN + KEM_PQ_PK_LEN + AEAD_TAG_LEN;
 
+/// CT_SD_APKE: the AEAD ciphertext portion of CT_APKE
+/// (excluding the two encapsulations).
+pub const CT_SD_APKE_LEN: usize = FIXED_MSG_LEN + AEAD_TAG_LEN;
+
+/// CT_SD_PKE: the AEAD ciphertext portion of CT_PKE
+/// (excluding the X-Wing encapsulation).
+pub const CT_SD_PKE_LEN: usize = AKEM_PK_LEN + KEM_PQ_PK_LEN + AEAD_TAG_LEN;
+
 /// Total envelope length per line 662.
 pub const ENVELOPE_LEN: usize =
     R255_POINT_LEN + R255_POINT_LEN + CT_APKE_LEN + CT_PKE_LEN;
 
-pub fn encode_envelope(_e: &Envelope) -> [u8; ENVELOPE_LEN] {
-    unimplemented!()
+pub fn encode_envelope(e: &Envelope) -> [u8; ENVELOPE_LEN] {
+    let mut out = [0u8; ENVELOPE_LEN];
+    let mut offset = 0;
+
+    // X
+    out[offset..offset + R255_POINT_LEN].copy_from_slice(&e.hint_x);
+    offset += R255_POINT_LEN;
+
+    // Z
+    out[offset..offset + R255_POINT_LEN].copy_from_slice(&e.hint_z);
+    offset += R255_POINT_LEN;
+
+    // CT_APKE = c2 (ML-KEM) || c1 (DH-AKEM) || cp (AEAD ct)
+    out[offset..offset + KEM_PQ_CT_LEN].copy_from_slice(&e.ct_apke.c2);
+    offset += KEM_PQ_CT_LEN;
+    out[offset..offset + AKEM_ENC_LEN].copy_from_slice(&e.ct_apke.c1);
+    offset += AKEM_ENC_LEN;
+    let cp_copy = if e.ct_apke.cp.len() > CT_SD_APKE_LEN {
+        CT_SD_APKE_LEN
+    } else {
+        e.ct_apke.cp.len()
+    };
+    out[offset..offset + cp_copy].copy_from_slice(&e.ct_apke.cp[..cp_copy]);
+    offset += CT_SD_APKE_LEN;
+
+    // CT_PKE = pke_c (X-Wing encaps) || pke_cp (AEAD ct)
+    let (pke_c, pke_cp) = &e.ct_pke;
+    out[offset..offset + XWING_ENC_LEN].copy_from_slice(pke_c);
+    offset += XWING_ENC_LEN;
+    let pke_cp_copy = if pke_cp.len() > CT_SD_PKE_LEN {
+        CT_SD_PKE_LEN
+    } else {
+        pke_cp.len()
+    };
+    out[offset..offset + pke_cp_copy].copy_from_slice(&pke_cp[..pke_cp_copy]);
+
+    out
 }
 
-pub fn decode_envelope(_bytes: &[u8; ENVELOPE_LEN]) -> Option<Envelope> {
-    unimplemented!()
+pub fn decode_envelope(bytes: &[u8; ENVELOPE_LEN]) -> Option<Envelope> {
+    let mut offset = 0;
+
+    let mut hint_x = [0u8; R255_POINT_LEN];
+    hint_x.copy_from_slice(&bytes[offset..offset + R255_POINT_LEN]);
+    offset += R255_POINT_LEN;
+
+    let mut hint_z = [0u8; R255_POINT_LEN];
+    hint_z.copy_from_slice(&bytes[offset..offset + R255_POINT_LEN]);
+    offset += R255_POINT_LEN;
+
+    // CT_APKE
+    let mut c2 = [0u8; KEM_PQ_CT_LEN];
+    c2.copy_from_slice(&bytes[offset..offset + KEM_PQ_CT_LEN]);
+    offset += KEM_PQ_CT_LEN;
+
+    let mut c1 = [0u8; AKEM_ENC_LEN];
+    c1.copy_from_slice(&bytes[offset..offset + AKEM_ENC_LEN]);
+    offset += AKEM_ENC_LEN;
+
+    let mut cp = Vec::new();
+    cp.extend_from_slice(&bytes[offset..offset + CT_SD_APKE_LEN]);
+    offset += CT_SD_APKE_LEN;
+
+    // CT_PKE
+    let mut pke_c = [0u8; XWING_ENC_LEN];
+    pke_c.copy_from_slice(&bytes[offset..offset + XWING_ENC_LEN]);
+    offset += XWING_ENC_LEN;
+
+    let mut pke_cp = Vec::new();
+    pke_cp.extend_from_slice(&bytes[offset..offset + CT_SD_PKE_LEN]);
+
+    Some(Envelope {
+        ct_apke: SdApkeCt { c1, cp, c2 },
+        ct_pke: (pke_c, pke_cp),
+        hint_x,
+        hint_z,
+    })
 }

--- a/securedrop-protocol/protocol-spec/src/wire.rs
+++ b/securedrop-protocol/protocol-spec/src/wire.rs
@@ -1,0 +1,77 @@
+//! §Message Formats (lines 616-678): byte-level encodings.
+//!
+//! These functions are total: encoding produces a fixed-length array,
+//! decoding takes a fixed-length array and produces the structured form.
+//! Lengths and layouts come directly from the doc.
+
+use crate::keys::{FetchPk, SdApkePk, SdPkePk};
+use crate::messaging::Envelope;
+use crate::primitives::*;
+use alloc::vec::Vec;
+
+// ===========================================================================
+// §SD-APKE Plaintext (line 626):
+// SENDER_FETCH_PUBKEY || SENDER_PKE_PUBKEY || message || padding
+// ===========================================================================
+
+/// Padded message length. The doc requires fixed-size message padding
+/// before encryption (line 630); the exact value is a deployment choice.
+pub const FIXED_MSG_LEN: usize = 1024;
+
+/// `32 + 1216 + FIXED_MSG_LEN` per line 628.
+pub const SD_APKE_PT_LEN: usize = R255_POINT_LEN + XWING_PK_LEN + FIXED_MSG_LEN;
+
+pub fn encode_apke_plaintext(
+    _sender_fetch: &FetchPk,
+    _sender_pke: &SdPkePk,
+    _msg: &[u8],
+) -> [u8; SD_APKE_PT_LEN] {
+    unimplemented!()
+}
+
+pub fn decode_apke_plaintext(
+    _bytes: &[u8; SD_APKE_PT_LEN],
+) -> (FetchPk, SdPkePk, Vec<u8>) {
+    unimplemented!()
+}
+
+// ===========================================================================
+// §SD-PKE Plaintext (line 636):
+// SENDER_LONG_TERM_SD_APKE_DHAKEM_PUBKEY || SENDER_LONG_TERM_SD_APKE_MLKEM768_PUBKEY
+// ===========================================================================
+
+/// `32 + 1184` per line 638.
+pub const SD_PKE_PT_LEN: usize = AKEM_PK_LEN + KEM_PQ_PK_LEN;
+
+pub fn encode_pke_plaintext(_sender_apke_pk: &SdApkePk) -> [u8; SD_PKE_PT_LEN] {
+    unimplemented!()
+}
+
+pub fn decode_pke_plaintext(_bytes: &[u8; SD_PKE_PT_LEN]) -> SdApkePk {
+    unimplemented!()
+}
+
+// ===========================================================================
+// §Encrypted Envelope (line 660):
+// X || Z || CT_APKE || CT_PKE
+// ===========================================================================
+
+/// CT_APKE per line 644: `MLKEM768_CT || DHAKEM_ENCAPS || CT_SD_APKE`.
+pub const CT_APKE_LEN: usize =
+    KEM_PQ_CT_LEN + AKEM_ENC_LEN + (FIXED_MSG_LEN + AEAD_TAG_LEN);
+
+/// CT_PKE per line 654: `XWING_SS_ENCAPS_CT || (DHAKEM_PK + MLKEM768_PK + AEAD_TAG_LEN)`.
+pub const CT_PKE_LEN: usize =
+    XWING_ENC_LEN + AKEM_PK_LEN + KEM_PQ_PK_LEN + AEAD_TAG_LEN;
+
+/// Total envelope length per line 662.
+pub const ENVELOPE_LEN: usize =
+    R255_POINT_LEN + R255_POINT_LEN + CT_APKE_LEN + CT_PKE_LEN;
+
+pub fn encode_envelope(_e: &Envelope) -> [u8; ENVELOPE_LEN] {
+    unimplemented!()
+}
+
+pub fn decode_envelope(_bytes: &[u8; ENVELOPE_LEN]) -> Option<Envelope> {
+    unimplemented!()
+}


### PR DESCRIPTION
On top of #250's closer examination of a smaller-scoped example:
1. 7d2017728c430a6980153934a1cb789f14856066 shows the skeleton translation of `docs/protocol.md` to hacspec: just types and signatures.
2. ca4322b23350766fcb7ee5c2c97cb950ef76d2e3 fleshes it out at the same level of detail as the specification itself.

This does *not* include the beginnings of any F* refinement proofs, but the possibilities and limitations outlined in #250 apply generally here.


(Like previous pull requests tagged `proof of concept`, this is opened for discussion and expected to be closed, not merged.)