### PR TITLE
ci: enable Dependabot updates for the `securedrop-protocol` Cargo workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/securedrop-protocol"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Towards freedomofpress/infrastructure#6757.  This is just the defaults from <https://github.com/freedomofpress/securedrop-client/blob/0b4341d47cc575d57857b3cbdecbd39e64e552a4/.github/dependabot.yml> with `package-ecosystem: cargo`.