### PR TITLE
Refactor keybundle for hax compatibility

### DIFF
--- a/securedrop-protocol/protocol-minimal/src/api.rs
+++ b/securedrop-protocol/protocol-minimal/src/api.rs
@@ -15,8 +15,7 @@
 //! 4. Each journalist's key bundles are self-signed.
 
 use crate::{
-    Enrollable, Envelope, FetchResponse, JournalistPublic, SignedKeyBundlePublic, UserPublic,
-    UserSecret, VerifyingKey,
+    Enrollable, Envelope, FetchResponse, JournalistPublic, UserPublic, UserSecret, VerifyingKey,
     encrypt_decrypt::{encrypt, solve_fetch_challenges},
     wire::{
         core::{
@@ -226,11 +225,9 @@ pub trait JournalistApi: Api + restricted::RestrictedApi {
     where
         Self: Enrollable,
     {
-        let bundles: Vec<SignedKeyBundlePublic> = self.signed_keybundles().collect();
-
         JournalistEphemeralKeyRequest {
             verifying_key: self.signing_key().clone(),
-            bundles,
+            bundles: self.signed_keybundles(),
         }
     }
 }

--- a/securedrop-protocol/protocol-minimal/src/api.rs
+++ b/securedrop-protocol/protocol-minimal/src/api.rs
@@ -16,6 +16,7 @@
 
 use crate::{
     Enrollable, Envelope, FetchResponse, JournalistPublic, UserPublic, UserSecret, VerifyingKey,
+    api::restricted::RestrictedApi,
     encrypt_decrypt::{encrypt, solve_fetch_challenges},
     wire::{
         core::{
@@ -194,12 +195,35 @@ pub(crate) mod restricted {
     pub trait RestrictedApi {}
 }
 
+/// Provide generic implementation, restricted to implementors of the sealed
+/// [`RestrictedApi`](restricted::RestrictedApi) trait and the Enrollable trait.
+/// Implementors of both those will automatically be able to use this generic
+/// JournalistApi implementation, but downstream crates will be unable to implement
+/// restrictedApi. Originally this was defined at the trait level
+/// (`pub trait JournalistApi: Api + restricted::RestrictedApi`), but hax was unable
+/// to extract the trait.
+impl<T> JournalistApi for T
+where
+    T: Api + Enrollable + restricted::RestrictedApi,
+{
+    fn create_setup_request(&self) -> Result<JournalistSetupRequest, Error> {
+        Ok(JournalistSetupRequest {
+            enrollment: self.enroll(),
+        })
+    }
+
+    fn create_ephemeral_key_request(&self) -> JournalistEphemeralKeyRequest {
+        JournalistEphemeralKeyRequest {
+            verifying_key: self.signing_key().clone(),
+            bundles: self.signed_keybundles(),
+        }
+    }
+}
+
 /// Journalist-specific API operations.
 ///
-/// Extends [`Api`] with enrollment and ephemeral key management. Only types
-/// that implement the sealed [`RestrictedApi`](restricted::RestrictedApi) trait
-/// can implement this, preventing misuse by downstream code.
-pub trait JournalistApi: Api + restricted::RestrictedApi {
+/// Extends [`Api`] with enrollment and ephemeral key management.
+pub trait JournalistApi {
     /// Creates an enrollment request for initial journalist onboarding.
     ///
     /// Packages the journalist's self-signed long-term key bundle into a
@@ -208,26 +232,11 @@ pub trait JournalistApi: Api + restricted::RestrictedApi {
     /// # Errors
     ///
     /// Returns an error if enrollment data cannot be constructed.
-    fn create_setup_request(&self) -> Result<JournalistSetupRequest, Error>
-    where
-        Self: Enrollable,
-    {
-        Ok(JournalistSetupRequest {
-            enrollment: self.enroll(),
-        })
-    }
+    fn create_setup_request(&self) -> Result<JournalistSetupRequest, Error>;
 
     /// Creates a request to replenish ephemeral key bundles on the server.
     ///
     /// Collects all current signed key bundles and packages them into a
     /// [`JournalistEphemeralKeyRequest`] for upload to the server (step 3.2).
-    fn create_ephemeral_key_request(&self) -> JournalistEphemeralKeyRequest
-    where
-        Self: Enrollable,
-    {
-        JournalistEphemeralKeyRequest {
-            verifying_key: self.signing_key().clone(),
-            bundles: self.signed_keybundles(),
-        }
-    }
+    fn create_ephemeral_key_request(&self) -> JournalistEphemeralKeyRequest;
 }

--- a/securedrop-protocol/protocol-minimal/src/journalist.rs
+++ b/securedrop-protocol/protocol-minimal/src/journalist.rs
@@ -146,8 +146,11 @@ impl UserSecret for Journalist {
         }
     }
 
-    fn keybundles(&self) -> impl Iterator<Item = &MessageKeyBundle> {
-        self.message_keys.iter().map(|signed| &signed.bundle)
+    fn keybundles(&self) -> Vec<&MessageKeyBundle> {
+        self.message_keys
+            .iter()
+            .map(|signed| &signed.bundle)
+            .collect()
     }
 }
 
@@ -164,10 +167,15 @@ impl Enrollable for Journalist {
         }
     }
 
-    fn signed_keybundles(&self) -> impl Iterator<Item = SignedKeyBundlePublic> {
+    fn signed_keybundles(&self) -> Vec<SignedKeyBundlePublic> {
+        fn extract_public_bundle(signed: &SignedMessageKeyBundle) -> SignedKeyBundlePublic {
+            (signed.bundle.public(), signed.selfsig)
+        }
+
         self.message_keys
             .iter()
-            .map(|k| (k.bundle.public(), k.selfsig))
+            .map(extract_public_bundle)
+            .collect()
     }
 
     fn signing_key(&self) -> &VerifyingKey {
@@ -257,7 +265,7 @@ mod tests {
 
         let journalist = Journalist::new(&mut rng, 5);
         assert_eq!(journalist.message_keys.len(), 5);
-        let skb: Vec<SignedKeyBundlePublic> = journalist.signed_keybundles().collect();
+        let skb: Vec<SignedKeyBundlePublic> = journalist.signed_keybundles();
         assert_eq!(journalist.message_keys.len(), skb.len());
 
         let kbs: Vec<&MessageKeyBundle> = journalist.keybundles().collect();

--- a/securedrop-protocol/protocol-minimal/src/journalist.rs
+++ b/securedrop-protocol/protocol-minimal/src/journalist.rs
@@ -113,8 +113,6 @@ impl Api for Journalist {
 }
 
 impl restricted::RestrictedApi for Journalist {}
-impl JournalistApi for Journalist {}
-
 impl private::Sealed for Journalist {}
 /// Private, common to all users, implemented for Journalists
 impl UserSecret for Journalist {
@@ -268,7 +266,7 @@ mod tests {
         let skb: Vec<SignedKeyBundlePublic> = journalist.signed_keybundles();
         assert_eq!(journalist.message_keys.len(), skb.len());
 
-        let kbs: Vec<&MessageKeyBundle> = journalist.keybundles().collect();
+        let kbs: Vec<&MessageKeyBundle> = journalist.keybundles();
         assert_eq!(kbs.len(), journalist.message_keys.len());
 
         for i in 0..kbs.len() {

--- a/securedrop-protocol/protocol-minimal/src/lib.rs
+++ b/securedrop-protocol/protocol-minimal/src/lib.rs
@@ -1,11 +1,10 @@
 #![no_std]
 // Deny direct access to system randomness except in tests.
 // See clippy.toml
-#![deny(clippy::disallowed_types)]
-#![deny(clippy::disallowed_methods)]
-#![cfg_attr(test, allow(clippy::disallowed_types))]
-#![cfg_attr(test, allow(clippy::disallowed_methods))]
-
+// hax breaks on these clippy statements
+#![cfg_attr(not(hax), deny(clippy::disallowed_types, clippy::disallowed_methods))]
+#![cfg_attr(all(not(hax), test), allow(clippy::disallowed_types))]
+#![cfg_attr(all(not(hax), test), allow(clippy::disallowed_methods))]
 extern crate alloc;
 
 pub mod api;

--- a/securedrop-protocol/protocol-minimal/src/source.rs
+++ b/securedrop-protocol/protocol-minimal/src/source.rs
@@ -110,8 +110,8 @@ impl UserSecret for Source {
         }
     }
 
-    fn keybundles(&self) -> impl Iterator<Item = &MessageKeyBundle> {
-        core::iter::once(&self.message_keys)
+    fn keybundles(&self) -> Vec<&MessageKeyBundle> {
+        alloc::vec![&self.message_keys]
     }
 }
 

--- a/securedrop-protocol/protocol-minimal/src/traits.rs
+++ b/securedrop-protocol/protocol-minimal/src/traits.rs
@@ -48,11 +48,9 @@ pub trait JournalistPublic: UserPublic {
 pub trait Enrollable: private::Sealed {
     fn signing_key(&self) -> &VerifyingKey;
     fn enroll(&self) -> Enrollment;
-    /// Returns an iterator over all signed ephemeral key bundles held by this journalist.
-    ///
     /// Each item is a [`SignedKeyBundlePublic`]: the public keys together with the
     /// journalist's self-signature over them.
-    fn signed_keybundles(&self) -> impl Iterator<Item = SignedKeyBundlePublic>;
+    fn signed_keybundles(&self) -> Vec<SignedKeyBundlePublic>;
 }
 
 /// Users have the following (secret traits) in common:
@@ -69,5 +67,5 @@ pub trait UserSecret: private::Sealed {
     /// The long-term SD-APKE public key `pk^APKE`.
     fn message_auth_pk(&self) -> &MessagePublicKey;
     fn build_message(&self, message: Vec<u8>) -> Plaintext;
-    fn keybundles(&self) -> impl Iterator<Item = &MessageKeyBundle>;
+    fn keybundles(&self) -> Vec<&MessageKeyBundle>;
 }


### PR DESCRIPTION
Towards #169 

- Improve keybundles type
- avoid relying on default trait impl for journalists: See https://github.com/cryspen/hax/issues/888  (followup PR to address further instances of this)
- fixup: clippy + hax don't play well together 
