### PR TITLE
refactor `Sealed` trait implementation

### DIFF
--- a/securedrop-protocol/protocol-minimal/src/api.rs
+++ b/securedrop-protocol/protocol-minimal/src/api.rs
@@ -16,8 +16,8 @@
 
 use crate::{
     Enrollable, Envelope, FetchResponse, JournalistPublic, UserPublic, UserSecret, VerifyingKey,
-    api::restricted::RestrictedApi,
     encrypt_decrypt::{encrypt, solve_fetch_challenges},
+    traits::RestrictedApi,
     wire::{
         core::{
             MessageChallengeFetchRequest, MessageFetchRequest, SourceJournalistKeyRequest,
@@ -187,24 +187,15 @@ pub trait Api {
     }
 }
 
-/// Restricts [`JournalistApi`] to types explicitly opted in by the crate.
-///
-/// This uses the [sealed trait pattern](https://rust-lang.github.io/api-guidelines/future-proofing.html#c-sealed)
-/// to prevent downstream crates from implementing [`JournalistApi`].
-pub(crate) mod restricted {
-    pub trait RestrictedApi {}
-}
-
-/// Provide generic implementation, restricted to implementors of the sealed
-/// [`RestrictedApi`](restricted::RestrictedApi) trait and the Enrollable trait.
-/// Implementors of both those will automatically be able to use this generic
-/// JournalistApi implementation, but downstream crates will be unable to implement
-/// restrictedApi. Originally this was defined at the trait level
+/// Provide generic implementation, restricted to implementors RestrictedApi trait and
+/// the Enrollable trait. Implementors of both those will automatically be able to use
+/// this generic JournalistApi implementation, but downstream crates will be unable to
+/// implement RestrictedApi. Originally this was defined at the trait level
 /// (`pub trait JournalistApi: Api + restricted::RestrictedApi`), but hax was unable
 /// to extract the trait.
 impl<T> JournalistApi for T
 where
-    T: Api + Enrollable + restricted::RestrictedApi,
+    T: Api + Enrollable + RestrictedApi,
 {
     fn create_setup_request(&self) -> Result<JournalistSetupRequest, Error> {
         Ok(JournalistSetupRequest {

--- a/securedrop-protocol/protocol-minimal/src/journalist.rs
+++ b/securedrop-protocol/protocol-minimal/src/journalist.rs
@@ -1,7 +1,5 @@
 use crate::VerifyingKey;
 use crate::api::Api;
-use crate::api::JournalistApi;
-use crate::api::restricted;
 use crate::message::{MessageKeyPair, MessagePublicKey, keygen as message_keygen};
 use crate::metadata::{MetadataPublicKey, keygen as metadata_keygen};
 use crate::primitives::x25519::DHPrivateKey;
@@ -14,8 +12,12 @@ use rand_core::{CryptoRng, RngCore};
 use crate::ciphertext::Plaintext;
 use crate::constants::*;
 use crate::keys::*;
-use crate::traits::private;
-use crate::traits::{Enrollable, JournalistPublic, UserPublic, UserSecret};
+use crate::traits::{Enrollable, JournalistPublic, RestrictedApi, UserPublic, UserSecret};
+
+// caution: do not re-export!
+use crate::sealed;
+impl sealed::Sealed for Journalist {}
+impl RestrictedApi for Journalist {}
 
 /// Journalists: ingredients.
 /// Journalists have a signing/verifying key, a reply key,
@@ -112,8 +114,6 @@ impl Api for Journalist {
     }
 }
 
-impl restricted::RestrictedApi for Journalist {}
-impl private::Sealed for Journalist {}
 /// Private, common to all users, implemented for Journalists
 impl UserSecret for Journalist {
     fn num_bundles(&self) -> usize {

--- a/securedrop-protocol/protocol-minimal/src/lib.rs
+++ b/securedrop-protocol/protocol-minimal/src/lib.rs
@@ -35,7 +35,6 @@ pub use journalist::{Journalist, JournalistPublicView};
 pub use source::{Source, SourcePublicView};
 
 pub(crate) use keys::MessageKeyBundle;
-pub(crate) use traits::private;
 
 // Primitives for signing
 pub mod sign;
@@ -49,3 +48,8 @@ pub mod storage;
 pub mod encrypt_decrypt;
 pub mod message;
 pub mod metadata;
+
+// Do not make this module public or re-export it anywhere!
+/// It uses the [sealed trait pattern](https://rust-lang.github.io/api-guidelines/future-proofing.html#c-sealed)
+/// to gate features that downstream crates should not implement.
+mod sealed;

--- a/securedrop-protocol/protocol-minimal/src/sealed.rs
+++ b/securedrop-protocol/protocol-minimal/src/sealed.rs
@@ -1,0 +1,9 @@
+/// Use [sealed trait pattern](https://rust-lang.github.io/api-guidelines/future-proofing.html#c-sealed)
+/// to gate features that downstream crates should not implement.
+/// This module should never be exposed publicly or re-exported (i.e., no `pub use::sealed::*`)!
+/// To use, define a public trait (eg in traits.rs):
+/// ``` use crate::sealed; ```
+/// ``` pub trait RestrictedTrait: sealed::Sealed {}` ```
+/// The `Sealed` trait is public as long as UserSecret, RestrictedApi, etc are public;
+/// if those ever become pub(crate) then this trait can be restricted as well.
+pub trait Sealed {}

--- a/securedrop-protocol/protocol-minimal/src/source.rs
+++ b/securedrop-protocol/protocol-minimal/src/source.rs
@@ -12,8 +12,11 @@ use rand_core::{CryptoRng, RngCore};
 use crate::ciphertext::Plaintext;
 use crate::constants::*;
 use crate::keys::*;
-use crate::traits::private;
 use crate::traits::{UserPublic, UserSecret};
+
+// do not re-export!
+use crate::sealed;
+impl sealed::Sealed for Source {}
 
 /// Fixed public salt for Argon2id. Argon2id requires a salt; since source
 /// keys must be deterministic from the passphrase alone, we use a fixed
@@ -75,8 +78,6 @@ impl Api for Source {
         self.session.nr_key = Some(key);
     }
 }
-
-impl private::Sealed for Source {}
 
 /// Private, common to all users, implemented for sources
 impl UserSecret for Source {

--- a/securedrop-protocol/protocol-minimal/src/traits.rs
+++ b/securedrop-protocol/protocol-minimal/src/traits.rs
@@ -11,11 +11,9 @@ use crate::keys::{
     Enrollment, KeyBundlePublic, MessageKeyBundle, SignedKeyBundlePublic, SignedLongtermPubKeyBytes,
 };
 
-// Seal Secret user traits behind a private module so that others can't access or implement them
-// This could be more restricted than pub(crate), except we also use it for testing
-pub(crate) mod private {
-    pub trait Sealed {}
-}
+// Sealed traits that downstream crates should not implement.
+// Do not re-export!
+use crate::sealed;
 
 ////////////////////////
 ///
@@ -45,7 +43,7 @@ pub trait JournalistPublic: UserPublic {
     fn ephemeral_signature(&self) -> &Signature<JournalistEphemeralKey>;
 }
 
-pub trait Enrollable: private::Sealed {
+pub trait Enrollable: sealed::Sealed {
     fn signing_key(&self) -> &VerifyingKey;
     fn enroll(&self) -> Enrollment;
     /// Each item is a [`SignedKeyBundlePublic`]: the public keys together with the
@@ -59,7 +57,7 @@ pub trait Enrollable: private::Sealed {
 /// authenticate their messages (via DH-AKEM);
 /// They can index a KeyBundle (tuple) and use it to attempt to
 /// decrypt a message.
-pub trait UserSecret: private::Sealed {
+pub trait UserSecret: sealed::Sealed {
     fn num_bundles(&self) -> usize;
     fn fetch_keypair(&self) -> (&DHPrivateKey, &DHPublicKey);
     /// The long-term SD-APKE private key `sk^APKE`.
@@ -69,3 +67,5 @@ pub trait UserSecret: private::Sealed {
     fn build_message(&self, message: Vec<u8>) -> Plaintext;
     fn keybundles(&self) -> Vec<&MessageKeyBundle>;
 }
+
+pub(crate) trait RestrictedApi: sealed::Sealed {}


### PR DESCRIPTION
~Stacked on https://github.com/freedomofpress/securedrop-protocol/pull/254 , will rebase and change branch when that's merged~ done!

Improve implementation of `sealed` module and trait pattern, add documentation