### PR TITLE
docs: link to Makefiles and documentation for hax extraction

### DIFF
--- a/securedrop-protocol/protocol-minimal/Cargo.toml
+++ b/securedrop-protocol/protocol-minimal/Cargo.toml
@@ -6,9 +6,16 @@ authors = ["SecureDrop Team <securedrop@freedom.press>"]
 description = "A wip impl of the securedrop protocol"
 license = "GPL-3.0"
 
+# hax extraction for this crate is configured in "Makefile", as documented here:
+# https://github.com/freedomofpress/securedrop-protocol/wiki/Verification#how-are-f-modules-extracted-from-protocol-minimal
+
 [lib]
 
 [dependencies]
+# hax extraction for dependencies is configured in "proofs/fstar/models/Makefile", as documented
+# here:
+# https://github.com/freedomofpress/securedrop-protocol/wiki/Verification#how-are-f-interfaces-extracted-from-our-dependencies
+
 # no rand/getrandom in core library!
 # crypto stack, pinned to cryspen/libcrux#1312
 libcrux-ed25519 = { git = "https://github.com/cryspen/libcrux", rev = "c1e75990cbcf1bf476199fb1367df680c6de570f", features = ["rand"] }

--- a/securedrop-protocol/protocol-minimal/Makefile
+++ b/securedrop-protocol/protocol-minimal/Makefile
@@ -1,3 +1,7 @@
+# This Makefile configures hax extraction and verification for the
+# "securedrop_protocol_minimal" crate, as documented here:
+# https://github.com/freedomofpress/securedrop-protocol/wiki/Verification#how-are-f-modules-extracted-from-protocol-minimal
+
 HAX_TARGETS := -**
 HAX_TARGETS += +securedrop_protocol_minimal::primitives::dh_akem::typed
 HAX_TARGETS += +securedrop_protocol_minimal::primitives::mlkem::typed

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/models/Makefile
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/models/Makefile
@@ -1,3 +1,7 @@
+# This Makefile configures hax extraction for dependencies of the
+# "securedrop_protocol_minimal" crate, as documented here:
+# https://github.com/freedomofpress/securedrop-protocol/wiki/Verification#how-are-f-interfaces-extracted-from-our-dependencies
+
 HAX_LIB_VERSION=$(shell make -C ../../.. -s hax-lib-version)
 
 # include pattern modifiers (e.g. `+`, `+!`, `+:`) are documented


### PR DESCRIPTION
Let's make the documentation that's now in the wiki discoverable from where we'll wish for it.