### PR TITLE
Update wasm-bindgen and wasm-bindgen-test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,9 @@ jobs:
           toolchain: stable
       # Swatinem/rust-cache@v2.8.0
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
+        with:
+          # wasm-bindgen-cli version change should invalidate cache too
+          prefix-key: ${{ hashFiles('securedrop-protocol/bench/Makefile') }}
       # dtolnay/rust-toolchain@30dc51db75d080812bc4a28ba3f342840b2e7dd7
       - run: cargo check
         working-directory: securedrop-protocol
@@ -40,6 +43,8 @@ jobs:
           toolchain: stable
       # Swatinem/rust-cache@v2.8.0
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
+        with:
+          prefix-key: ${{ hashFiles('securedrop-protocol/bench/Makefile') }}
       # dtolnay/rust-toolchain@30dc51db75d080812bc4a28ba3f342840b2e7dd7
       - run: cargo test --all-features
         working-directory: securedrop-protocol
@@ -59,6 +64,8 @@ jobs:
           components: rustfmt
       # Swatinem/rust-cache@v2.8.0
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
+        with:
+          prefix-key: ${{ hashFiles('securedrop-protocol/bench/Makefile') }}
       # dtolnay/rust-toolchain@30dc51db75d080812bc4a28ba3f342840b2e7dd7
       - run: cargo fmt --all --check
         working-directory: securedrop-protocol
@@ -121,6 +128,9 @@ jobs:
           targets: wasm32-unknown-unknown
       # Swatinem/rust-cache@v2.8.0
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
+        with:
+          # wasm-bindgen-cli version change should invalidate cache too
+          prefix-key: ${{ hashFiles('securedrop-protocol/bench/Makefile') }}
       # dtolnay/rust-toolchain@30dc51db75d080812bc4a28ba3f342840b2e7dd7
       - name: Cache node and selenium dependencies
         uses: actions/cache@v4

--- a/securedrop-protocol/Cargo.lock
+++ b/securedrop-protocol/Cargo.lock
@@ -220,6 +220,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,10 +417,12 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -773,6 +799,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1237,22 +1275,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1260,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1273,18 +1308,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.56"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e90e66d265d3a1efc0e72a54809ab90b9c0c515915c67cdf658689d2c22c6c"
+checksum = "af5ec93229ad9ccd0a545a516dec76dc276613f278f6a91aa6b463d5b33d42d0"
 dependencies = [
  "async-trait",
  "cast",
@@ -1299,18 +1334,25 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.56"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7150335716dce6028bead2b848e72f47b45e7b9422f64cccdc23bedca89affc1"
+checksum = "3c81b9fef827e575e0e54431736d1baa0d700315d8c62cfef1f61fa3aad0cbeb"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4d8ae7ad5440360e9799dfd42857d126454a88441ddf72d288ef83fa47f527"
 
 [[package]]
 name = "wasm-encoder"
@@ -1344,16 +1386,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/securedrop-protocol/bench/Cargo.toml
+++ b/securedrop-protocol/bench/Cargo.toml
@@ -18,7 +18,9 @@ getrandom = { version = "0.3", default-features = false, features = ["wasm_js"] 
 getrandom04 = { package = "getrandom", version = "0.4", default-features = false, features = ["wasm_js"] }
 
 js-sys = "0.3"
-rand_chacha = { version = "0.9.0", default-features = false }
+# Previously, rand_chacha was pinned to 0.9.0 to resolve incompatibility with older wasm-bindgen.
+# Check rand_chacha version compat if wasm builds or browser tests spuriously fail
+rand_chacha = { version = "0.9", default-features = false }
 rand_core = { version = "0.9.3" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/securedrop-protocol/bench/Cargo.toml
+++ b/securedrop-protocol/bench/Cargo.toml
@@ -27,10 +27,10 @@ hashbrown = { version = "0.14", features = ["raw"] }
 uuid = { version = "1.0", default-features = false, features = ["v4", "rng-getrandom", "js"] }
 
 # Keep in sync with Makefile version
-wasm-bindgen = "0.2.106"
+wasm-bindgen = "0.2.121"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.56"
+wasm-bindgen-test = "0.3.71"
 
 [features]
 default = []

--- a/securedrop-protocol/bench/Makefile
+++ b/securedrop-protocol/bench/Makefile
@@ -21,7 +21,7 @@ CRATE_WASM := $(TARGET_DIR)/$(WASM_TARGET)/release/securedrop_protocol_bench.was
 PKG_DIR := pkg
 
 # Keep consistent with wasm-bindgen version in Cargo.toml
-WASM_BINDGEN_CLI_VERSION := 0.2.106
+WASM_BINDGEN_CLI_VERSION := 0.2.121
 
 RUSTFLAGS := --cfg getrandom_backend="wasm_js"
 

--- a/securedrop-protocol/protocol-minimal/Cargo.toml
+++ b/securedrop-protocol/protocol-minimal/Cargo.toml
@@ -30,8 +30,7 @@ uuid = { version = "1.0", default-features = false, features = ["v4", "js"] }
 argon2 = "0.5"
 blake2 = "0.10"
 
-# pin an exact version to resolve wasm-bindgen schema compatibility issue
-rand_chacha = {  version = "0.9.0", default-features = false  }
+rand_chacha = {  version = "0.9", default-features = false  }
 
 [dev-dependencies]
 proptest = "1.3"


### PR DESCRIPTION
Fixes #245 (hopefully?)

- Update wasm-bindgen to 0.2.121, wasm-bindgen test to 0.3.71
- Include the hash of (bench/Makefile) in the rust cache key, otherwise the wasm-bindgen-cli mismatch causes CI failures.  (We could also not cache bin dependencies using `cache-bin: "false"`) but that seems slightly more wasteful)

Test plan:
- Visual review
- CI 
- `make clean` then `make quick-bench` in the benches crate. Observe successful run + browser output. If you have an old wasm-bindgen-cli version already installed, you'll see an error and be notified about a mismatch and prompted to reinstall wasm-bindgen-cli  using `cargo install -f wasm-bindgen-cli --version 0.2.121`. 
 