### PR TITLE
ci: add `make libcrux` check to ci

### DIFF
--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -33,3 +33,9 @@ jobs:
       - name: Type-check and verify
         run: make verify
         working-directory: securedrop-protocol/protocol-minimal
+
+      - name: Libcrux extraction completes and is reproducible
+        run: |
+          make libcrux
+          git diff --exit-code .
+        working-directory: securedrop-protocol/protocol-minimal/proofs/fstar/models


### PR DESCRIPTION
Add `make libcrux` regression test to the end of hax.yml. Check that it completes and does not introduce changes to the `models/` directory. 
refs #238 