### PR TITLE
proof of concept: `Plaintext` wire format with proofs/tests for round-trip correctness, non-malleability, and injective versioning

### DIFF
--- a/securedrop-protocol/protocol-minimal/Makefile
+++ b/securedrop-protocol/protocol-minimal/Makefile
@@ -11,6 +11,7 @@ HAX_TARGETS += +securedrop_protocol_minimal::primitives::pad::**
 HAX_TARGETS += +securedrop_protocol_minimal::message::**
 HAX_TARGETS += +securedrop_protocol_minimal::metadata::**
 HAX_TARGETS += +securedrop_protocol_minimal::ciphertext::**
+HAX_TARGETS += +securedrop_protocol_minimal::wire_format::**
 HAX_TARGETS += +securedrop_protocol_minimal::constants::**
 
 # Admit modules we extract but that fail panic freedom:

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Ciphertext.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Ciphertext.fst
@@ -52,6 +52,27 @@ let impl_5 = impl_5'
 let impl_6: Core_models.Clone.t_Clone t_Plaintext =
   { f_clone = (fun x -> x); f_clone_pre = (fun _ -> True); f_clone_post = (fun _ _ -> True) }
 
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_7': Core_models.Marker.t_StructuralPartialEq t_Plaintext
+
+unfold
+let impl_7 = impl_7'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_8': Core_models.Cmp.t_PartialEq t_Plaintext t_Plaintext
+
+unfold
+let impl_8 = impl_8'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_9': Core_models.Cmp.t_Eq t_Plaintext
+
+unfold
+let impl_9 = impl_9'
+
 let impl_Plaintext__to_bytes (self: t_Plaintext) : Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
   let buf:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Alloc.Vec.impl__new #u8 () in
   let buf:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
@@ -146,15 +167,15 @@ type t_FetchResponse = {
   f_pmgdh:t_Array u8 (mk_usize 32)
 }
 
-let impl_7: Core_models.Clone.t_Clone t_FetchResponse =
+let impl_10: Core_models.Clone.t_Clone t_FetchResponse =
   { f_clone = (fun x -> x); f_clone_pre = (fun _ -> True); f_clone_post = (fun _ _ -> True) }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
-val impl_8': Core_models.Fmt.t_Debug t_FetchResponse
+val impl_11': Core_models.Fmt.t_Debug t_FetchResponse
 
 unfold
-let impl_8 = impl_8'
+let impl_11 = impl_11'
 
 let impl_FetchResponse__new (enc_id: t_Array u8 (mk_usize 44)) (pmgdh: t_Array u8 (mk_usize 32))
     : t_FetchResponse = { f_enc_id = enc_id; f_pmgdh = pmgdh } <: t_FetchResponse

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Dh_akem.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Dh_akem.fst
@@ -165,8 +165,8 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
       <:
       Core_models.Result.t_Result (t_Array u8 (mk_usize 32)) Anyhow.t_Error
     with
-    | Core_models.Result.Result_Ok hoist2 ->
-      let private_key:t_DhAkemPrivateKey = impl_DhAkemPrivateKey__from_bytes hoist2 in
+    | Core_models.Result.Result_Ok hoist5 ->
+      let private_key:t_DhAkemPrivateKey = impl_DhAkemPrivateKey__from_bytes hoist5 in
       (match
           Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 32))
             #Core_models.Array.t_TryFromSliceError
@@ -194,8 +194,8 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
           <:
           Core_models.Result.t_Result (t_Array u8 (mk_usize 32)) Anyhow.t_Error
         with
-        | Core_models.Result.Result_Ok hoist3 ->
-          let public_key:t_DhAkemPublicKey = impl_DhAkemPublicKey__from_bytes hoist3 in
+        | Core_models.Result.Result_Ok hoist6 ->
+          let public_key:t_DhAkemPublicKey = impl_DhAkemPublicKey__from_bytes hoist6 in
           Core_models.Result.Result_Ok
           (private_key, public_key <: (t_DhAkemPrivateKey & t_DhAkemPublicKey))
           <:

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Mlkem.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Mlkem.fst
@@ -110,8 +110,8 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
       <:
       Core_models.Result.t_Result (t_Array u8 (mk_usize 2400)) Anyhow.t_Error
     with
-    | Core_models.Result.Result_Ok hoist7 ->
-      let private_key:t_MLKEM768PrivateKey = impl_MLKEM768PrivateKey__from_bytes hoist7 in
+    | Core_models.Result.Result_Ok hoist10 ->
+      let private_key:t_MLKEM768PrivateKey = impl_MLKEM768PrivateKey__from_bytes hoist10 in
       (match
           Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 1184))
             #Core_models.Array.t_TryFromSliceError
@@ -139,8 +139,8 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
           <:
           Core_models.Result.t_Result (t_Array u8 (mk_usize 1184)) Anyhow.t_Error
         with
-        | Core_models.Result.Result_Ok hoist8 ->
-          let public_key:t_MLKEM768PublicKey = impl_MLKEM768PublicKey__from_bytes hoist8 in
+        | Core_models.Result.Result_Ok hoist11 ->
+          let public_key:t_MLKEM768PublicKey = impl_MLKEM768PublicKey__from_bytes hoist11 in
           Core_models.Result.Result_Ok
           (private_key, public_key <: (t_MLKEM768PrivateKey & t_MLKEM768PublicKey))
           <:

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Xwing.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Xwing.fst
@@ -147,8 +147,8 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
       <:
       Core_models.Result.t_Result (t_Array u8 (mk_usize 32)) Anyhow.t_Error
     with
-    | Core_models.Result.Result_Ok hoist12 ->
-      let private_key:t_XWingPrivateKey = impl_XWingPrivateKey__from_bytes hoist12 in
+    | Core_models.Result.Result_Ok hoist15 ->
+      let private_key:t_XWingPrivateKey = impl_XWingPrivateKey__from_bytes hoist15 in
       (match
           Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 1216))
             #Core_models.Array.t_TryFromSliceError
@@ -176,8 +176,8 @@ let typed (sk: Libcrux_kem.t_PrivateKey) (pk: Libcrux_kem.t_PublicKey)
           <:
           Core_models.Result.t_Result (t_Array u8 (mk_usize 1216)) Anyhow.t_Error
         with
-        | Core_models.Result.Result_Ok hoist13 ->
-          let public_key:t_XWingPublicKey = impl_XWingPublicKey__from_bytes hoist13 in
+        | Core_models.Result.Result_Ok hoist16 ->
+          let public_key:t_XWingPublicKey = impl_XWingPublicKey__from_bytes hoist16 in
           Core_models.Result.Result_Ok
           (private_key, public_key <: (t_XWingPrivateKey & t_XWingPublicKey))
           <:

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Wire_format.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Wire_format.fst
@@ -1,0 +1,443 @@
+module Securedrop_protocol_minimal.Wire_format
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open FStar.Mul
+open Core_models
+
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Securedrop_protocol_minimal.Ciphertext in
+  ()
+
+let v_LEN_REPLY_PUBKEY: usize = mk_usize 1216
+
+let v_LEN_FETCH_KEY: usize = mk_usize 32
+
+let v_PREFIX_LEN: usize = v_LEN_REPLY_PUBKEY +! v_LEN_FETCH_KEY
+
+let v_TAG_V0: u8 = mk_u8 0
+
+let v_TAG_V1: u8 = mk_u8 1
+
+type t_WireError =
+  | WireError_UnknownVersion : t_WireError
+  | WireError_TooShort : t_WireError
+  | WireError_RoundTripFailed : t_WireError
+  | WireError_NonCanonical : t_WireError
+
+let t_WireError_cast_to_repr (x: t_WireError) : isize =
+  match x <: t_WireError with
+  | WireError_UnknownVersion  -> mk_isize 0
+  | WireError_TooShort  -> mk_isize 1
+  | WireError_RoundTripFailed  -> mk_isize 2
+  | WireError_NonCanonical  -> mk_isize 3
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl': Core_models.Fmt.t_Debug t_WireError
+
+unfold
+let impl = impl'
+
+let impl_1: Core_models.Clone.t_Clone t_WireError =
+  { f_clone = (fun x -> x); f_clone_pre = (fun _ -> True); f_clone_post = (fun _ _ -> True) }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_2': Core_models.Marker.t_StructuralPartialEq t_WireError
+
+unfold
+let impl_2 = impl_2'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_3': Core_models.Cmp.t_PartialEq t_WireError t_WireError
+
+unfold
+let impl_3 = impl_3'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_4': Core_models.Cmp.t_Eq t_WireError
+
+unfold
+let impl_4 = impl_4'
+
+let version_tag (bytes: t_Slice u8) : Core_models.Option.t_Option u8 =
+  if Core_models.Slice.impl__is_empty #u8 bytes
+  then Core_models.Option.Option_None <: Core_models.Option.t_Option u8
+  else Core_models.Option.Option_Some bytes.[ mk_usize 0 ] <: Core_models.Option.t_Option u8
+
+let v_MAX_MSG_LEN: usize = (Core_models.Num.impl_usize__MAX -! v_PREFIX_LEN <: usize) -! mk_usize 1
+
+let serialize_v0 (p: Securedrop_protocol_minimal.Ciphertext.t_Plaintext)
+    : Prims.Pure (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+      (requires
+        (Alloc.Vec.impl_1__len #u8
+            #Alloc.Alloc.t_Global
+            p.Securedrop_protocol_minimal.Ciphertext.f_msg
+          <:
+          usize) <=.
+        v_MAX_MSG_LEN)
+      (fun _ -> Prims.l_True) =
+  let buf:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Alloc.Vec.impl__new #u8 () in
+  let buf:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
+    Alloc.Vec.impl_1__push #u8 #Alloc.Alloc.t_Global buf v_TAG_V0
+  in
+  let buf:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
+    Alloc.Vec.impl_2__extend_from_slice #u8
+      #Alloc.Alloc.t_Global
+      buf
+      (p.Securedrop_protocol_minimal.Ciphertext.f_sender_reply_pubkey_hybrid <: t_Slice u8)
+  in
+  let buf:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
+    Alloc.Vec.impl_2__extend_from_slice #u8
+      #Alloc.Alloc.t_Global
+      buf
+      (p.Securedrop_protocol_minimal.Ciphertext.f_sender_fetch_key <: t_Slice u8)
+  in
+  let buf:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
+    Alloc.Vec.impl_2__extend_from_slice #u8
+      #Alloc.Alloc.t_Global
+      buf
+      (Alloc.Vec.impl_1__as_slice p.Securedrop_protocol_minimal.Ciphertext.f_msg <: t_Slice u8)
+  in
+  buf
+
+let deserialize_v0_body (body: t_Slice u8)
+    : Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext t_WireError =
+  if (Core_models.Slice.impl__len #u8 body <: usize) <. v_PREFIX_LEN
+  then
+    Core_models.Result.Result_Err (WireError_TooShort <: t_WireError)
+    <:
+    Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext t_WireError
+  else
+    let sender_reply_pubkey_hybrid:t_Array u8 (mk_usize 1216) =
+      Rust_primitives.Hax.repeat (mk_u8 0) (mk_usize 1216)
+    in
+    let sender_reply_pubkey_hybrid:t_Array u8 (mk_usize 1216) =
+      Core_models.Slice.impl__copy_from_slice #u8
+        sender_reply_pubkey_hybrid
+        (body.[ {
+              Core_models.Ops.Range.f_start = mk_usize 0;
+              Core_models.Ops.Range.f_end = v_LEN_REPLY_PUBKEY
+            }
+            <:
+            Core_models.Ops.Range.t_Range usize ]
+          <:
+          t_Slice u8)
+    in
+    let sender_fetch_key:t_Array u8 (mk_usize 32) =
+      Rust_primitives.Hax.repeat (mk_u8 0) (mk_usize 32)
+    in
+    let sender_fetch_key:t_Array u8 (mk_usize 32) =
+      Core_models.Slice.impl__copy_from_slice #u8
+        sender_fetch_key
+        (body.[ {
+              Core_models.Ops.Range.f_start = v_LEN_REPLY_PUBKEY;
+              Core_models.Ops.Range.f_end = v_PREFIX_LEN
+            }
+            <:
+            Core_models.Ops.Range.t_Range usize ]
+          <:
+          t_Slice u8)
+    in
+    let msg:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
+      Alloc.Slice.impl__to_vec #u8
+        (body.[ { Core_models.Ops.Range.f_start = v_PREFIX_LEN }
+            <:
+            Core_models.Ops.Range.t_RangeFrom usize ]
+          <:
+          t_Slice u8)
+    in
+    Core_models.Result.Result_Ok
+    ({
+        Securedrop_protocol_minimal.Ciphertext.f_sender_reply_pubkey_hybrid
+        =
+        sender_reply_pubkey_hybrid;
+        Securedrop_protocol_minimal.Ciphertext.f_sender_fetch_key = sender_fetch_key;
+        Securedrop_protocol_minimal.Ciphertext.f_msg = msg
+      }
+      <:
+      Securedrop_protocol_minimal.Ciphertext.t_Plaintext)
+    <:
+    Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext t_WireError
+
+let serialize_v1 (p: Securedrop_protocol_minimal.Ciphertext.t_Plaintext)
+    : Prims.Pure (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+      (requires
+        (Alloc.Vec.impl_1__len #u8
+            #Alloc.Alloc.t_Global
+            p.Securedrop_protocol_minimal.Ciphertext.f_msg
+          <:
+          usize) <=.
+        v_MAX_MSG_LEN)
+      (fun _ -> Prims.l_True) =
+  let buf:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Alloc.Vec.impl__new #u8 () in
+  let buf:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
+    Alloc.Vec.impl_1__push #u8 #Alloc.Alloc.t_Global buf v_TAG_V1
+  in
+  let buf:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
+    Alloc.Vec.impl_2__extend_from_slice #u8
+      #Alloc.Alloc.t_Global
+      buf
+      (p.Securedrop_protocol_minimal.Ciphertext.f_sender_fetch_key <: t_Slice u8)
+  in
+  let buf:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
+    Alloc.Vec.impl_2__extend_from_slice #u8
+      #Alloc.Alloc.t_Global
+      buf
+      (p.Securedrop_protocol_minimal.Ciphertext.f_sender_reply_pubkey_hybrid <: t_Slice u8)
+  in
+  let buf:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
+    Alloc.Vec.impl_2__extend_from_slice #u8
+      #Alloc.Alloc.t_Global
+      buf
+      (Alloc.Vec.impl_1__as_slice p.Securedrop_protocol_minimal.Ciphertext.f_msg <: t_Slice u8)
+  in
+  buf
+
+let deserialize_v1_body (body: t_Slice u8)
+    : Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext t_WireError =
+  if (Core_models.Slice.impl__len #u8 body <: usize) <. v_PREFIX_LEN
+  then
+    Core_models.Result.Result_Err (WireError_TooShort <: t_WireError)
+    <:
+    Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext t_WireError
+  else
+    let sender_fetch_key:t_Array u8 (mk_usize 32) =
+      Rust_primitives.Hax.repeat (mk_u8 0) (mk_usize 32)
+    in
+    let sender_fetch_key:t_Array u8 (mk_usize 32) =
+      Core_models.Slice.impl__copy_from_slice #u8
+        sender_fetch_key
+        (body.[ {
+              Core_models.Ops.Range.f_start = mk_usize 0;
+              Core_models.Ops.Range.f_end = v_LEN_FETCH_KEY
+            }
+            <:
+            Core_models.Ops.Range.t_Range usize ]
+          <:
+          t_Slice u8)
+    in
+    let sender_reply_pubkey_hybrid:t_Array u8 (mk_usize 1216) =
+      Rust_primitives.Hax.repeat (mk_u8 0) (mk_usize 1216)
+    in
+    let sender_reply_pubkey_hybrid:t_Array u8 (mk_usize 1216) =
+      Core_models.Slice.impl__copy_from_slice #u8
+        sender_reply_pubkey_hybrid
+        (body.[ {
+              Core_models.Ops.Range.f_start = v_LEN_FETCH_KEY;
+              Core_models.Ops.Range.f_end = v_PREFIX_LEN
+            }
+            <:
+            Core_models.Ops.Range.t_Range usize ]
+          <:
+          t_Slice u8)
+    in
+    let msg:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
+      Alloc.Slice.impl__to_vec #u8
+        (body.[ { Core_models.Ops.Range.f_start = v_PREFIX_LEN }
+            <:
+            Core_models.Ops.Range.t_RangeFrom usize ]
+          <:
+          t_Slice u8)
+    in
+    Core_models.Result.Result_Ok
+    ({
+        Securedrop_protocol_minimal.Ciphertext.f_sender_reply_pubkey_hybrid
+        =
+        sender_reply_pubkey_hybrid;
+        Securedrop_protocol_minimal.Ciphertext.f_sender_fetch_key = sender_fetch_key;
+        Securedrop_protocol_minimal.Ciphertext.f_msg = msg
+      }
+      <:
+      Securedrop_protocol_minimal.Ciphertext.t_Plaintext)
+    <:
+    Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext t_WireError
+
+let deserialize (bytes: t_Slice u8)
+    : Prims.Pure
+      (Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext t_WireError)
+      Prims.l_True
+      (ensures
+        fun result ->
+          let result:Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext
+            t_WireError =
+            result
+          in
+          match
+            result
+            <:
+            Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext
+              t_WireError
+          with
+          | Core_models.Result.Result_Ok p ->
+            (Alloc.Vec.impl_1__len #u8
+                #Alloc.Alloc.t_Global
+                p.Securedrop_protocol_minimal.Ciphertext.f_msg
+              <:
+              usize) <=.
+            v_MAX_MSG_LEN &&
+            (Alloc.Vec.impl_1__as_slice #u8
+                #Alloc.Alloc.t_Global
+                (serialize_v0 p <: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+              <:
+              t_Slice u8) =.
+            bytes
+          | Core_models.Result.Result_Err _ -> true) =
+  match version_tag bytes <: Core_models.Option.t_Option u8 with
+  | Core_models.Option.Option_Some (Rust_primitives.Integers.MkInt 0) ->
+    (match
+        deserialize_v0_body (bytes.[ { Core_models.Ops.Range.f_start = mk_usize 1 }
+              <:
+              Core_models.Ops.Range.t_RangeFrom usize ]
+            <:
+            t_Slice u8)
+        <:
+        Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext t_WireError
+      with
+      | Core_models.Result.Result_Ok ok ->
+        let p:Securedrop_protocol_minimal.Ciphertext.t_Plaintext = ok in
+        if
+          (Alloc.Vec.impl_1__len #u8
+              #Alloc.Alloc.t_Global
+              p.Securedrop_protocol_minimal.Ciphertext.f_msg
+            <:
+            usize) <=.
+          v_MAX_MSG_LEN &&
+          (Alloc.Vec.impl_1__as_slice #u8
+              #Alloc.Alloc.t_Global
+              (serialize_v0 p <: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+            <:
+            t_Slice u8) =.
+          bytes
+        then
+          Core_models.Result.Result_Ok p
+          <:
+          Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext t_WireError
+        else
+          Core_models.Result.Result_Err (WireError_NonCanonical <: t_WireError)
+          <:
+          Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext t_WireError
+      | Core_models.Result.Result_Err err ->
+        Core_models.Result.Result_Err err
+        <:
+        Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext t_WireError)
+  | _ ->
+    Core_models.Result.Result_Err (WireError_UnknownVersion <: t_WireError)
+    <:
+    Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext t_WireError
+
+let serialize (p: Securedrop_protocol_minimal.Ciphertext.t_Plaintext)
+    : Prims.Pure (Core_models.Result.t_Result (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) t_WireError)
+      (requires
+        (Alloc.Vec.impl_1__len #u8
+            #Alloc.Alloc.t_Global
+            p.Securedrop_protocol_minimal.Ciphertext.f_msg
+          <:
+          usize) <=.
+        v_MAX_MSG_LEN)
+      (ensures
+        fun result ->
+          let result:Core_models.Result.t_Result (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+            t_WireError =
+            result
+          in
+          match
+            result
+            <:
+            Core_models.Result.t_Result (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) t_WireError
+          with
+          | Core_models.Result.Result_Ok buf ->
+            (deserialize (Alloc.Vec.impl_1__as_slice buf <: t_Slice u8)
+              <:
+              Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext
+                t_WireError) =.
+            (Core_models.Result.Result_Ok
+              (Core_models.Clone.f_clone #Securedrop_protocol_minimal.Ciphertext.t_Plaintext
+                  #FStar.Tactics.Typeclasses.solve
+                  p
+                <:
+                Securedrop_protocol_minimal.Ciphertext.t_Plaintext)
+              <:
+              Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext
+                t_WireError)
+          | Core_models.Result.Result_Err _ -> true) =
+  let buf:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = serialize_v0 p in
+  if
+    (deserialize (Alloc.Vec.impl_1__as_slice buf <: t_Slice u8)
+      <:
+      Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext t_WireError) =.
+    (Core_models.Result.Result_Ok
+      (Core_models.Clone.f_clone #Securedrop_protocol_minimal.Ciphertext.t_Plaintext
+          #FStar.Tactics.Typeclasses.solve
+          p
+        <:
+        Securedrop_protocol_minimal.Ciphertext.t_Plaintext)
+      <:
+      Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext t_WireError)
+  then
+    Core_models.Result.Result_Ok buf
+    <:
+    Core_models.Result.t_Result (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) t_WireError
+  else
+    Core_models.Result.Result_Err (WireError_RoundTripFailed <: t_WireError)
+    <:
+    Core_models.Result.t_Result (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) t_WireError
+
+let deserialize_versioned (bytes: t_Slice u8)
+    : Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext t_WireError =
+  match version_tag bytes <: Core_models.Option.t_Option u8 with
+  | Core_models.Option.Option_Some (Rust_primitives.Integers.MkInt 0) ->
+    deserialize_v0_body (bytes.[ { Core_models.Ops.Range.f_start = mk_usize 1 }
+          <:
+          Core_models.Ops.Range.t_RangeFrom usize ]
+        <:
+        t_Slice u8)
+  | Core_models.Option.Option_Some (Rust_primitives.Integers.MkInt 1) ->
+    deserialize_v1_body (bytes.[ { Core_models.Ops.Range.f_start = mk_usize 1 }
+          <:
+          Core_models.Ops.Range.t_RangeFrom usize ]
+        <:
+        t_Slice u8)
+  | _ ->
+    Core_models.Result.Result_Err (WireError_UnknownVersion <: t_WireError)
+    <:
+    Core_models.Result.t_Result Securedrop_protocol_minimal.Ciphertext.t_Plaintext t_WireError
+
+let lemma_version_tag_v0 (p: Securedrop_protocol_minimal.Ciphertext.t_Plaintext)
+    : Lemma
+    (ensures
+      (Alloc.Vec.impl_1__len #u8
+          #Alloc.Alloc.t_Global
+          p.Securedrop_protocol_minimal.Ciphertext.f_msg
+        <:
+        usize) >.
+      v_MAX_MSG_LEN ||
+      (version_tag (Alloc.Vec.impl_1__as_slice (serialize_v0 p
+                <:
+                Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+            <:
+            t_Slice u8)
+        <:
+        Core_models.Option.t_Option u8) =.
+      (Core_models.Option.Option_Some v_TAG_V0 <: Core_models.Option.t_Option u8)) = ()
+
+let lemma_version_tag_v1 (p: Securedrop_protocol_minimal.Ciphertext.t_Plaintext)
+    : Lemma
+    (ensures
+      (Alloc.Vec.impl_1__len #u8
+          #Alloc.Alloc.t_Global
+          p.Securedrop_protocol_minimal.Ciphertext.f_msg
+        <:
+        usize) >.
+      v_MAX_MSG_LEN ||
+      (version_tag (Alloc.Vec.impl_1__as_slice (serialize_v1 p
+                <:
+                Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+            <:
+            t_Slice u8)
+        <:
+        Core_models.Option.t_Option u8) =.
+      (Core_models.Option.Option_Some v_TAG_V1 <: Core_models.Option.t_Option u8)) = ()

--- a/securedrop-protocol/protocol-minimal/src/ciphertext.rs
+++ b/securedrop-protocol/protocol-minimal/src/ciphertext.rs
@@ -44,7 +44,7 @@ impl Envelope {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 /// Toy pt structure - TODO: provide params in correct order
 pub struct Plaintext {
     /// Metadata key: $pk_S^{PKE}$ in the spec

--- a/securedrop-protocol/protocol-minimal/src/lib.rs
+++ b/securedrop-protocol/protocol-minimal/src/lib.rs
@@ -15,6 +15,7 @@ pub mod server;
 pub mod setup;
 mod traits;
 pub mod wire;
+pub mod wire_format;
 
 pub mod journalist;
 pub mod source;

--- a/securedrop-protocol/protocol-minimal/src/wire_format.rs
+++ b/securedrop-protocol/protocol-minimal/src/wire_format.rs
@@ -1,0 +1,201 @@
+use alloc::vec::Vec;
+
+use crate::ciphertext::Plaintext;
+
+const LEN_REPLY_PUBKEY: usize = 1216;
+const LEN_FETCH_KEY: usize = 32;
+
+const PREFIX_LEN: usize = LEN_REPLY_PUBKEY + LEN_FETCH_KEY;
+
+#[cfg(not(hax))]
+const _: () = {
+    assert!(LEN_REPLY_PUBKEY == crate::primitives::xwing::XWING_PUBLIC_KEY_LEN);
+    assert!(LEN_FETCH_KEY == crate::primitives::x25519::DH_PUBLIC_KEY_LEN);
+};
+
+pub const TAG_V0: u8 = 0x00;
+pub const TAG_V1: u8 = 0x01;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WireError {
+    UnknownVersion,
+    TooShort,
+    RoundTripFailed,
+    NonCanonical,
+}
+
+pub fn version_tag(bytes: &[u8]) -> Option<u8> {
+    if bytes.is_empty() {
+        None
+    } else {
+        Some(bytes[0])
+    }
+}
+
+pub const MAX_MSG_LEN: usize = usize::MAX - PREFIX_LEN - 1;
+
+// [Theorem] Proves: the encoded length never overflows `usize`, so `serialize_v0` is panic-free.
+#[cfg_attr(hax, hax_lib::requires(p.msg.len() <= MAX_MSG_LEN))]
+pub fn serialize_v0(p: &Plaintext) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.push(TAG_V0);
+    buf.extend_from_slice(&p.sender_reply_pubkey_hybrid);
+    buf.extend_from_slice(&p.sender_fetch_key);
+    buf.extend_from_slice(&p.msg);
+    buf
+}
+
+fn deserialize_v0_body(body: &[u8]) -> Result<Plaintext, WireError> {
+    if body.len() < PREFIX_LEN {
+        return Err(WireError::TooShort);
+    }
+
+    let mut sender_reply_pubkey_hybrid = [0u8; LEN_REPLY_PUBKEY];
+    sender_reply_pubkey_hybrid.copy_from_slice(&body[0..LEN_REPLY_PUBKEY]);
+
+    let mut sender_fetch_key = [0u8; LEN_FETCH_KEY];
+    sender_fetch_key.copy_from_slice(&body[LEN_REPLY_PUBKEY..PREFIX_LEN]);
+
+    let msg = body[PREFIX_LEN..].to_vec();
+
+    Ok(Plaintext {
+        sender_reply_pubkey_hybrid,
+        sender_fetch_key,
+        msg,
+    })
+}
+
+// [Theorem] Proves: the encoded length never overflows `usize`, so `serialize_v1` is panic-free.
+#[cfg_attr(hax, hax_lib::requires(p.msg.len() <= MAX_MSG_LEN))]
+pub fn serialize_v1(p: &Plaintext) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.push(TAG_V1);
+    buf.extend_from_slice(&p.sender_fetch_key);
+    buf.extend_from_slice(&p.sender_reply_pubkey_hybrid);
+    buf.extend_from_slice(&p.msg);
+    buf
+}
+
+fn deserialize_v1_body(body: &[u8]) -> Result<Plaintext, WireError> {
+    if body.len() < PREFIX_LEN {
+        return Err(WireError::TooShort);
+    }
+
+    let mut sender_fetch_key = [0u8; LEN_FETCH_KEY];
+    sender_fetch_key.copy_from_slice(&body[0..LEN_FETCH_KEY]);
+
+    let mut sender_reply_pubkey_hybrid = [0u8; LEN_REPLY_PUBKEY];
+    sender_reply_pubkey_hybrid.copy_from_slice(&body[LEN_FETCH_KEY..PREFIX_LEN]);
+
+    let msg = body[PREFIX_LEN..].to_vec();
+
+    Ok(Plaintext {
+        sender_reply_pubkey_hybrid,
+        sender_fetch_key,
+        msg,
+    })
+}
+
+// [Theorem] Proves: the call to `serialize_v0` cannot overflow (its precondition holds here).
+#[cfg_attr(hax, hax_lib::requires(p.msg.len() <= MAX_MSG_LEN))]
+// [Guarded] Proves (round-trip): whenever `serialize` returns `Ok(buf)`, `deserialize(buf)` recovers `p`.
+#[cfg_attr(hax, hax_lib::ensures(|result| match result {
+    Ok(buf) => deserialize(&buf) == Ok(p.clone()),
+    Err(_) => true,
+}))]
+pub fn serialize(p: &Plaintext) -> Result<Vec<u8>, WireError> {
+    let buf = serialize_v0(p);
+    if deserialize(&buf) == Ok(p.clone()) {
+        Ok(buf)
+    } else {
+        Err(WireError::RoundTripFailed)
+    }
+}
+
+// [Guarded] Proves (non-malleability): whenever `deserialize` returns `Ok(p)`, re-encoding `p` reproduces the input bytes exactly.
+#[cfg_attr(hax, hax_lib::ensures(|result| match result {
+    Ok(p) => p.msg.len() <= MAX_MSG_LEN && serialize_v0(&p).as_slice() == bytes,
+    Err(_) => true,
+}))]
+pub fn deserialize(bytes: &[u8]) -> Result<Plaintext, WireError> {
+    let p = match version_tag(bytes) {
+        Some(TAG_V0) => deserialize_v0_body(&bytes[1..])?,
+        _ => return Err(WireError::UnknownVersion),
+    };
+    if p.msg.len() <= MAX_MSG_LEN && serialize_v0(&p).as_slice() == bytes {
+        Ok(p)
+    } else {
+        Err(WireError::NonCanonical)
+    }
+}
+
+pub fn deserialize_versioned(bytes: &[u8]) -> Result<Plaintext, WireError> {
+    match version_tag(bytes) {
+        Some(TAG_V0) => deserialize_v0_body(&bytes[1..]),
+        Some(TAG_V1) => deserialize_v1_body(&bytes[1..]),
+        _ => Err(WireError::UnknownVersion),
+    }
+}
+
+// [Theorem] Proves (injective versioning): every V0 encoding begins with tag `TAG_V0`, for all records.
+#[cfg(hax)]
+#[hax_lib::lemma]
+fn lemma_version_tag_v0(
+    p: Plaintext,
+) -> Proof<{ p.msg.len() > MAX_MSG_LEN || version_tag(&serialize_v0(&p)) == Some(TAG_V0) }> {
+}
+
+// [Theorem] Proves (injective versioning): every V1 encoding begins with tag `TAG_V1`, for all records (and `TAG_V0 != TAG_V1`, so versions never collide).
+#[cfg(hax)]
+#[hax_lib::lemma]
+fn lemma_version_tag_v1(
+    p: Plaintext,
+) -> Proof<{ p.msg.len() > MAX_MSG_LEN || version_tag(&serialize_v1(&p)) == Some(TAG_V1) }> {
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn plaintext_strategy() -> impl Strategy<Value = Plaintext> {
+        (
+            proptest::array::uniform(any::<u8>()).prop_map(|a: [u8; LEN_REPLY_PUBKEY]| a),
+            proptest::array::uniform(any::<u8>()).prop_map(|a: [u8; LEN_FETCH_KEY]| a),
+            proptest::collection::vec(any::<u8>(), 0..256),
+        )
+            .prop_map(
+                |(sender_reply_pubkey_hybrid, sender_fetch_key, msg)| Plaintext {
+                    sender_reply_pubkey_hybrid,
+                    sender_fetch_key,
+                    msg,
+                },
+            )
+    }
+
+    proptest! {
+        // Tests (round-trip): on sampled records, `serialize` succeeds and `deserialize` recovers the record.
+        #[test]
+        fn prop_roundtrip(p in plaintext_strategy()) {
+            let bytes = serialize(&p).expect("serialize must succeed for a valid record");
+            let decoded = deserialize(&bytes).expect("valid V0 encoding must decode");
+            prop_assert_eq!(decoded, p);
+        }
+
+        // Tests (non-malleability): on sampled byte strings, any that decode re-encode back to themselves.
+        #[test]
+        fn prop_non_malleable(m in proptest::collection::vec(any::<u8>(), 0..(PREFIX_LEN + 256))) {
+            if let Ok(p) = deserialize(&m) {
+                prop_assert_eq!(serialize_v0(&p), m);
+            }
+        }
+
+        // Tests (injective versioning): on sampled records, each encoder stamps its own distinct tag.
+        #[test]
+        fn prop_version_tags(p in plaintext_strategy()) {
+            prop_assert_eq!(version_tag(&serialize_v0(&p)), Some(TAG_V0));
+            prop_assert_eq!(version_tag(&serialize_v1(&p)), Some(TAG_V1));
+            prop_assert_ne!(TAG_V0, TAG_V1);
+        }
+    }
+}


### PR DESCRIPTION
This is the result of several iterations with Claude to explore what's currently possible towards #132.  The parameters I've arrived at are:

- Start with just one wire format: `Plaintext` seemed to be the simplest.
- Demonstrate versioning while we're at it.
- No inline F*; only hax annotations.
- Learn as much as possible from Bertie's de/serialization, beginning at <https://github.com/cryspen/bertie/blob/main/src/tls13utils.rs#L172> and especially at <https://github.com/cryspen/bertie/blob/a1f27d62f419511e0212da84270b078805e60bae/src/tls13utils.rs#L416-L532>.

Here's what it turns out to be possible to do within these constraints:

- https://github.com/freedomofpress/securedrop-protocol/blob/0bae54d3523fc9273bb3334fab853998c1218913/securedrop-protocol/protocol-minimal/src/wire_format.rs#L37
- https://github.com/freedomofpress/securedrop-protocol/blob/0bae54d3523fc9273bb3334fab853998c1218913/securedrop-protocol/protocol-minimal/src/wire_format.rs#L68
- https://github.com/freedomofpress/securedrop-protocol/blob/0bae54d3523fc9273bb3334fab853998c1218913/securedrop-protocol/protocol-minimal/src/wire_format.rs#L99
- https://github.com/freedomofpress/securedrop-protocol/blob/0bae54d3523fc9273bb3334fab853998c1218913/securedrop-protocol/protocol-minimal/src/wire_format.rs#L115
- https://github.com/freedomofpress/securedrop-protocol/blob/0bae54d3523fc9273bb3334fab853998c1218913/securedrop-protocol/protocol-minimal/src/wire_format.rs#L140
- https://github.com/freedomofpress/securedrop-protocol/blob/0bae54d3523fc9273bb3334fab853998c1218913/securedrop-protocol/protocol-minimal/src/wire_format.rs#L148
- https://github.com/freedomofpress/securedrop-protocol/blob/0bae54d3523fc9273bb3334fab853998c1218913/securedrop-protocol/protocol-minimal/src/wire_format.rs#L177
- https://github.com/freedomofpress/securedrop-protocol/blob/0bae54d3523fc9273bb3334fab853998c1218913/securedrop-protocol/protocol-minimal/src/wire_format.rs#L185
- https://github.com/freedomofpress/securedrop-protocol/blob/0bae54d3523fc9273bb3334fab853998c1218913/securedrop-protocol/protocol-minimal/src/wire_format.rs#L193

This is substantively what we want, with a few caveats and nuances:
1. hax's core models don't give us (either for our `Vec<U8>` or for Bertie's [`Bytes`]) a lemma like "`a.concat(b).concat(c)` slices back to `a,b,c`".  So it turns out to be easier to prove round-tripness and non-malleability by hax annotations on the control flow of *fallible* de/serialize functions, rather than on the totality of the pure de/serialize functions that are theoretically possible.  These are the proofs marked "guarded" rather than "theorem" in the list above.
2. The property tests exercise these properties at runtime, showing that these functions are actually correct for specific inputs.  The hax annotations make these properties reusable elsewhere (i.e., as part of contracts for functions higher up in the crate).

I believe this is the most we'll be able to do without writing *some* proof code ourselves.  (If we were to go down that path, at this point I would strongly favor Lean over F*, so I think we're wise to stick to what's hax-idiomatic for now.)  Let's review this at our next working-group meeting and discuss whether we think this pattern is worth trying for all of our message formats, beyond `Plaintext` in this proof of concept.


[`Bytes`]: https://github.com/cryspen/bertie/blob/a1f27d62f419511e0212da84270b078805e60bae/src/tls13utils.rs#L416-L532