### PR TITLE
soundness: include `encrypt_message_id`, `decrypt_message_id` in verification

### DIFF
--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Provider.Chacha20poly1305.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.Provider.Chacha20poly1305.fst
@@ -3,23 +3,11 @@ module Securedrop_protocol_minimal.Primitives.Provider.Chacha20poly1305
 open FStar.Mul
 open Core_models
 
-assume
-val v_KEY_LEN': usize
+let v_KEY_LEN: usize = Libcrux_chacha20poly1305.v_KEY_LEN
 
-unfold
-let v_KEY_LEN = v_KEY_LEN'
+let v_NONCE_LEN: usize = Libcrux_chacha20poly1305.v_NONCE_LEN
 
-assume
-val v_NONCE_LEN': usize
-
-unfold
-let v_NONCE_LEN = v_NONCE_LEN'
-
-assume
-val v_TAG_LEN': usize
-
-unfold
-let v_TAG_LEN = v_TAG_LEN'
+let v_TAG_LEN: usize = Libcrux_chacha20poly1305.v_TAG_LEN
 
 assume
 val encrypt':
@@ -28,7 +16,18 @@ val encrypt':
     ciphertext: t_Slice u8 ->
     aad: t_Slice u8 ->
     nonce: t_Array u8 (mk_usize 12)
-  -> (t_Slice u8 & Core_models.Result.t_Result Prims.unit Libcrux_chacha20poly1305.t_AeadError)
+  -> Prims.Pure
+      (t_Slice u8 & Core_models.Result.t_Result Prims.unit Libcrux_chacha20poly1305.t_AeadError)
+      Prims.l_True
+      (ensures
+        fun temp_0_ ->
+          let
+          (ciphertext_future: t_Slice u8),
+          (e_result: Core_models.Result.t_Result Prims.unit Libcrux_chacha20poly1305.t_AeadError) =
+            temp_0_
+          in
+          (Core_models.Slice.impl__len #u8 ciphertext_future <: usize) =.
+          (Core_models.Slice.impl__len #u8 ciphertext <: usize))
 
 unfold
 let encrypt = encrypt'

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Primitives.fst
@@ -15,8 +15,6 @@ let _ =
 /// regardless of how many actual messages exist.
 let v_MESSAGE_ID_FETCH_SIZE: usize = mk_usize 10
 
-#push-options "--admit_smt_queries true"
-
 /// Symmetric encryption for message IDs using ChaCha20-Poly1305
 /// This is used in step 7 for encrypting message IDs with a shared secret
 let encrypt_message_id
@@ -25,7 +23,18 @@ let encrypt_message_id
       (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng v_R)
       (key message_id: t_Slice u8)
       (rng: v_R)
-    : (v_R & Core_models.Result.t_Result (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Anyhow.t_Error) =
+    : Prims.Pure
+      (v_R & Core_models.Result.t_Result (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Anyhow.t_Error)
+      (requires
+        (Core_models.Slice.impl__len #u8 message_id <: usize) <=.
+        ((Core_models.Num.impl_usize__MAX -!
+            Securedrop_protocol_minimal.Primitives.Provider.Chacha20poly1305.v_NONCE_LEN
+            <:
+            usize) -!
+          Securedrop_protocol_minimal.Primitives.Provider.Chacha20poly1305.v_TAG_LEN
+          <:
+          usize))
+      (fun _ -> Prims.l_True) =
   if
     (Core_models.Slice.impl__len #u8 key <: usize) <>.
     Securedrop_protocol_minimal.Primitives.Provider.Chacha20poly1305.v_KEY_LEN
@@ -163,10 +172,6 @@ let encrypt_message_id
         Core_models.Result.t_Result (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Anyhow.t_Error)
       <:
       (v_R & Core_models.Result.t_Result (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Anyhow.t_Error)
-
-#pop-options
-
-#push-options "--admit_smt_queries true"
 
 /// Symmetric decryption for message IDs using ChaCha20-Poly1305
 /// This is used in step 7 for decrypting message IDs with a shared secret
@@ -358,5 +363,3 @@ let decrypt_message_id (key encrypted_data: t_Slice u8)
         Core_models.Result.Result_Err err
         <:
         Core_models.Result.t_Result (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Anyhow.t_Error
-
-#pop-options

--- a/securedrop-protocol/protocol-minimal/src/primitives.rs
+++ b/securedrop-protocol/protocol-minimal/src/primitives.rs
@@ -15,11 +15,16 @@ pub(crate) mod xwing;
 /// regardless of how many actual messages exist.
 pub const MESSAGE_ID_FETCH_SIZE: usize = 10;
 
-// TODO: aesgcm256 for consistency with other methods
 /// Symmetric encryption for message IDs using ChaCha20-Poly1305
 ///
 /// This is used in step 7 for encrypting message IDs with a shared secret
-#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+///
+#[cfg_attr(hax, hax_lib::requires(
+    message_id.len()
+        <= usize::MAX
+            - provider::chacha20poly1305::NONCE_LEN
+            - provider::chacha20poly1305::TAG_LEN
+))]
 pub fn encrypt_message_id<R: RngCore + CryptoRng>(
     key: &[u8],
     message_id: &[u8],
@@ -61,7 +66,6 @@ pub fn encrypt_message_id<R: RngCore + CryptoRng>(
 /// Symmetric decryption for message IDs using ChaCha20-Poly1305
 ///
 /// This is used in step 7 for decrypting message IDs with a shared secret
-#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 pub fn decrypt_message_id(key: &[u8], encrypted_data: &[u8]) -> Result<Vec<u8>, Error> {
     use provider::chacha20poly1305::{KEY_LEN, NONCE_LEN, TAG_LEN};
 

--- a/securedrop-protocol/protocol-minimal/src/primitives/provider.rs
+++ b/securedrop-protocol/protocol-minimal/src/primitives/provider.rs
@@ -108,19 +108,16 @@ pub mod chacha20poly1305 {
     #[cfg_attr(hax, hax_lib::opaque)]
     use libcrux_chacha20poly1305::AeadError;
 
-    #[cfg_attr(hax, hax_lib::opaque)]
     pub(crate) const KEY_LEN: usize = libcrux_chacha20poly1305::KEY_LEN;
 
-    #[cfg_attr(hax, hax_lib::opaque)]
     pub(crate) const NONCE_LEN: usize = libcrux_chacha20poly1305::NONCE_LEN;
 
-    #[cfg_attr(hax, hax_lib::opaque)]
     pub(crate) const TAG_LEN: usize = libcrux_chacha20poly1305::TAG_LEN;
 
     // #[cfg_attr(hax, hax_lib::opaque)]
     // pub(crate) use libcrux_chacha20poly1305::{decrypt, encrypt};
 
-    // Hax extraction is struggling with the types
+    #[cfg_attr(hax, hax_lib::ensures(|_result| future(ciphertext).len() == ciphertext.len()))]
     #[cfg_attr(hax, hax_lib::opaque)]
     pub fn encrypt(
         key: &[u8; KEY_LEN],


### PR DESCRIPTION
Towards #279

This removes the lax verification on `encrypt_message_id`, `decrypt_message_id` and removes a few opaque markers in the providers module (we need constants from there)