### PR TITLE
Remove metadata.rs from HAX_ADMITS

### DIFF
--- a/securedrop-protocol/protocol-minimal/Makefile
+++ b/securedrop-protocol/protocol-minimal/Makefile
@@ -12,7 +12,6 @@ HAX_TARGETS += +securedrop_protocol_minimal::api::Client
 
 # Admit modules we extract but that fail panic freedom:
 HAX_ADMITS := Securedrop_protocol_minimal.Message.fst
-HAX_ADMITS += Securedrop_protocol_minimal.Metadata.fst
 HAX_ADMITS += Securedrop_protocol_minimal.Ciphertext.fst
 
 REPO_ROOT = $(shell git rev-parse --show-toplevel)

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Encrypt_decrypt.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Encrypt_decrypt.fst
@@ -125,22 +125,24 @@ let encrypt
           Anyhow.t_Error)
       "Failed to generate shared secret"
   in
-  let sender_apke_bytes:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
-    Securedrop_protocol_minimal.Message.impl_MessagePublicKey__as_bytes (Securedrop_protocol_minimal.Traits.f_own_message_auth_pk
-          #v_Sender
-          #FStar.Tactics.Typeclasses.solve
-          sender
-        <:
-        Securedrop_protocol_minimal.Message.t_MessagePublicKey)
-  in
   let ct_pke:Securedrop_protocol_minimal.Metadata.t_MetadataCiphertext =
-    Securedrop_protocol_minimal.Metadata.encrypt (Securedrop_protocol_minimal.Traits.f_message_metadata_pk
-          #v_Recipient
-          #FStar.Tactics.Typeclasses.solve
-          recipient
+    Core_models.Result.impl__expect #Securedrop_protocol_minimal.Metadata.t_MetadataCiphertext
+      #Anyhow.t_Error
+      (Securedrop_protocol_minimal.Metadata.encrypt (Securedrop_protocol_minimal.Traits.f_message_metadata_pk
+              #v_Recipient
+              #FStar.Tactics.Typeclasses.solve
+              recipient
+            <:
+            Securedrop_protocol_minimal.Metadata.t_MetadataPublicKey)
+          (Securedrop_protocol_minimal.Traits.f_own_message_auth_pk #v_Sender
+              #FStar.Tactics.Typeclasses.solve
+              sender
+            <:
+            Securedrop_protocol_minimal.Message.t_MessagePublicKey)
         <:
-        Securedrop_protocol_minimal.Metadata.t_MetadataPublicKey)
-      (Alloc.Vec.impl_1__as_slice sender_apke_bytes <: t_Slice u8)
+        Core_models.Result.t_Result Securedrop_protocol_minimal.Metadata.t_MetadataCiphertext
+          Anyhow.t_Error)
+      "Valid Keybundle should allow metadata seal"
   in
   let hax_temp_output:Securedrop_protocol_minimal.Ciphertext.t_Envelope =
     {

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Metadata.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Metadata.fst
@@ -13,6 +13,8 @@ let _ =
   let open Securedrop_protocol_minimal.Primitives.Xwing in
   ()
 
+let v_LEN_METADATA_CIPHERTEXT: usize = mk_usize 1232
+
 /// The recipient's metadata public key (`pk_R^PKE` in the spec).
 type t_MetadataPublicKey =
   | MetadataPublicKey : Securedrop_protocol_minimal.Primitives.Xwing.t_XWingPublicKey
@@ -49,7 +51,7 @@ let impl_MetadataKeyPair__private_key (self: t_MetadataKeyPair) : t_MetadataPriv
 /// ciphertext `c'`.
 type t_MetadataCiphertext = {
   f_c:t_Array u8 (mk_usize 1120);
-  f_cp:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global
+  f_cp:t_Array u8 (mk_usize 1232)
 }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
@@ -64,8 +66,8 @@ let impl_7: Core_models.Clone.t_Clone t_MetadataCiphertext =
 
 /// Total byte length of the ciphertext: encapsulation `c` + AEAD ciphertext `c'`.
 let impl_MetadataCiphertext__len (self: t_MetadataCiphertext) : usize =
-  (Core_models.Slice.impl__len #u8 (self.f_c <: t_Slice u8) <: usize) +!
-  (Alloc.Vec.impl_1__len #u8 #Alloc.Alloc.t_Global self.f_cp <: usize)
+  Securedrop_protocol_minimal.Primitives.Xwing.v_LEN_XWING_SHAREDSECRET_ENCAPS +!
+  v_LEN_METADATA_CIPHERTEXT
 
 /// SD-PKE.KGen: generate a `MetadataKeyPair`.
 /// # Errors
@@ -147,8 +149,9 @@ let impl_MetadataPublicKey__as_bytes (self: t_MetadataPublicKey) : t_Slice u8 =
   Securedrop_protocol_minimal.Primitives.Xwing.impl_XWingPublicKey__as_bytes self._0 <: t_Slice u8
 
 /// SD-PKE.Enc: encrypt message `m` to recipient key `pk_r`, returning `(c, c')`.
-/// `m` is the sender's serialized long-term APKE public key.
-let encrypt (pk_r: t_MetadataPublicKey) (m: t_Slice u8) : t_MetadataCiphertext =
+/// `m` is the sender's long-term APKE public key, which must be serializable.
+let encrypt (pk_r: t_MetadataPublicKey) (m: Securedrop_protocol_minimal.Message.t_MessagePublicKey)
+    : Core_models.Result.t_Result t_MetadataCiphertext Anyhow.t_Error =
   let hpke:Hpke_rs.t_Hpke Hpke_rs_libcrux.t_HpkeLibcrux =
     Hpke_rs.impl_7__new #Hpke_rs_libcrux.t_HpkeLibcrux
       (Hpke_rs.Mode_Base <: Hpke_rs.t_Mode)
@@ -185,33 +188,93 @@ let encrypt (pk_r: t_MetadataPublicKey) (m: t_Slice u8) : t_MetadataCiphertext =
           Rust_primitives.Hax.array_of_list 0 list)
         <:
         t_Slice u8)
-      m
+      (Alloc.Vec.impl_1__as_slice (Securedrop_protocol_minimal.Message.impl_MessagePublicKey__as_bytes
+              m
+            <:
+            Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+        <:
+        t_Slice u8)
       (Core_models.Option.Option_None <: Core_models.Option.t_Option (t_Slice u8))
       (Core_models.Option.Option_None <: Core_models.Option.t_Option (t_Slice u8))
       (Core_models.Option.Option_None <: Core_models.Option.t_Option Hpke_rs.t_HpkePrivateKey)
   in
   let hpke:Hpke_rs.t_Hpke Hpke_rs_libcrux.t_HpkeLibcrux = tmp0 in
-  let
-  (c_vec: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global), (cp: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) =
-    Core_models.Result.impl__expect #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global &
-        Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
-      #Hpke_rs.t_HpkeError
-      out
-      "SD-PKE encryption failed"
-  in
-  let (c: t_Array u8 (mk_usize 1120)):t_Array u8 (mk_usize 1120) =
-    Core_models.Result.impl__expect #(t_Array u8 (mk_usize 1120))
-      #Core_models.Array.t_TryFromSliceError
-      (Core_models.Convert.f_try_into #(t_Slice u8)
+  match
+    out
+    <:
+    Core_models.Result.t_Result
+      (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global & Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+      Hpke_rs.t_HpkeError
+  with
+  | Core_models.Result.Result_Ok (c_vec, cp_vec) ->
+    let
+    (c_vec: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global),
+    (cp_vec: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) =
+      c_vec, cp_vec
+      <:
+      (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global & Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+    in
+    (match
+        Core_models.Convert.f_try_into #(t_Slice u8)
           #(t_Array u8 (mk_usize 1120))
           #FStar.Tactics.Typeclasses.solve
           (Alloc.Vec.impl_1__as_slice #u8 #Alloc.Alloc.t_Global c_vec <: t_Slice u8)
         <:
         Core_models.Result.t_Result (t_Array u8 (mk_usize 1120))
-          Core_models.Array.t_TryFromSliceError)
-      "X-Wing encapsulation output has unexpected length"
-  in
-  { f_c = c; f_cp = cp } <: t_MetadataCiphertext
+          Core_models.Array.t_TryFromSliceError
+      with
+      | Core_models.Result.Result_Ok c ->
+        let (c: t_Array u8 (mk_usize 1120)):t_Array u8 (mk_usize 1120) = c in
+        (match
+            Core_models.Convert.f_try_into #(t_Slice u8)
+              #(t_Array u8 (mk_usize 1232))
+              #FStar.Tactics.Typeclasses.solve
+              (Alloc.Vec.impl_1__as_slice #u8 #Alloc.Alloc.t_Global cp_vec <: t_Slice u8)
+            <:
+            Core_models.Result.t_Result (t_Array u8 (mk_usize 1232))
+              Core_models.Array.t_TryFromSliceError
+          with
+          | Core_models.Result.Result_Ok cp ->
+            let cp:t_Array u8 (mk_usize 1232) = cp in
+            Core_models.Result.Result_Ok ({ f_c = c; f_cp = cp } <: t_MetadataCiphertext)
+            <:
+            Core_models.Result.t_Result t_MetadataCiphertext Anyhow.t_Error
+          | Core_models.Result.Result_Err _ ->
+            let error:Anyhow.t_Error =
+              Anyhow.__private.format_err (Core_models.Fmt.Rt.impl_1__new_const (mk_usize 1)
+                    (let list = ["Unexpected md ciphertext length"] in
+                      FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
+                      Rust_primitives.Hax.array_of_list 1 list)
+                  <:
+                  Core_models.Fmt.t_Arguments)
+            in
+            Core_models.Result.Result_Err (Anyhow.__private.must_use error)
+            <:
+            Core_models.Result.t_Result t_MetadataCiphertext Anyhow.t_Error)
+      | Core_models.Result.Result_Err _ ->
+        let error:Anyhow.t_Error =
+          Anyhow.__private.format_err (Core_models.Fmt.Rt.impl_1__new_const (mk_usize 1)
+                (let list = ["Unexpected md encapsulated secret length"] in
+                  FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
+                  Rust_primitives.Hax.array_of_list 1 list)
+              <:
+              Core_models.Fmt.t_Arguments)
+        in
+        Core_models.Result.Result_Err (Anyhow.__private.must_use error)
+        <:
+        Core_models.Result.t_Result t_MetadataCiphertext Anyhow.t_Error)
+  | Core_models.Result.Result_Err _ ->
+    let error:Anyhow.t_Error =
+      Anyhow.__private.format_err (Core_models.Fmt.Rt.impl_1__new_const (mk_usize 1)
+            (let list = ["Metadata encryption failed"] in
+              FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
+              Rust_primitives.Hax.array_of_list 1 list)
+          <:
+          Core_models.Fmt.t_Arguments)
+    in
+    Core_models.Result.Result_Err (Anyhow.__private.must_use error)
+    <:
+    Core_models.Result.t_Result t_MetadataCiphertext Anyhow.t_Error
 
 /// SD-PKE.Dec: decrypt `(c, c')` using recipient key `sk_r`, returning message `m`.
 /// # Errors
@@ -249,7 +312,7 @@ let decrypt (sk_r: t_MetadataPrivateKey) (ct: t_MetadataCiphertext)
             FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 0);
             Rust_primitives.Hax.array_of_list 0 list)
           <:
-          t_Slice u8) (Alloc.Vec.impl_1__as_slice ct.f_cp <: t_Slice u8)
+          t_Slice u8) (ct.f_cp <: t_Slice u8)
         (Core_models.Option.Option_None <: Core_models.Option.t_Option (t_Slice u8))
         (Core_models.Option.Option_None <: Core_models.Option.t_Option (t_Slice u8))
         (Core_models.Option.Option_None <: Core_models.Option.t_Option Hpke_rs.t_HpkePublicKey)

--- a/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
+++ b/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
@@ -57,7 +57,9 @@ where
     let sender_apke_bytes = sender.own_message_auth_pk().as_bytes();
 
     // spec: ct^PKE = SD-PKE.Enc(pk_R^PKE, pk_S^APKE)
-    let ct_pke = metadata::encrypt(recipient.message_metadata_pk(), &sender_apke_bytes);
+    // TODO! Refactor to return Result<T, E> instead of panicking at failed metadata seal
+    let ct_pke = metadata::encrypt(recipient.message_metadata_pk(), &sender_apke_bytes)
+        .expect("Valid Keybundle should allow metadata seal");
 
     Envelope {
         ct_apke,                              // spec: ct^APKE

--- a/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
+++ b/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
@@ -54,12 +54,13 @@ where
             .expect("Failed to generate shared secret");
 
     // spec: pk_S^APKE - sender's long-term APKE public key
-    let sender_apke_bytes = sender.own_message_auth_pk().as_bytes();
-
     // spec: ct^PKE = SD-PKE.Enc(pk_R^PKE, pk_S^APKE)
-    // TODO! Refactor to return Result<T, E> instead of panicking at failed metadata seal
-    let ct_pke = metadata::encrypt(recipient.message_metadata_pk(), &sender_apke_bytes)
-        .expect("Valid Keybundle should allow metadata seal");
+    // TODO: Refactor to return Result<T, E> instead of panicking at failed metadata seal
+    let ct_pke = metadata::encrypt(
+        recipient.message_metadata_pk(),
+        &sender.own_message_auth_pk(),
+    )
+    .expect("Valid Keybundle should allow metadata seal");
 
     Envelope {
         ct_apke,                              // spec: ct^APKE

--- a/securedrop-protocol/protocol-minimal/src/metadata.rs
+++ b/securedrop-protocol/protocol-minimal/src/metadata.rs
@@ -15,16 +15,20 @@
 //!     return m
 //! ```
 
-use crate::primitives::provider::hpke_rs::{
-    Aes256Gcm, HkdfSha256, Hpke, HpkeLibcrux, Mode, XWingDraft06,
+use crate::{
+    message::MessagePublicKey,
+    primitives::provider::hpke_rs::{Aes256Gcm, HkdfSha256, Hpke, HpkeLibcrux, Mode, XWingDraft06},
 };
 use alloc::vec::Vec;
-use anyhow::Error;
 use rand_core::{CryptoRng, RngCore};
 
 use crate::primitives::xwing::{
     LEN_XWING_SHAREDSECRET_ENCAPS, XWingPrivateKey, XWingPublicKey, generate_xwing_keypair,
 };
+
+// TODO: maybe needs a better location
+// DHAKEM_PKLEN + MLKEM768PK_LEN + AEAD_TAG_LEN = 32 + 1184 + 16
+pub(crate) const LEN_METADATA_CIPHERTEXT: usize = 1232;
 
 /// The recipient's metadata public key (`pk_R^PKE` in the spec).
 #[derive(Debug, Clone)]
@@ -58,13 +62,15 @@ pub struct MetadataCiphertext {
     /// HPKE encapsulation output (`c` in the spec)
     pub(crate) c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS],
     /// HPKE AEAD ciphertext (`c'` / `cp` in the spec)
-    pub(crate) cp: Vec<u8>,
+    pub(crate) cp: [u8; LEN_METADATA_CIPHERTEXT],
 }
 
 impl MetadataCiphertext {
     /// Total byte length of the ciphertext: encapsulation `c` + AEAD ciphertext `c'`.
     pub fn len(&self) -> usize {
-        self.c.len() + self.cp.len()
+        // TODO: hax_lib::refine(self.c.len() == LEN_XWING_SHAREDSECRET_ENCAPS && self.cp.len() == LEN_METADATA_CIPHERTEXT)
+        // This isn't the best, but hax is struggling to parse c.len()
+        LEN_XWING_SHAREDSECRET_ENCAPS + LEN_METADATA_CIPHERTEXT
     }
 }
 
@@ -115,21 +121,32 @@ impl MetadataPrivateKey {
 
 /// SD-PKE.Enc: encrypt message `m` to recipient key `pk_r`, returning `(c, c')`.
 ///
-/// `m` is the sender's serialized long-term APKE public key.
+/// `m` is the sender's long-term APKE public key, which must be serializable.
 pub(crate) fn encrypt(
     pk_r: &MetadataPublicKey,
-    m: &[u8],
+    m: &MessagePublicKey,
 ) -> Result<MetadataCiphertext, anyhow::Error> {
     let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
     let pk_r_hpke = pk_r.0.clone().into();
 
     // MetadataPublicKey always holds a valid XWing key, so seal should not fail.
-    let (c_vec, cp) = hpke
-        .seal(&pk_r_hpke, b"", b"", m, None, None, None)
-        .map_err(|e| anyhow::anyhow!("Metadata seal failed: {e}"))?;
+    let (c_vec, cp_vec) = match hpke.seal(&pk_r_hpke, b"", b"", &m.as_bytes(), None, None, None) {
+        Ok((c_vec, cp_vec)) => (c_vec, cp_vec),
+        Err(_) => return Err(anyhow::anyhow!("Metadata encryption failed")),
+    };
 
-    // XWing will always produce this length ciphertext, so this .expect is fine.
-    let c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS] = c_vec.as_slice().try_into()?;
+    // XWing will always produce same length ciphertext
+    let c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS] = match c_vec.as_slice().try_into() {
+        Ok(c) => c,
+        Err(_) => {
+            return Err(anyhow::anyhow!("Unexpected md encapsulated secret length"));
+        }
+    };
+
+    let cp = match cp_vec.as_slice().try_into() {
+        Ok(cp) => cp,
+        Err(_) => return Err(anyhow::anyhow!("Unexpected md ciphertext length")),
+    };
 
     Ok(MetadataCiphertext { c, cp })
 }
@@ -153,9 +170,11 @@ pub fn decrypt(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::primitives::dh_akem::DH_AKEM_PUBLIC_KEY_LEN;
+    use crate::primitives::mlkem::MLKEM768_PUBLIC_KEY_LEN;
     use proptest::prelude::*;
     use rand_chacha::ChaCha20Rng;
-    use rand_core::SeedableRng;
+    use rand_core::{SeedableRng, TryRng};
 
     fn get_rng() -> ChaCha20Rng {
         let mut seed = [0u8; 32];
@@ -169,10 +188,15 @@ mod tests {
             let mut rng = get_rng();
             let kp = keygen(&mut rng).expect("KGen failed");
 
+            let mut fake_key_bytes: [u8; DH_AKEM_PUBLIC_KEY_LEN + MLKEM768_PUBLIC_KEY_LEN] = [0u8; DH_AKEM_PUBLIC_KEY_LEN + MLKEM768_PUBLIC_KEY_LEN];
+            rng.try_fill_bytes(&mut fake_key_bytes);
+
+            let m = MessagePublicKey::from_bytes(&fake_key_bytes).unwrap();
+
             let ct = encrypt(kp.public_key(), &m);
             let decrypted = decrypt(kp.private_key(), &ct.unwrap()).expect("Decryption failed");
 
-            prop_assert_eq!(m, decrypted);
+            prop_assert_eq!(m.as_bytes(), decrypted);
         }
     }
 
@@ -181,8 +205,13 @@ mod tests {
         let mut rng = get_rng();
         let kp = keygen(&mut rng).expect("KGen failed");
         let wrong_kp = keygen(&mut rng).expect("KGen failed");
+        let mut fake_key_bytes: [u8; DH_AKEM_PUBLIC_KEY_LEN + MLKEM768_PUBLIC_KEY_LEN] =
+            [0u8; DH_AKEM_PUBLIC_KEY_LEN + MLKEM768_PUBLIC_KEY_LEN];
+        rng.try_fill_bytes(&mut fake_key_bytes);
 
-        let ct = encrypt(kp.public_key(), b"some sender apke key bytes");
+        let m = MessagePublicKey::from_bytes(&fake_key_bytes).unwrap();
+
+        let ct = encrypt(kp.public_key(), &m);
         assert!(decrypt(wrong_kp.private_key(), &ct.unwrap()).is_err());
     }
 }

--- a/securedrop-protocol/protocol-minimal/src/metadata.rs
+++ b/securedrop-protocol/protocol-minimal/src/metadata.rs
@@ -116,22 +116,22 @@ impl MetadataPrivateKey {
 /// SD-PKE.Enc: encrypt message `m` to recipient key `pk_r`, returning `(c, c')`.
 ///
 /// `m` is the sender's serialized long-term APKE public key.
-pub fn encrypt(pk_r: &MetadataPublicKey, m: &[u8]) -> MetadataCiphertext {
+pub(crate) fn encrypt(
+    pk_r: &MetadataPublicKey,
+    m: &[u8],
+) -> Result<MetadataCiphertext, anyhow::Error> {
     let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
     let pk_r_hpke = pk_r.0.clone().into();
 
-    // MetadataPublicKey always holds a valid XWing key, so seal cannot fail.
+    // MetadataPublicKey always holds a valid XWing key, so seal should not fail.
     let (c_vec, cp) = hpke
         .seal(&pk_r_hpke, b"", b"", m, None, None, None)
-        .expect("SD-PKE encryption failed");
+        .map_err(|e| anyhow::anyhow!("Metadata seal failed: {e}"))?;
 
     // XWing will always produce this length ciphertext, so this .expect is fine.
-    let c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS] = c_vec
-        .as_slice()
-        .try_into()
-        .expect("X-Wing encapsulation output has unexpected length");
+    let c: [u8; LEN_XWING_SHAREDSECRET_ENCAPS] = c_vec.as_slice().try_into()?;
 
-    MetadataCiphertext { c, cp }
+    Ok(MetadataCiphertext { c, cp })
 }
 
 /// SD-PKE.Dec: decrypt `(c, c')` using recipient key `sk_r`, returning message `m`.
@@ -139,7 +139,10 @@ pub fn encrypt(pk_r: &MetadataPublicKey, m: &[u8]) -> MetadataCiphertext {
 /// # Errors
 ///
 /// Returns an error if HPKE decryption fails.
-pub fn decrypt(sk_r: &MetadataPrivateKey, ct: &MetadataCiphertext) -> Result<Vec<u8>, Error> {
+pub fn decrypt(
+    sk_r: &MetadataPrivateKey,
+    ct: &MetadataCiphertext,
+) -> Result<Vec<u8>, anyhow::Error> {
     let hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
     let sk_r_hpke = sk_r.0.clone().into();
 
@@ -167,7 +170,7 @@ mod tests {
             let kp = keygen(&mut rng).expect("KGen failed");
 
             let ct = encrypt(kp.public_key(), &m);
-            let decrypted = decrypt(kp.private_key(), &ct).expect("Decryption failed");
+            let decrypted = decrypt(kp.private_key(), &ct.unwrap()).expect("Decryption failed");
 
             prop_assert_eq!(m, decrypted);
         }
@@ -180,6 +183,6 @@ mod tests {
         let wrong_kp = keygen(&mut rng).expect("KGen failed");
 
         let ct = encrypt(kp.public_key(), b"some sender apke key bytes");
-        assert!(decrypt(wrong_kp.private_key(), &ct).is_err());
+        assert!(decrypt(wrong_kp.private_key(), &ct.unwrap()).is_err());
     }
 }


### PR DESCRIPTION
Towards #279 

- Refactor Metadata to take pubkey type instead of bytes type, strictly enforcing its length. Adjust proptest
- Refactor hax-unfriendly syntax (`map_err(||_|)`....) into match statements
- wrap md type return in Result<T, E> 
- drop metadara.rs from HAX_ADMITS
- update fst for metadata, encrypt_decrypt