### PR TITLE
soundness(`MetadataCiphertext.len`): just return field lengths

### DIFF
--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Metadata.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Metadata.fst
@@ -66,8 +66,8 @@ let impl_7: Core_models.Clone.t_Clone t_MetadataCiphertext =
 
 /// Total byte length of the ciphertext: encapsulation `c` + AEAD ciphertext `c'`.
 let impl_MetadataCiphertext__len (self: t_MetadataCiphertext) : usize =
-  Securedrop_protocol_minimal.Primitives.Xwing.v_LEN_XWING_SHAREDSECRET_ENCAPS +!
-  v_LEN_METADATA_CIPHERTEXT
+  (Core_models.Slice.impl__len #u8 (self.f_c <: t_Slice u8) <: usize) +!
+  (Core_models.Slice.impl__len #u8 (self.f_cp <: t_Slice u8) <: usize)
 
 /// SD-PKE.KGen: generate a `MetadataKeyPair`.
 /// # Errors

--- a/securedrop-protocol/protocol-minimal/src/metadata.rs
+++ b/securedrop-protocol/protocol-minimal/src/metadata.rs
@@ -68,9 +68,7 @@ pub struct MetadataCiphertext {
 impl MetadataCiphertext {
     /// Total byte length of the ciphertext: encapsulation `c` + AEAD ciphertext `c'`.
     pub fn len(&self) -> usize {
-        // TODO: hax_lib::refine(self.c.len() == LEN_XWING_SHAREDSECRET_ENCAPS && self.cp.len() == LEN_METADATA_CIPHERTEXT)
-        // This isn't the best, but hax is struggling to parse c.len()
-        LEN_XWING_SHAREDSECRET_ENCAPS + LEN_METADATA_CIPHERTEXT
+        self.c.len() + self.cp.len()
     }
 }
 


### PR DESCRIPTION
@rocodes, this is the only (albeit commented-out) instance of `hax_lib::refine` I could find.  I don't see that it needs to be a refinement at all, rather than just returning the lengths of the Rust types, which hax extracts to F* types just fine.  Let me know if I'm missing something or if there's another candidate for refinement you'd like me to look at.