### PR TITLE
[wip] demo: show in-memory source "state"

### DIFF
--- a/securedrop-protocol/Cargo.lock
+++ b/securedrop-protocol/Cargo.lock
@@ -1860,6 +1860,8 @@ dependencies = [
  "reqwest",
  "securedrop-protocol-minimal",
  "serde",
+ "serde_json",
+ "shlex 1.3.0",
 ]
 
 [[package]]

--- a/securedrop-protocol/source-cli/Cargo.toml
+++ b/securedrop-protocol/source-cli/Cargo.toml
@@ -19,3 +19,5 @@ hex = "0.4"
 rand = "0.10"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+shlex = "1"

--- a/securedrop-protocol/source-cli/src/identity.rs
+++ b/securedrop-protocol/source-cli/src/identity.rs
@@ -3,7 +3,7 @@ use securedrop_protocol_minimal::{Source, UserPublic};
 
 use crate::util::read_passphrase;
 
-pub(crate) fn generate() -> Result<()> {
+pub(crate) fn generate() -> Result<Source> {
     let source = Source::new(rand::rng());
     let mnemonic = source.passphrase();
     let fetch_pk = source.public().fetch_pk().into_bytes();
@@ -14,7 +14,7 @@ pub(crate) fn generate() -> Result<()> {
     println!("  {mnemonic}");
     println!();
     println!("Fetch public key: {}", hex(&fetch_pk));
-    Ok(())
+    Ok(source)
 }
 
 pub(crate) fn show() -> Result<()> {

--- a/securedrop-protocol/source-cli/src/main.rs
+++ b/securedrop-protocol/source-cli/src/main.rs
@@ -2,11 +2,16 @@
 
 mod fetch;
 mod identity;
+mod state;
 mod submit;
 mod util;
 
+use std::io::{self, Write};
+
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+
+use crate::state::State;
 
 #[derive(Parser)]
 #[command(name = "source-cli", about = "Demo SecureDrop source client")]
@@ -22,7 +27,7 @@ enum Command {
     /// Generate a new source identity and print its recovery passphrase.
     Generate,
     /// Rederive a source identity from its passphrase and print its public keys.
-    Show,
+    ShowSelf,
     /// Submit a message to every enrolled journalist of a newsroom.
     Submit {
         /// Newsroom server URL.
@@ -44,17 +49,80 @@ enum Command {
         #[arg(long = "fpf-vk")]
         fpf_vk: String,
     },
+    /// Show everything the source has access to (in-memory state).
+    /// This corresponds to the information that is available to display
+    /// in the UI for a given source.
+    ShowState {},
+    Exit {},
 }
 
 fn main() -> Result<()> {
-    match Cli::parse().command {
-        Command::Generate => identity::generate(),
-        Command::Show => identity::show(),
-        Command::Submit {
-            server,
-            fpf_vk,
-            message,
-        } => submit::submit(&server, &fpf_vk, &message),
-        Command::Fetch { server, fpf_vk } => fetch::fetch(&server, &fpf_vk),
+    let mut in_memory_state: State = State::new();
+
+    println!("SecureDrop Protocol Source demo");
+    println!("(actions: generate, show-self, submit, fetch, show-state, help, exit)");
+
+    loop {
+        print!("source> ");
+        io::stdout().flush()?;
+
+        let mut line = String::new();
+        io::stdin().read_line(&mut line)?;
+
+        let line = line.trim();
+
+        if line.is_empty() {
+            continue;
+        }
+
+        // parse shell quotes
+        let argv = match shlex::split(line) {
+            Some(mut args) => {
+                args.insert(0, "source-cli".to_string());
+                args
+            }
+            None => {
+                eprintln!("Could not parse command");
+                continue;
+            }
+        };
+
+        let cli = match Cli::try_parse_from(argv) {
+            Ok(cli) => cli,
+            Err(err) => {
+                eprintln!("{err}");
+                continue;
+            }
+        };
+
+        let result = match cli.command {
+            Command::Generate => {
+                let s = state::SourcePretty(identity::generate()?);
+                in_memory_state.source = Some(s);
+
+                Ok(())
+            }
+            Command::ShowSelf => identity::show(),
+            Command::Submit {
+                server,
+                fpf_vk,
+                message,
+            } => {
+                in_memory_state.fpf_vk = Some(fpf_vk.clone());
+                in_memory_state.server = Some(server.clone());
+
+                submit::submit(&server, &fpf_vk, &message)
+            }
+            Command::Fetch { server, fpf_vk } => { 
+                fetch::fetch(&server, &fpf_vk)
+            },
+            Command::ShowState {} => in_memory_state.show_state(),
+            Command::Exit {} => break,
+        };
+
+        if let Err(err) = result {
+            eprintln!("{err}");
+        }
     }
+    Ok(())
 }

--- a/securedrop-protocol/source-cli/src/main.rs
+++ b/securedrop-protocol/source-cli/src/main.rs
@@ -113,9 +113,7 @@ fn main() -> Result<()> {
 
                 submit::submit(&server, &fpf_vk, &message)
             }
-            Command::Fetch { server, fpf_vk } => { 
-                fetch::fetch(&server, &fpf_vk)
-            },
+            Command::Fetch { server, fpf_vk } => fetch::fetch(&server, &fpf_vk),
             Command::ShowState {} => in_memory_state.show_state(),
             Command::Exit {} => break,
         };

--- a/securedrop-protocol/source-cli/src/state.rs
+++ b/securedrop-protocol/source-cli/src/state.rs
@@ -1,0 +1,70 @@
+use securedrop_protocol_minimal::{JournalistPublic, JournalistPublicView, Source, UserPublic};
+use serde::{
+    Serialize,
+    ser::{SerializeStruct, Serializer},
+};
+
+pub struct JournalistPretty(pub JournalistPublicView);
+
+impl Serialize for JournalistPretty {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let j = &self.0;
+        let mut s = serializer.serialize_struct("Journalist", 4)?;
+
+        s.serialize_field("vk", &j.verifying_key().into_bytes())?;
+        s.serialize_field("fetch", &j.fetch_pk().into_bytes())?;
+        s.serialize_field("apke_longterm", &j.message_auth_pk().as_bytes())?;
+
+        s.end()
+    }
+}
+
+pub struct SourcePretty(pub Source);
+
+impl Serialize for SourcePretty {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let source = &self.0;
+        let mut s = serializer.serialize_struct("Source", 4)?;
+
+        s.serialize_field("passphrase", &source.passphrase())?;
+        s.end()
+    }
+}
+
+#[derive(Default, Serialize)]
+pub struct State {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fpf_vk: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<SourcePretty>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery_phrase: Option<String>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub recipients: Vec<JournalistPretty>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub replies: Vec<String>,
+}
+
+impl State {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn show_state(&self) -> anyhow::Result<()> {
+        println!("{}", serde_json::to_string_pretty(self)?);
+        Ok(())
+    }
+}

--- a/securedrop-protocol/source-cli/src/state.rs
+++ b/securedrop-protocol/source-cli/src/state.rs
@@ -1,10 +1,22 @@
-use securedrop_protocol_minimal::{JournalistPublic, JournalistPublicView, Source, UserPublic};
+use securedrop_protocol_minimal::{
+    JournalistPublic, JournalistPublicView, Source, UserPublic, UserSecret,
+};
 use serde::{
     Serialize,
     ser::{SerializeStruct, Serializer},
 };
 
 pub struct JournalistPretty(pub JournalistPublicView);
+
+pub(crate) fn serialize_long_key(bytes: &Vec<u8>) -> String {
+    if bytes.len() <= 32 {
+        hex::encode(bytes)
+    } else {
+        let first = hex::encode(&bytes[..16]);
+        let last = hex::encode(&bytes[bytes.len() - 16..]);
+        format!("{}...{}", first, last)
+    }
+}
 
 impl Serialize for JournalistPretty {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -14,9 +26,14 @@ impl Serialize for JournalistPretty {
         let j = &self.0;
         let mut s = serializer.serialize_struct("Journalist", 4)?;
 
-        s.serialize_field("vk", &j.verifying_key().into_bytes())?;
-        s.serialize_field("fetch", &j.fetch_pk().into_bytes())?;
-        s.serialize_field("apke_longterm", &j.message_auth_pk().as_bytes())?;
+        s.serialize_field("vk", &hex::encode(&j.verifying_key().into_bytes()))?;
+        s.serialize_field("fetch", &hex::encode(&j.fetch_pk().into_bytes()))?;
+
+        let apke = serialize_long_key(&j.message_auth_pk().as_bytes());
+        s.serialize_field("apke_longterm_pk", &apke)?;
+
+        let md = serialize_long_key(&j.message_metadata_pk().as_bytes().to_vec());
+        s.serialize_field("metadata_pk", &md)?;
 
         s.end()
     }
@@ -33,6 +50,14 @@ impl Serialize for SourcePretty {
         let mut s = serializer.serialize_struct("Source", 4)?;
 
         s.serialize_field("passphrase", &source.passphrase())?;
+
+        let apke = serialize_long_key(&source.own_message_auth_pk().as_bytes());
+        s.serialize_field("apke_longterm_pk", &apke)?;
+        s.serialize_field(
+            "fetch pk",
+            &hex::encode(&source.fetch_keypair().1.into_bytes()),
+        )?;
+
         s.end()
     }
 }

--- a/securedrop-protocol/source-cli/src/submit.rs
+++ b/securedrop-protocol/source-cli/src/submit.rs
@@ -11,6 +11,21 @@ struct MessageSubmitResponse {
     message_id: String,
 }
 
+pub(crate) fn welcome(server: &str) -> Result<WelcomeBundle, anyhow::Error> {
+    let client = reqwest::blocking::Client::new();
+
+    // Fetch the newsroom welcome bundle again (we can cache this in the future)
+    let wb: WelcomeBundle = client
+        .get(format!("{server}/welcome"))
+        .send()
+        .with_context(|| format!("fetching {server}/welcome"))?
+        .error_for_status()
+        .context("newsroom rejected welcome request")?
+        .json()?;
+
+    Ok(wb)
+}
+
 pub(crate) fn submit(server: &str, fpf_vk_hex: &str, message: &str) -> Result<()> {
     let fpf_vk = parse_fpf_vk(fpf_vk_hex)?;
 
@@ -21,13 +36,8 @@ pub(crate) fn submit(server: &str, fpf_vk_hex: &str, message: &str) -> Result<()
     let client = reqwest::blocking::Client::new();
 
     // Fetch the newsroom welcome bundle again (we can cache this in the future)
-    let welcome: WelcomeBundle = client
-        .get(format!("{server}/welcome"))
-        .send()
-        .with_context(|| format!("fetching {server}/welcome"))?
-        .error_for_status()
-        .context("newsroom rejected welcome request")?
-        .json()?;
+    let welcome: WelcomeBundle = welcome(server)?;
+
     source
         .handle_welcome(&welcome, &fpf_vk)
         .context("welcome bundle failed verification against the pinned FPF key")?;


### PR DESCRIPTION
(For discussion purposes) refs https://github.com/freedomofpress/securedrop-protocol/pull/270#issuecomment-4858700709

refactors the source demo a bit so it is more like a repl.  the source gets a prompt and can call `show-state` to view the info it currently has access to.  This is an in-memory representation that is meant to mimic the limitations of what the source can access/store for people who are thinking about how to implement the UI or wrapping application. 

I'm not totally sold on it (vs just printing out a string after each operation and keeping them as originally written), but if people think the concept is useful, I can add to it (it isn't consistently implemented for all cli operations).

example:

```
$ cargo run --bin source-cli help
SecureDrop Protocol Source demo
(actions: generate, show-self, submit, fetch, show-state, help, exit)
source> show-state
{}
source> generate
New source identity

Recovery passphrase (write this down!!):
  end grid tourist rose rib bread evoke era weekend lyrics report impulse

Fetch public key: adcbcf23e044c3e87e895682a5b33fcace657f7359dd9f0a66a9434da936796c
source> show-state
{
  "source": {
    "passphrase": "end grid tourist rose rib bread evoke era weekend lyrics report impulse",
    "apke_longterm_pk": "67bd4bef66c829b888384b2603e46835...cc9bef04e3e1b19839c4fcb3a895f5d3",
    "fetch pk": "adcbcf23e044c3e87e895682a5b33fcace657f7359dd9f0a66a9434da936796c"
  }
}
source> 
```
