### PR TITLE
Replace aesgcm256 with chacha20poly1305 

### DIFF
--- a/SOUNDNESS.md
+++ b/SOUNDNESS.md
@@ -100,8 +100,7 @@ verification status:
 - `libcrux-kem` and `libcrux-traits` - not verified
 - `libcrux-ecdh` and `libcrux-hkdf` - verified by calling out to code
   generated from the HACL\* project
-- `libcrux-aead` - `ChaCha20Poly1305` is verified (via HACL\*), but AES-GCM is
-  not, and we do rely on AES-GCM
+- `libcrux-aead` - `ChaCha20Poly1305` is verified (via HACL\*), but the wrapper crate is not Hax extraction-compatible.
 
 [hacl]: https://hacl-star.github.io/
 [hpke-rs]: https://github.com/cryspen/hpke-rs

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -327,7 +327,7 @@ $\text{SD-PKE}[\text{KEM}_H, \text{AEAD}, \text{KS}]$ instantiates [HPKE `Base`
 mode][RFC 9180 §5.1.1] with:
 
 - $\text{KEM}_H =$ X-Wing
-- $\text{AEAD} =$ AES-GCM
+- $\text{AEAD} =$ ChaCha20Poly1305
 - $\text{KS} =$ HPKE's [`KeySchedule()`][RFC 9180 §5.1] with [HKDF-SHA256][RFC 9180 §7.2]
 
 | Syntax                                                | Description                                                  |
@@ -377,7 +377,7 @@ $\text{pskAPKE}[\text{AKEM}, \text{KS}, \text{AEAD}]$ instantiates [HPKE
 
 - $\text{AKEM}$ as above
 - $\text{KS} =$ HPKE's [`KeySchedule()`][RFC 9180 §5.1] with [HKDF-SHA256][RFC 9180 §7.2]
-- $\text{AEAD} =$ AES-GCM
+- $\text{AEAD} =$ ChaCha20Poly1305
 
 | Syntax                                                                              | Description                                                                                           |
 | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Message.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Message.fst
@@ -453,7 +453,7 @@ let auth_enc
       (Hpke_rs.Mode_AuthPsk <: Hpke_rs.t_Mode)
       (Hpke_rs_crypto.Types.KemAlgorithm_DhKem25519 <: Hpke_rs_crypto.Types.t_KemAlgorithm)
       (Hpke_rs_crypto.Types.KdfAlgorithm_HkdfSha256 <: Hpke_rs_crypto.Types.t_KdfAlgorithm)
-      (Hpke_rs_crypto.Types.AeadAlgorithm_Aes256Gcm <: Hpke_rs_crypto.Types.t_AeadAlgorithm)
+      (Hpke_rs_crypto.Types.AeadAlgorithm_ChaCha20Poly1305 <: Hpke_rs_crypto.Types.t_AeadAlgorithm)
   in
   let randomness:t_Array u8 (mk_usize 32) = Rust_primitives.Hax.repeat (mk_u8 0) (mk_usize 32) in
   let (tmp0: v_R), (tmp1: t_Array u8 (mk_usize 32)) =
@@ -642,7 +642,7 @@ let auth_dec
       (Hpke_rs.Mode_AuthPsk <: Hpke_rs.t_Mode)
       (Hpke_rs_crypto.Types.KemAlgorithm_DhKem25519 <: Hpke_rs_crypto.Types.t_KemAlgorithm)
       (Hpke_rs_crypto.Types.KdfAlgorithm_HkdfSha256 <: Hpke_rs_crypto.Types.t_KdfAlgorithm)
-      (Hpke_rs_crypto.Types.AeadAlgorithm_Aes256Gcm <: Hpke_rs_crypto.Types.t_AeadAlgorithm)
+      (Hpke_rs_crypto.Types.AeadAlgorithm_ChaCha20Poly1305 <: Hpke_rs_crypto.Types.t_AeadAlgorithm)
   in
   match
     Core_models.Result.impl__map_err #(t_Array u8 (mk_usize 32))

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Metadata.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Metadata.fst
@@ -349,7 +349,7 @@ let encrypt (pk_r: t_MetadataPublicKey) (m: Securedrop_protocol_minimal.Message.
       (Hpke_rs.Mode_Base <: Hpke_rs.t_Mode)
       (Hpke_rs_crypto.Types.KemAlgorithm_XWingDraft06 <: Hpke_rs_crypto.Types.t_KemAlgorithm)
       (Hpke_rs_crypto.Types.KdfAlgorithm_HkdfSha256 <: Hpke_rs_crypto.Types.t_KdfAlgorithm)
-      (Hpke_rs_crypto.Types.AeadAlgorithm_Aes256Gcm <: Hpke_rs_crypto.Types.t_AeadAlgorithm)
+      (Hpke_rs_crypto.Types.AeadAlgorithm_ChaCha20Poly1305 <: Hpke_rs_crypto.Types.t_AeadAlgorithm)
   in
   let pk_r_hpke:Hpke_rs.t_HpkePublicKey =
     Core_models.Convert.f_into #Securedrop_protocol_minimal.Primitives.Xwing.t_XWingPublicKey
@@ -478,7 +478,7 @@ let decrypt (sk_r: t_MetadataPrivateKey) (ct: t_MetadataCiphertext)
       (Hpke_rs.Mode_Base <: Hpke_rs.t_Mode)
       (Hpke_rs_crypto.Types.KemAlgorithm_XWingDraft06 <: Hpke_rs_crypto.Types.t_KemAlgorithm)
       (Hpke_rs_crypto.Types.KdfAlgorithm_HkdfSha256 <: Hpke_rs_crypto.Types.t_KdfAlgorithm)
-      (Hpke_rs_crypto.Types.AeadAlgorithm_Aes256Gcm <: Hpke_rs_crypto.Types.t_AeadAlgorithm)
+      (Hpke_rs_crypto.Types.AeadAlgorithm_ChaCha20Poly1305 <: Hpke_rs_crypto.Types.t_AeadAlgorithm)
   in
   let sk_r_hpke:Hpke_rs.t_HpkePrivateKey =
     Core_models.Convert.f_into #Securedrop_protocol_minimal.Primitives.Xwing.t_XWingPrivateKey

--- a/securedrop-protocol/protocol-minimal/src/message.rs
+++ b/securedrop-protocol/protocol-minimal/src/message.rs
@@ -21,7 +21,8 @@
 //! ```
 
 use crate::primitives::provider::hpke_rs::{
-    Aes256Gcm, DhKem25519, HkdfSha256, Hpke, HpkeLibcrux, HpkePrivateKey, HpkePublicKey, Mode,
+    ChaCha20Poly1305, DhKem25519, HkdfSha256, Hpke, HpkeLibcrux, HpkePrivateKey, HpkePublicKey,
+    Mode,
 };
 use crate::primitives::provider::kem::MlKem768;
 use crate::primitives::provider::traits::OwnedKem as Kem;
@@ -272,7 +273,8 @@ pub fn auth_enc<R: RngCore + CryptoRng>(
     ad: &[u8],
     info: &[u8],
 ) -> Result<MessageCiphertext, Error> {
-    let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::AuthPsk, DhKem25519, HkdfSha256, Aes256Gcm);
+    let mut hpke =
+        Hpke::<HpkeLibcrux>::new(Mode::AuthPsk, DhKem25519, HkdfSha256, ChaCha20Poly1305);
 
     let mut randomness = [0u8; LEN_MLKEM_ENCAPS_RAND];
     rng.fill_bytes(&mut randomness);
@@ -327,7 +329,7 @@ pub fn auth_dec(
     ad: &[u8],
     info: &[u8],
 ) -> Result<Vec<u8>, Error> {
-    let hpke = Hpke::<HpkeLibcrux>::new(Mode::AuthPsk, DhKem25519, HkdfSha256, Aes256Gcm);
+    let hpke = Hpke::<HpkeLibcrux>::new(Mode::AuthPsk, DhKem25519, HkdfSha256, ChaCha20Poly1305);
 
     // K2 = KEM_PQ.Decap(skR=skR2, enc=c2)
     let k2 = MlKem768::decaps(&ct.c2, sk.mlkem.as_bytes())

--- a/securedrop-protocol/protocol-minimal/src/metadata.rs
+++ b/securedrop-protocol/protocol-minimal/src/metadata.rs
@@ -17,7 +17,9 @@
 
 use crate::{
     message::MessagePublicKey,
-    primitives::provider::hpke_rs::{Aes256Gcm, HkdfSha256, Hpke, HpkeLibcrux, Mode, XWingDraft06},
+    primitives::provider::hpke_rs::{
+        ChaCha20Poly1305, HkdfSha256, Hpke, HpkeLibcrux, Mode, XWingDraft06,
+    },
 };
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -230,7 +232,7 @@ pub(crate) fn encrypt(
     pk_r: &MetadataPublicKey,
     m: &MessagePublicKey,
 ) -> Result<MetadataCiphertext, anyhow::Error> {
-    let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
+    let mut hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, ChaCha20Poly1305);
     let pk_r_hpke = pk_r.0.clone().into();
 
     // MetadataPublicKey always holds a valid XWing key, so seal should not fail.
@@ -264,7 +266,7 @@ pub fn decrypt(
     sk_r: &MetadataPrivateKey,
     ct: &MetadataCiphertext,
 ) -> Result<Vec<u8>, anyhow::Error> {
-    let hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, Aes256Gcm);
+    let hpke = Hpke::<HpkeLibcrux>::new(Mode::Base, XWingDraft06, HkdfSha256, ChaCha20Poly1305);
     let sk_r_hpke = sk_r.0.clone().into();
 
     hpke.open(&ct.c, &sk_r_hpke, b"", b"", &ct.cp, None, None, None)

--- a/securedrop-protocol/protocol-minimal/src/primitives/provider.rs
+++ b/securedrop-protocol/protocol-minimal/src/primitives/provider.rs
@@ -172,7 +172,7 @@ pub mod hpke_rs {
 
     #[cfg_attr(hax, hax_lib::opaque)]
     pub(crate) use hpke_rs::{
-        Hpke, HpkePrivateKey, HpkePublicKey, Mode, hpke_types::AeadAlgorithm::Aes256Gcm,
+        Hpke, HpkePrivateKey, HpkePublicKey, Mode, hpke_types::AeadAlgorithm::ChaCha20Poly1305,
         hpke_types::KdfAlgorithm::HkdfSha256, hpke_types::KemAlgorithm::DhKem25519,
         hpke_types::KemAlgorithm::XWingDraft06, libcrux::HpkeLibcrux,
     };
@@ -183,7 +183,6 @@ pub mod constants {
     // Message ID (uuid) and KMID
     #[cfg_attr(hax, hax_lib::opaque)]
     pub(crate) const LEN_MESSAGE_ID: usize = 16;
-    // TODO: this will be aes-gcm and use AES GCM TagSize
     // TODO: current implementation prepends the nonce to the encrypted message.
     // Recheck this when switching implementations.
     #[cfg_attr(hax, hax_lib::opaque)]


### PR DESCRIPTION
Closes #226 

- Replace aes with chachapoly in hpke operations
- Update fst
- Replace references in docs, include note about libcrux chachapoly crate (hacl* but wrapper crate is not hax compatible)
- note: `cargo tree` tells us we still depend on the libcrux aes crate hpke-rs-libcrux.

## Test plan
- [ ] Visual review
- [ ] CI