### PR TITLE
Fix build wasm

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,6 +87,10 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt,clippy
+      # Swatinem/rust-cache@v2.8.0
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
+        with:
+          prefix-key: ${{ hashFiles('securedrop-protocol/bench/Makefile') }}
       - run: make clippy
 
   check_wasm_bindgen:
@@ -120,6 +124,7 @@ jobs:
   build_wasm:
     name: wasm build
     runs-on: ubuntu-latest
+    needs: [check_wasm_bindgen]
     steps:
       # actions/checkout@4.1.1
       - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
@@ -142,18 +147,23 @@ jobs:
           path: |
             securedrop-protocol/bench/.selenium-cache
             securedrop-protocol/bench/node_modules
-          key: node-${{ runner.os }}-${{ hashFiles('securedrop-protocol/bench/package-lock.json') }}
-      - name: Cache wasm artifacts
+          key: node-${{ runner.os }}-${{ hashFiles('securedrop-protocol/bench/package-lock.json') }}-${{ github.run_id }}
+          restore-keys: node-${{ runner.os }}-${{ hashFiles('securedrop-protocol/bench/package-lock.json') }}-
+      - name: Cache wasm and Rust artifacts
         uses: actions/cache@v4
         with:
           path: |
-            securedrop-protocol/bench/target
+            securedrop-protocol/target
             securedrop-protocol/bench/pkg
-          key: wasm-target-${{ runner.os }}-${{ github.run_id }}
-      - name: Compile for wasm32-unknown-unknown with wasm-bindgen
-        run: |
-          make rust-target
-          make build
+          key: wasm-rust-target-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: wasm-rust-target-${{ runner.os }}-${{ github.run_id }}
+      - name: Ensure wasm-bindgen is available
+        run: make rust-target
+        working-directory: securedrop-protocol/bench
+      - name: Compile protocol-minimal wasm32-unknown-unknown
+        run: make core-wasm
+      - name: Build wasm32-unknown-unknown benchmark crate and wasm artifacts
+        run: make build
         working-directory: securedrop-protocol/bench
 
   quick_bench:
@@ -179,14 +189,16 @@ jobs:
           path: |
             securedrop-protocol/bench/node_modules
             securedrop-protocol/bench/.selenium-cache
-          key: node-${{ runner.os }}-${{ hashFiles('securedrop-protocol/bench/package-lock.json') }}
-      - name: Restore wasm artifacts
+          key: node-${{ runner.os }}-${{ hashFiles('securedrop-protocol/bench/package-lock.json') }}-${{ github.run_id }}
+          restore-keys: node-${{ runner.os }}-${{ hashFiles('securedrop-protocol/bench/package-lock.json') }}-
+      - name: Restore wasm and Rust artifacts
         uses: actions/cache@v4
         with:
           path: |
-            securedrop-protocol/bench/target
+            securedrop-protocol/target
             securedrop-protocol/bench/pkg
-          key: wasm-target-${{ runner.os }}-${{ github.run_id }}
+          key: wasm-rust-target-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: wasm-rust-target-${{ runner.os }}-${{ github.run_id }}
       - name: Install wasm-bindgen + target
         run: make rust-target
         working-directory: securedrop-protocol/bench

--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,20 @@ deps-rust:  ## Install clippy and rustfmt.
 clippy: deps-rust  ## Check Rust code with clippy
 	@cargo clippy --manifest-path=securedrop-protocol/Cargo.toml --workspace --all-targets --all-features --
 
-.PHONY: build-wasm
-build-wasm:  ## Compile securedrop-protocol crate for wasm32-unknown-unknown (browser compat, requires rust toolchain).
+# Enforces build from a clean cache, to be used before running benchmarks.
+.PHONY: build-wasm-bench
+build-wasm:  ## Compile protocol-minimal and benchmark crates for wasm32-unknown-unknown (browser compat, requires rust toolchain).
+	@echo "Build wasm32 crates and wasm-bindgen"
+	$(MAKE) -C ./securedrop-protocol/bench/ clean build
+	@echo "Build complete, run 'make quick-bench' for local benchmarks."
+
+.PHONY: core-wasm
+core-wasm: ## Compile just the protocol-minimal crate in release mode for wasm32-unknown-unknown
 	@which cargo >> /dev/null || { echo "Please install the Rust toolchain"; exit 1; }
 	@rustup target list --installed | grep wasm32-unknown-unknown || { echo "Install wasm32 target using \`rustup target add wasm32-unknown-unknown\`"; exit 1; }
-	RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo build --manifest-path securedrop-protocol/Cargo.toml --target wasm32-unknown-unknown
+	@echo "Compile protocol-minimal crate for wasm32-unknown-unknown."
+	cargo build --quiet --manifest-path=securedrop-protocol/Cargo.toml --package=securedrop-protocol-minimal --target wasm32-unknown-unknown --release
+	@echo "Build complete, artifacts in securedrop-protocol/target/wasm32-unknown-unknown/release/."
 
 .PHONY: help
 help: ## Prints this message and exits.

--- a/securedrop-protocol/.cargo/config.toml
+++ b/securedrop-protocol/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/securedrop-protocol/Cargo.lock
+++ b/securedrop-protocol/Cargo.lock
@@ -2014,7 +2014,7 @@ dependencies = [
  "anyhow",
  "bip39",
  "criterion",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "hashbrown 0.14.5",
  "hax-lib",
  "hex",

--- a/securedrop-protocol/bench/Makefile
+++ b/securedrop-protocol/bench/Makefile
@@ -23,8 +23,6 @@ PKG_DIR := pkg
 # Keep consistent with wasm-bindgen version in Cargo.toml
 WASM_BINDGEN_CLI_VERSION := 0.2.121
 
-RUSTFLAGS := --cfg getrandom_backend="wasm_js"
-
 SELENIUM_CACHE ?= .selenium-cache
 SELENIUM_TOML  := $(SELENIUM_CACHE)/se-config.toml
 SELENIUM_STAMP := $(SELENIUM_CACHE)/.ready
@@ -75,8 +73,10 @@ build: $(CRATE_WASM)
 	wasm-bindgen --target web --out-dir $(PKG_DIR) $(CRATE_WASM)
 	@echo "WASM + bindings in $(PKG_DIR)/"
 
+# rustflags are defined in workspace .cargo/config.toml
 $(CRATE_WASM):
-	RUSTFLAGS='$(RUSTFLAGS)' cargo build --target $(WASM_TARGET) --release --target-dir $(TARGET_DIR)
+	cargo build -p securedrop-protocol-bench --target $(WASM_TARGET) --release --target-dir $(TARGET_DIR)
+	@echo "Built securedrop-protocol-bench in $(TARGET_DIR)"
 
 bench: deps build
 	@echo "Running bench with ITER=$(ITER)"
@@ -86,6 +86,9 @@ bench: deps build
 	# Benches for the sweeps charts
 	node bench.js -n $(ITER) --sweeps-only --flavors firefox,chrome --mode profile --j-min $(CHALLENGES_START) --j-max $(CHALLENGES_END) --j-step $(CHALLENGES_STEP) --k-min $(KEYBUNDLES_MIN) --k-max $(KEYBUNDLES_MAX) --k-step $(KEYBUNDLES_STEP)
 
+# !Note: this does not rebuild artifacts!
+# If you have made changes to the benchmarking crate, run \'make build quick-bench\'.
+# If you have made changes to the core crate, run \'make clean build quick-bench\'.
 quick-bench: deps build
 	@echo "Running bench with ITER=5"
 	SE_CACHE_PATH="$(abspath $(SELENIUM_CACHE))" \

--- a/securedrop-protocol/protocol-minimal/Cargo.toml
+++ b/securedrop-protocol/protocol-minimal/Cargo.toml
@@ -11,12 +11,12 @@ license = "GPL-3.0"
 
 [lib]
 
+# Note for no_std compat: Don't add rand/getrandom dependencies in core library!
 [dependencies]
 # hax extraction for dependencies is configured in "proofs/fstar/models/Makefile", as documented
 # here:
 # https://github.com/freedomofpress/securedrop-protocol/wiki/Verification#how-are-f-interfaces-extracted-from-our-dependencies
 
-# no rand/getrandom in core library!
 # Crypto stack, pinned to cfm/libcrux@hax-lib-0.3.7 pending cryspen/libcrux#1478:
 libcrux-ed25519 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf", features = ["rand"] }
 libcrux-curve25519 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
@@ -43,17 +43,23 @@ serde = { version = "1", default-features = false, features = ["derive", "alloc"
 # pin an exact version to resolve wasm-bindgen schema compatibility issue
 rand_chacha = {  version = "0.10.0", default-features = false  }
 
+# TODO: getrandom/rand should be removed from the protocol-minimal crate's core dependencies, and a randomness
+# source should only be supplied by an architecture-specific consumer crate, but this is blocked
+# on https://github.com/celabshq/libcrux/issues/1544, which depends on getrandom 0.4.2.
+## for wasm32-unknown-unknown
+[target.'cfg(all(target_arch="wasm32", target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.4", default-features = false, features = ["wasm_js"] }
+
 [dev-dependencies]
 proptest = "1.11"
-getrandom = { version = "0.3", default-features = false }
 serde_json = "1"
 criterion = "0.5"
 rand = "0.10"
+getrandom = { version = "0.4", default-features = false }
 
 [[bench]]
 name = "challenges"
 harness = false
-
 
 [profile.release]
 opt-level = "z"     # smallest code size


### PR DESCRIPTION
Refs #312 ~and expected to fail until that is resolved~
Refs #316  

- Update `make build-wasm` target and use it in CI, so that CI builds both the protocol-minimal and benchmark crate for wasm32-unknown-unknown.
- Add github run ID to ci cache key so it's clear these are a per-run cache.
- Add documentation about quick-bench behaviour in benchmarking Makefile
- To address #316 for now, add getrandom as a dependency if building for wasm32, with notes we should revisit.  I also filed an upstream ticket https://github.com/celabshq/libcrux/issues/1544 that's linked in that issue as well.

## Test plan  
- [ ] Visual review
- [ ] Passing CI
