### PR TITLE
Refactor toml files to inherit versions from workspace

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          CARGO_VERSION=$(grep -E '^wasm-bindgen\s*=' securedrop-protocol/bench/Cargo.toml \
+          CARGO_VERSION=$(grep -E '^wasm-bindgen\s*=' securedrop-protocol/Cargo.toml \
             | sed -E 's/.*"=?([^"]+)".*/\1/')
 
           MAKEFILE_VERSION=$(grep -E '^WASM_BINDGEN_CLI_VERSION\s*:=' securedrop-protocol/bench/Makefile \

--- a/securedrop-protocol/Cargo.toml
+++ b/securedrop-protocol/Cargo.toml
@@ -11,12 +11,51 @@ libcrux-kem = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8
 libcrux-sha3 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
 libcrux-traits = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
 
+# Crates use version.workspace for consistency.
 [workspace.package]
 name = "securedrop-protocol"
 version = "0.4.0"
 edition = "2024"
 authors = ["SecureDrop Team <securedrop@freedom.press>"]
 license = "GPL-3.0"
+
+[workspace.dependencies]
+# Crypto stack, pinned to cfm/libcrux@hax-lib-0.3.7 pending cryspen/libcrux#1478:
+libcrux-ed25519 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-curve25519 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-chacha20poly1305 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-traits = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-kem = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-ml-kem = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-sha2 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-hkdf = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+
+# See workspace-level `Cargo.toml` for patching to enforce hax-lib 0.3.7.
+hpke-rs = { git = "https://github.com/cryspen/hpke-rs", rev = "634caf8" }
+anyhow = "1.0"
+axum = "0.7"
+bip39 = { version = "2", default-features = false }
+clap = "4"
+criterion = "0.5"
+directories = "5"
+getrandom = { version = "0.3", default-features = false }
+hashbrown = "0.14"
+hax-lib = "0.3.7"
+hex = { version = "0.4", default-features = false }
+js-sys = "0.3"
+proptest = "1.11"
+rand = "0.10"
+rand_chacha = { version = "0.10.0", default-features = false }
+rand_core = "0.10"
+reqwest = { version = "0.12", default-features = false }
+serde = { version = "1", default-features = false }
+serde_json = { version = "1", default-features = false }
+tokio = "1"
+uuid = { version = "1.0", default-features = false }
+wasm-bindgen = "0.2.121"
+
+# exact version is pinned to avoid forced updates to wasm-bindgen.
+wasm-bindgen-test = "=0.3.71"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(hax)"] }

--- a/securedrop-protocol/Cargo.toml
+++ b/securedrop-protocol/Cargo.toml
@@ -30,7 +30,7 @@ libcrux-ml-kem = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b
 libcrux-sha2 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
 libcrux-hkdf = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
 
-# See workspace-level `Cargo.toml` for patching to enforce hax-lib 0.3.7.
+# See the `patch.crates-io` section for patching to enforce hax-lib 0.3.7.
 hpke-rs = { git = "https://github.com/cryspen/hpke-rs", rev = "634caf8" }
 anyhow = "1.0"
 axum = "0.7"

--- a/securedrop-protocol/bench/Cargo.toml
+++ b/securedrop-protocol/bench/Cargo.toml
@@ -14,25 +14,27 @@ securedrop-protocol-minimal = { path = "../protocol-minimal" }
 
 # Force all versions of getrandom in the dependency tree to build with
 # `wasm_js`:
-getrandom = { version = "0.3", default-features = false, features = ["wasm_js"] }
-getrandom04 = { package = "getrandom", version = "0.4", default-features = false, features = ["wasm_js"] }
+getrandom = { workspace = true, features = ["wasm_js"] }
+getrandom04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
 
-js-sys = "0.3"
+js-sys.workspace = true
+
 # Previously, rand_chacha was pinned to 0.9.0 to resolve incompatibility with older wasm-bindgen.
 # Check rand_chacha version compat if wasm builds or browser tests spuriously fail
-rand_chacha = { version = "0.10.0", default-features = false }
-rand_core = { version = "0.10" }
-serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
-serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-hashbrown = { version = "0.14", features = ["raw"] }
+rand_chacha = { workspace = true }
+rand_core.workspace = true
+serde = { workspace = true, features = ["derive", "alloc"] }
+serde_json = { workspace = true, features = ["alloc"] }
+hashbrown = { workspace = true, features = ["raw"] }
+
 # In theory, it should be possible to use v4 uuids with getrandom per https://docs.rs/uuid/1.18.1/uuid/#building-for-other-targets, but cargo nono complains vigorously
-uuid = { version = "1.0", default-features = false, features = ["v4", "rng-getrandom", "js"] }
+uuid = { workspace = true, features = ["v4", "rng-getrandom", "js"] }
 
 # Keep in sync with Makefile version
-wasm-bindgen = "0.2.121"
+wasm-bindgen.workspace = true
 
 [dev-dependencies]
-wasm-bindgen-test = "=0.3.71"  # exact to avoid forced updates to wasm-bindgen above
+wasm-bindgen-test.workspace = true
 
 [features]
 default = []

--- a/securedrop-protocol/bench/Makefile
+++ b/securedrop-protocol/bench/Makefile
@@ -20,7 +20,7 @@ WASM_TARGET := wasm32-unknown-unknown
 CRATE_WASM := $(TARGET_DIR)/$(WASM_TARGET)/release/securedrop_protocol_bench.wasm
 PKG_DIR := pkg
 
-# Keep consistent with wasm-bindgen version in Cargo.toml
+# Keep consistent with wasm-bindgen version in workspace Cargo.toml
 WASM_BINDGEN_CLI_VERSION := 0.2.121
 
 SELENIUM_CACHE ?= .selenium-cache

--- a/securedrop-protocol/demo-server/Cargo.toml
+++ b/securedrop-protocol/demo-server/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "securedrop-demo-server"
+description = "Demo SecureDrop protocol server"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-authors = ["SecureDrop Team <securedrop@freedom.press>"]
-description = "Demo SecureDrop protocol server"
+authors.workspace = true
 
 [[bin]]
 name = "demo-server"
@@ -13,12 +13,12 @@ path = "src/main.rs"
 [dependencies]
 securedrop-protocol-minimal = { path = "../protocol-minimal" }
 
-anyhow = "1.0"
-axum = "0.7"
-clap = { version = "4", features = ["derive"] }
-directories = "5"
-hex = "0.4"
-rand = "0.10"
-serde = { version = "1", features = ["derive"] }
-tokio = { version = "1", features = ["rt-multi-thread", "net", "signal"] }
-uuid = { version = "1", features = ["v4"] }
+anyhow.workspace = true
+axum.workspace = true
+clap = { workspace = true, features = ["derive"] }
+directories.workspace = true
+hex = { workspace = true, default-features = true }
+rand.workspace = true
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "net", "signal"] }
+uuid = { workspace = true, default-features = true, features = ["v4"] }

--- a/securedrop-protocol/journalist-cli/Cargo.toml
+++ b/securedrop-protocol/journalist-cli/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "securedrop-journalist-cli"
+description = "Demo SecureDrop journalist client"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-authors = ["SecureDrop Team <securedrop@freedom.press>"]
-description = "Demo SecureDrop journalist client"
+authors.workspace = true
 
 [[bin]]
 name = "journalist-cli"
@@ -13,12 +13,12 @@ path = "src/main.rs"
 [dependencies]
 securedrop-protocol-minimal = { path = "../protocol-minimal" }
 
-anyhow = "1.0"
-clap = { version = "4", features = ["derive"] }
-directories = "5"
-hex = "0.4"
-rand = "0.10"
-rand_core = "0.10"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+directories.workspace = true
+hex.workspace = true
+rand.workspace = true
+rand_core.workspace = true
+reqwest = { workspace = true, features = ["blocking", "json", "rustls-tls"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true

--- a/securedrop-protocol/protocol-minimal/Cargo.toml
+++ b/securedrop-protocol/protocol-minimal/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "securedrop-protocol-minimal"
-version = "0.4.0"
-edition = "2024"
-authors = ["SecureDrop Team <securedrop@freedom.press>"]
 description = "A wip impl of the securedrop protocol"
-license = "GPL-3.0"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
 
 # hax extraction for this crate is configured in "Makefile", as documented here:
 # https://github.com/freedomofpress/securedrop-protocol/wiki/Verification#how-are-f-modules-extracted-from-protocol-minimal
@@ -18,30 +18,30 @@ license = "GPL-3.0"
 # https://github.com/freedomofpress/securedrop-protocol/wiki/Verification#how-are-f-interfaces-extracted-from-our-dependencies
 
 # Crypto stack, pinned to cfm/libcrux@hax-lib-0.3.7 pending cryspen/libcrux#1478:
-libcrux-ed25519 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf", features = ["rand"] }
-libcrux-curve25519 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
-libcrux-chacha20poly1305 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
-libcrux-traits = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
-libcrux-kem = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
-libcrux-ml-kem = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
-libcrux-sha2 = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
-libcrux-hkdf = { git = "https://github.com/cfm/libcrux", rev = "3cd1843b0f029b2c8499d1af4234670ad04341bf" }
+libcrux-ed25519 = { workspace = true, features = ["rand"] }
+libcrux-curve25519.workspace = true
+libcrux-chacha20poly1305.workspace = true
+libcrux-traits.workspace = true
+libcrux-kem.workspace = true
+libcrux-ml-kem.workspace = true
+libcrux-sha2.workspace = true
+libcrux-hkdf.workspace = true
 
 # See workspace-level `Cargo.toml` for patching to enforce hax-lib 0.3.7.
 # Pinned here until published crates use hax-lib 0.3.7 and libcrux-sha3 0.0.9.
-hpke-rs = { git = "https://github.com/cryspen/hpke-rs", rev = "634caf8", features = ["libcrux"] }
+hpke-rs = { workspace = true, features = ["libcrux"] }
 
-rand_core = { version = "0.10" }
+rand_core.workspace = true
 
-anyhow = "1.0"
-hashbrown = { version = "0.14", features = ["raw"] }
-uuid = { version = "1.0", default-features = false, features = ["v4", "js"] }
-bip39 = { version = "2", default-features = false, features = ["alloc"] }
-hex = { version = "0.4", default-features = false, features = ["alloc"] }
-serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
+anyhow.workspace = true
+hashbrown = { workspace = true, features = ["raw"] }
+uuid = { workspace = true, features = ["v4", "js"] }
+bip39 = { workspace = true, features = ["alloc"] }
+hex = { workspace = true, features = ["alloc"] }
+serde = { workspace = true, features = ["derive", "alloc"] }
 
 # pin an exact version to resolve wasm-bindgen schema compatibility issue
-rand_chacha = {  version = "0.10.0", default-features = false  }
+rand_chacha = { workspace = true }
 
 # TODO: getrandom/rand should be removed from the protocol-minimal crate's core dependencies, and a randomness
 # source should only be supplied by an architecture-specific consumer crate, but this is blocked
@@ -51,11 +51,11 @@ rand_chacha = {  version = "0.10.0", default-features = false  }
 getrandom = { version = "0.4", default-features = false, features = ["wasm_js"] }
 
 [dev-dependencies]
-proptest = "1.11"
-serde_json = "1"
-criterion = "0.5"
-rand = "0.10"
-getrandom = { version = "0.4", default-features = false }
+proptest.workspace = true
+getrandom.workspace = true
+serde_json.workspace = true
+criterion.workspace = true
+rand.workspace = true
 
 [[bench]]
 name = "challenges"
@@ -69,7 +69,7 @@ panic = "abort"
 strip = true
 
 [target."cfg(hax)".dependencies]
-hax-lib = { version = "0.3.7" }
+hax-lib.workspace = true
 
 [lints]
 workspace = true

--- a/securedrop-protocol/source-cli/Cargo.toml
+++ b/securedrop-protocol/source-cli/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "securedrop-source-cli"
+description = "Demo source CLI for the SecureDrop protocol"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-authors = ["SecureDrop Team <securedrop@freedom.press>"]
-description = "Demo source CLI for the SecureDrop protocol"
+authors.workspace = true
 
 [[bin]]
 name = "source-cli"
@@ -13,9 +13,9 @@ path = "src/main.rs"
 [dependencies]
 securedrop-protocol-minimal = { path = "../protocol-minimal" }
 
-anyhow = "1.0"
-clap = { version = "4", features = ["derive"] }
-hex = "0.4"
-rand = "0.10"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
-serde = { version = "1", features = ["derive"] }
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+hex.workspace = true
+rand.workspace = true
+reqwest = { workspace = true, features = ["blocking", "json", "rustls-tls"] }
+serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Closes #320 

Use workspace toml file for dependency versioninng, inherit in various crates.
Does not take steps to try to consolidate/tweak versions (eg to reduce duplicate dependencies) because I wanted it to be easier to review:

- [ ] CI passes +
- [ ] No changes to Cargo.lock 
- [ ] (+ standard visual review)