### PR TITLE
docs: consolidate links and update references to the eprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 | [Specification]                   | 0.4 ([changelog])     |
 | [Tamarin models]                  | 0.3                   |
 
+A peer-reviewed formalization of this project's goals, threat model, and
+security properties can be found in Berra et al. (2026), ["The SecureDrop
+Protocol: End-to-End Encrypted Whistleblowing for All"][eprint].
+
 [changelog]: ./docs/protocol.md#changelog
 [documentation]: https://freedomofpress.github.io/securedrop-protocol/securedrop_protocol_minimal/
 [Proof-of-concept implementation]: https://github.com/freedomofpress/securedrop-protocol/tree/main/securedrop-protocol/protocol-minimal
@@ -19,9 +23,10 @@
 > [!WARNING]
 > This repository contains proof-of-concept code and is not intended for production use. The protocol details are not yet finalized.
 
-**March 2026:** A manuscript, specifying and proving [version 0.3][v0.3] of the
-protocol and its [Tamarin models], is under peer review. An eprint is
-forthcoming.
+**July 2026:** ["The SecureDrop Protocol: End-to-End Encrypted Whistleblowing
+for All"][eprint] is forthcoming in ACM CCS 2026. This work, with Felix Linker,
+Luca Maier, Kenneth G. Paterson, and Shannon Veitch, led to [version 0.3][v0.3]
+of the specification.
 
 **January 2025:** A formal analysis was performed by [Luca Maier][lumaier] in
 ["A Formal Analysis of the SecureDrop Protocol"][lumaier-thesis], supervised by
@@ -37,6 +42,8 @@ performed by [Michele Orrù][mmaker].
 **January 2023:** Proof-of-concept implementation work with [Shielder] began.
 
 ## Background
+
+<!-- Update <https://securedrop.org/research> when you update this list. -->
 
 To better understand the context of this research and the previous steps that led to it, read the following blog posts:
 
@@ -120,6 +127,7 @@ You may also need to follow the console_error_panic_hook docs to increase the st
 [`console_error_panic_hook`]: https://crates.io/crates/console_error_panic_hook
 [`wasm-bindgen`]: https://crates.io/crates/wasm-bindgen
 [Shielder]: https://www.shielder.com/
+[eprint]: https://eprint.iacr.org/2026/1484
 [lumaier]: https://github.com/lumaier
 [lumaier-thesis]: https://doi.org/10.3929/ethz-b-000718325
 [mmaker]: https://github.com/mmaker

--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ The script prints the TikZ code for the chart to the console, which you can copy
 
 #### Debugging wasm and benchmarking code
 
-[`wasm-bindgen`] exposes Rust objects and functions in Javascript in the benchmarking code. If troubleshooting, ensure you are using the same version of the wasm-bindgen cli as is specified in Cargo.toml (`wasm-bindgen -V`).
+[`wasm-bindgen`] exposes Rust objects and functions in JavaScript in the benchmarking code. If troubleshooting, ensure you are using the same version of the wasm-bindgen cli as is specified in Cargo.toml (`wasm-bindgen -V`).
 
-`wasm-bindgen` requires wrapper classes for Rust objects to marshall in and out of Javascript. If any structs or function signatures that are being used in `www/index.html` (rendering benchmarks) are changed, the corresponding wrapper structs, annotated with `#[wasm_bindgen]`, will need to change accordingly.
+`wasm-bindgen` requires wrapper classes for Rust objects to marshall in and out of JavaScript. If any structs or function signatures that are being used in `www/index.html` (rendering benchmarks) are changed, the corresponding wrapper structs, annotated with `#[wasm_bindgen]`, will need to change accordingly.
 
 If the wasm-compiled Rust code panics, the browser may display a fairly generic/unhelpful message with limited information (for example, `{"error":"unreachable executed"}`). Add the [`console_error_panic_hook`] crate and use the `console_error_panic_hook::set_once();` method in a common codepath annotated by `#[wasm-bindgen]` in order to log further information to the browser console. You will also need to temporarily adjust Cargo.toml:
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 [specification]: ./docs/protocol.md
 [Tamarin models]: https://github.com/freedomofpress/securedrop-protocol-models
 
+<!-- After this preamble, all subsequent links are defined at the bottom of this file. -->
+
 ## Status
 
 > [!WARNING]
@@ -21,35 +23,27 @@
 protocol and its [Tamarin models], is under peer review. An eprint is
 forthcoming.
 
-**January 2025:** A formal analysis was performed by
-[Luca Maier](https://github.com/lumaier) in ["A Formal Analysis of the
-SecureDrop Protocol"](https://doi.org/10.3929/ethz-b-000718325), supervised by
+**January 2025:** A formal analysis was performed by [Luca Maier][lumaier] in
+["A Formal Analysis of the SecureDrop Protocol"][lumaier-thesis], supervised by
 David Basin, Felix Linker, and Shannon Veitch in the Information Security Group
 at ETH Zürich. This work led to [version 0.2][v0.2] of the specification.
 
 **May 2024:** [Version 0.1][v0.1] of a [proof-of-concept
-implementation][v0.1-tag] was [announced publicly](https://securedrop.org/news/introducing-securedrop-protocol/).
+implementation][v0.1-tag] was [announced publicly][sd-introducing].
 
-**December 2023:** A preliminary cryptographic audit was performed by
-[Michele Orrù](https://github.com/mmaker). See
-<https://github.com/freedomofpress/securedrop-protocol/issues/36>.
+**December 2023:** [A preliminary cryptographic audit][mmaker-audit] was
+performed by [Michele Orrù][mmaker].
 
-**January 2023:** Proof-of-concept implementation work with
-[Shielder](https://www.shielder.com/) began.
-
-[v0.1]: ./docs/protocol.md#01
-[v0.1-tag]: https://github.com/freedomofpress/securedrop-protocol/releases/tag/v0.1
-[v0.2]: ./docs/protocol.md#02
-[v0.3]: ./docs/protocol.md#03
+**January 2023:** Proof-of-concept implementation work with [Shielder] began.
 
 ## Background
 
 To better understand the context of this research and the previous steps that led to it, read the following blog posts:
 
-- [Part 1: Future directions for SecureDrop](https://securedrop.org/news/future-directions-for-securedrop/)
-- [Part 2: Anatomy of a whistleblowing system](https://securedrop.org/news/anatomy-of-a-whistleblowing-system/)
-- [Part 3: How to research your own cryptography and survive](https://securedrop.org/news/how-to-research-your-own-cryptography-and-survive/)
-- [Part 4: Introducing SecureDrop Protocol](https://securedrop.org/news/introducing-securedrop-protocol/)
+- [Part 1: Future directions for SecureDrop][sd-future]
+- [Part 2: Anatomy of a whistleblowing system][sd-anatomy]
+- [Part 3: How to research your own cryptography and survive][sd-how-to]
+- [Part 4: Introducing SecureDrop Protocol][sd-introducing]
 
 ## Setup instructions
 
@@ -105,11 +99,11 @@ The script prints the TikZ code for the chart to the console, which you can copy
 
 #### Debugging wasm and benchmarking code
 
-[`wasm-bindgen`](https://crates.io/crates/wasm-bindgen) exposes Rust objects and functions in Javascript in the benchmarking code. If troubleshooting, ensure you are using the same version of the wasm-bindgen cli as is specified in Cargo.toml (`wasm-bindgen -V`).
+[`wasm-bindgen`] exposes Rust objects and functions in Javascript in the benchmarking code. If troubleshooting, ensure you are using the same version of the wasm-bindgen cli as is specified in Cargo.toml (`wasm-bindgen -V`).
 
 `wasm-bindgen` requires wrapper classes for Rust objects to marshall in and out of Javascript. If any structs or function signatures that are being used in `www/index.html` (rendering benchmarks) are changed, the corresponding wrapper structs, annotated with `#[wasm_bindgen]`, will need to change accordingly.
 
-If the wasm-compiled Rust code panics, the browser may display a fairly generic/unhelpful message with limited information (for example, `{"error":"unreachable executed"}`). Add the [`console_error_panic_hook`](https://crates.io/crates/console_error_panic_hook) crate and use the `console_error_panic_hook::set_once();` method in a common codepath annotated by `#[wasm-bindgen]` in order to log further information to the browser console. You will also need to temporarily adjust Cargo.toml:
+If the wasm-compiled Rust code panics, the browser may display a fairly generic/unhelpful message with limited information (for example, `{"error":"unreachable executed"}`). Add the [`console_error_panic_hook`] crate and use the `console_error_panic_hook::set_once();` method in a common codepath annotated by `#[wasm-bindgen]` in order to log further information to the browser console. You will also need to temporarily adjust Cargo.toml:
 
 ```
 [profile.release]
@@ -120,3 +114,21 @@ panic = "unwind"
 ```
 
 You may also need to follow the console_error_panic_hook docs to increase the stacktrace lines printed by your browser.
+
+<!-- Body links should be defined here, sorted alphabetically. -->
+
+[`console_error_panic_hook`]: https://crates.io/crates/console_error_panic_hook
+[`wasm-bindgen`]: https://crates.io/crates/wasm-bindgen
+[Shielder]: https://www.shielder.com/
+[lumaier]: https://github.com/lumaier
+[lumaier-thesis]: https://doi.org/10.3929/ethz-b-000718325
+[mmaker]: https://github.com/mmaker
+[mmaker-audit]: https://github.com/freedomofpress/securedrop-protocol/issues/36
+[sd-anatomy]: https://securedrop.org/news/anatomy-of-a-whistleblowing-system/
+[sd-future]: https://securedrop.org/news/future-directions-for-securedrop/
+[sd-how-to]: https://securedrop.org/news/how-to-research-your-own-cryptography-and-survive/
+[sd-introducing]: https://securedrop.org/news/introducing-securedrop-protocol/
+[v0.1]: ./docs/protocol.md#01
+[v0.1-tag]: https://github.com/freedomofpress/securedrop-protocol/releases/tag/v0.1
+[v0.2]: ./docs/protocol.md#02
+[v0.3]: ./docs/protocol.md#03

--- a/SOUNDNESS.md
+++ b/SOUNDNESS.md
@@ -8,9 +8,10 @@
 ## Specification
 
 As [specified][spec], the security properties of the SecureDrop Protocol have
-been proven with game-based proofs in the computational model in a manuscript
-currently (as of March 2026) under peer review. A subset of these properties
-have also been [proven in the symbolic model][models] using the Tamarin Prover.
+been proven with game-based proofs in the computational model in Berra et al.
+(2026), ["The SecureDrop Protocol: End-to-End Encrypted Whistleblowing for
+All"][berra-2026]. A subset of these properties have also been [proven in the
+symbolic model][models] using the Tamarin Prover.
 
 ## Implementation
 
@@ -104,6 +105,7 @@ verification status:
 
 [hacl]: https://hacl-star.github.io/
 [hpke-rs]: https://github.com/cryspen/hpke-rs
+[berra-2026]: https://eprint.iacr.org/2026/1484
 [bhargavan-2025]: https://eprint.iacr.org/2025/980
 [hax]: https://github.com/cryspen/hax
 [`HAX_TARGETS`]: ./securedrop-protocol/protocol-minimal/Makefile#L5

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -62,7 +62,7 @@ The choice of an unauthenticated API avoids a serverside "users" database.
 - Be maintainable: Use well-known encryption primitives and existing cryptography libraries
 - Be readily-deployable: Use a single-server design, consider realistic threat models with respect to cloud deployments.
 
-For further context, see [our Research page](https://securedrop.org/research/), particularly the blog post series.
+For further context, see Berra et al. (2026), ["The SecureDrop Protocol: End-to-End Encrypted Whistleblowing for All"][berra-2026] and our [research] page.
 
 ### Sequence Diagram
 
@@ -728,9 +728,9 @@ Protocol"][maier2025], using modified $`\text{HPKE}^{pq}_{auth}`$.
 
 ### [0.3]
 
-Using standard HPKE modes `Base` and `AuthPSK`.
-
-<!-- TODO: ...as formalized in... -->
+As formalized in Berra et al. (2026), ["The SecureDrop Protocol: End-to-End
+Encrypted Whistleblowing for All"][berra-2026], using standard HPKE modes `base` and
+`auth_psk`.
 
 ### 0.4
 
@@ -775,9 +775,10 @@ insertion order.
 [0.2]: https://github.com/freedomofpress/securedrop-protocol/blob/9e6c165673c03e9821725f72b3df4d8292b8cabf/docs/protocol.md
 [0.3]: https://github.com/freedomofpress/securedrop-protocol/blob/v0.3/docs/protocol.md
 [#127]: https://github.com/freedomofpress/securedrop-protocol/issues/127
-[alwen2020]: https://eprint.iacr.org/2020/1499
 [BIP39]: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
+[alwen2020]: https://eprint.iacr.org/2020/1499
 [alwen2023]: https://eprint.iacr.org/2023/1480
+[berra-2026]: https://eprint.iacr.org/2026/1484
 [maier2025]: https://github.com/lumaier/securedrop-formalanalysis/tree/fd0daf0ce90144e12956032abf1817e18cec48e0
 [milestones]: https://github.com/freedomofpress/securedrop-protocol/milestones
 [nist-ir-8547]: https://nvlpubs.nist.gov/nistpubs/ir/2024/NIST.IR.8547.ipd.pdf
@@ -794,5 +795,6 @@ insertion order.
 [RFC 9180 §7.2]: https://datatracker.ietf.org/doc/html/rfc9180#name-key-derivation-functions-kd
 [RFC 9180 §9.9]: https://datatracker.ietf.org/doc/html/rfc9180#name-metadata-protection
 [RFC 9496]: https://datatracker.ietf.org/doc/html/rfc9496
+[research]: https://securedrop.org/research
 [semantic versioning]: https://semver.org
 [v0.1-config]: https://github.com/freedomofpress/securedrop-protocol/blob/d512528f42760f7ccb5205291ba11a377333cc0e/README.md?plain=1#L29


### PR DESCRIPTION
This is the chore part of #211: replacing literal references to our manuscript with links to the eprint.  I'll stack the substantive changes on top of this.