### PR TITLE
Commit to sender sd-apke pubkey in info param

### DIFF
--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Encrypt_decrypt.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Encrypt_decrypt.fst
@@ -45,23 +45,28 @@ let encrypt
       (plaintext: Securedrop_protocol_minimal.Ciphertext.t_Plaintext)
       (recipient: v_Recipient)
     : (v_R & Securedrop_protocol_minimal.Ciphertext.t_Envelope) =
-  let sk_s:Securedrop_protocol_minimal.Message.t_MessagePrivateKey =
-    Securedrop_protocol_minimal.Traits.f_message_auth_key #v_Sender
+  let keypair_s:Securedrop_protocol_minimal.Message.t_MessageKeyPair =
+    Securedrop_protocol_minimal.Traits.f_message_auth_keypair #v_Sender
       #FStar.Tactics.Typeclasses.solve
       sender
+  in
+  let pk_s:Securedrop_protocol_minimal.Message.t_MessagePublicKey =
+    Securedrop_protocol_minimal.Message.impl_MessageKeyPair__public_key (Securedrop_protocol_minimal.Traits.f_message_auth_keypair
+          #v_Sender
+          #FStar.Tactics.Typeclasses.solve
+          sender
+        <:
+        Securedrop_protocol_minimal.Message.t_MessageKeyPair)
   in
   let pk_r:Securedrop_protocol_minimal.Message.t_MessagePublicKey =
     Securedrop_protocol_minimal.Traits.f_message_enc_pk #v_Recipient
       #FStar.Tactics.Typeclasses.solve
       recipient
   in
-  let pk_r_fetch:t_Array u8 (mk_usize 32) =
-    Securedrop_protocol_minimal.Primitives.Ristretto255.impl_DHPublicKey__into_bytes (Securedrop_protocol_minimal.Traits.f_fetch_pk
-          #v_Recipient
-          #FStar.Tactics.Typeclasses.solve
-          recipient
-        <:
-        Securedrop_protocol_minimal.Primitives.Ristretto255.t_DHPublicKey)
+  let pk_r_fetch:Securedrop_protocol_minimal.Primitives.Ristretto255.t_DHPublicKey =
+    Securedrop_protocol_minimal.Traits.f_fetch_pk #v_Recipient
+      #FStar.Tactics.Typeclasses.solve
+      recipient
   in
   let
   (tmp0: v_R),
@@ -70,7 +75,7 @@ let encrypt
       Anyhow.t_Error) =
     Securedrop_protocol_minimal.Message.auth_enc #v_R
       rng
-      sk_s
+      keypair_s
       pk_r
       (Alloc.Vec.impl_1__as_slice (Securedrop_protocol_minimal.Ciphertext.impl_Plaintext__to_bytes plaintext
 
@@ -79,7 +84,7 @@ let encrypt
         <:
         t_Slice u8)
       v_NR_ID
-      (pk_r_fetch <: t_Slice u8)
+      pk_r_fetch
   in
   let rng:v_R = tmp0 in
   let ct_apke:Securedrop_protocol_minimal.Message.t_MessageCiphertext =
@@ -120,9 +125,12 @@ let encrypt
               recipient
             <:
             Securedrop_protocol_minimal.Metadata.t_MetadataPublicKey)
-          (Securedrop_protocol_minimal.Traits.f_own_message_auth_pk #v_Sender
-              #FStar.Tactics.Typeclasses.solve
-              sender
+          (Securedrop_protocol_minimal.Message.impl_MessageKeyPair__public_key (Securedrop_protocol_minimal.Traits.f_message_auth_keypair
+                  #v_Sender
+                  #FStar.Tactics.Typeclasses.solve
+                  sender
+                <:
+                Securedrop_protocol_minimal.Message.t_MessageKeyPair)
             <:
             Securedrop_protocol_minimal.Message.t_MessagePublicKey)
         <:
@@ -239,15 +247,11 @@ let decrypt_with_sender
           Anyhow.t_Error)
       "Metadata must contain valid sender APKE key tuple"
   in
-  let pk_r_fetch:t_Array u8 (mk_usize 32) =
-    Securedrop_protocol_minimal.Primitives.Ristretto255.impl_DHPublicKey__into_bytes (Securedrop_protocol_minimal.Traits.f_fetch_keypair
-          #v_U
-          #FStar.Tactics.Typeclasses.solve
-          receiver
-        <:
-        (Securedrop_protocol_minimal.Primitives.Ristretto255.t_DHPrivateKey &
-          Securedrop_protocol_minimal.Primitives.Ristretto255.t_DHPublicKey))
-        ._2
+  let pk_r_fetch:Securedrop_protocol_minimal.Primitives.Ristretto255.t_DHPublicKey =
+    (Securedrop_protocol_minimal.Traits.f_fetch_keypair #v_U
+        #FStar.Tactics.Typeclasses.solve
+        receiver)
+      ._2
   in
   let pt:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
     Core_models.Result.impl__expect #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
@@ -259,7 +263,7 @@ let decrypt_with_sender
           sender_pk
           envelope.Securedrop_protocol_minimal.Ciphertext.f_ct_apke
           v_NR_ID
-          (pk_r_fetch <: t_Slice u8)
+          pk_r_fetch
         <:
         Core_models.Result.t_Result (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Anyhow.t_Error)
       "SD-APKE AuthDec failed"

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Encrypt_decrypt.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Encrypt_decrypt.fst
@@ -50,14 +50,6 @@ let encrypt
       #FStar.Tactics.Typeclasses.solve
       sender
   in
-  let pk_s:Securedrop_protocol_minimal.Message.t_MessagePublicKey =
-    Securedrop_protocol_minimal.Message.impl_MessageKeyPair__public_key (Securedrop_protocol_minimal.Traits.f_message_auth_keypair
-          #v_Sender
-          #FStar.Tactics.Typeclasses.solve
-          sender
-        <:
-        Securedrop_protocol_minimal.Message.t_MessageKeyPair)
-  in
   let pk_r:Securedrop_protocol_minimal.Message.t_MessagePublicKey =
     Securedrop_protocol_minimal.Traits.f_message_enc_pk #v_Recipient
       #FStar.Tactics.Typeclasses.solve
@@ -125,12 +117,7 @@ let encrypt
               recipient
             <:
             Securedrop_protocol_minimal.Metadata.t_MetadataPublicKey)
-          (Securedrop_protocol_minimal.Message.impl_MessageKeyPair__public_key (Securedrop_protocol_minimal.Traits.f_message_auth_keypair
-                  #v_Sender
-                  #FStar.Tactics.Typeclasses.solve
-                  sender
-                <:
-                Securedrop_protocol_minimal.Message.t_MessageKeyPair)
+          (Securedrop_protocol_minimal.Message.impl_MessageKeyPair__public_key keypair_s
             <:
             Securedrop_protocol_minimal.Message.t_MessagePublicKey)
         <:

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Journalist.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Journalist.fst
@@ -344,23 +344,11 @@ let impl_4: Securedrop_protocol_minimal.Traits.t_UserSecret t_Journalist =
         <:
         (Securedrop_protocol_minimal.Primitives.Ristretto255.t_DHPrivateKey &
           Securedrop_protocol_minimal.Primitives.Ristretto255.t_DHPublicKey));
-    f_message_auth_key_pre = (fun (self: t_Journalist) -> true);
-    f_message_auth_key_post
+    f_message_auth_keypair_pre = (fun (self: t_Journalist) -> true);
+    f_message_auth_keypair_post
     =
-    (fun (self: t_Journalist) (out: Securedrop_protocol_minimal.Message.t_MessagePrivateKey) -> true
-    );
-    f_message_auth_key
-    =
-    (fun (self: t_Journalist) ->
-        Securedrop_protocol_minimal.Message.impl_MessageKeyPair__private_key self.f_reply_apke);
-    f_own_message_auth_pk_pre = (fun (self: t_Journalist) -> true);
-    f_own_message_auth_pk_post
-    =
-    (fun (self: t_Journalist) (out: Securedrop_protocol_minimal.Message.t_MessagePublicKey) -> true);
-    f_own_message_auth_pk
-    =
-    (fun (self: t_Journalist) ->
-        Securedrop_protocol_minimal.Message.impl_MessageKeyPair__public_key self.f_reply_apke);
+    (fun (self: t_Journalist) (out: Securedrop_protocol_minimal.Message.t_MessageKeyPair) -> true);
+    f_message_auth_keypair = (fun (self: t_Journalist) -> self.f_reply_apke);
     f_build_message_pre
     =
     (fun (self: t_Journalist) (message: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) -> true);

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Message.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Message.fst
@@ -436,7 +436,7 @@ let deterministic_keygen (dh_seed: t_Array u8 (mk_usize 32)) (mlkem_seed: t_Arra
 /// - `sk = (skS1, skS2)`: sender's SD-APKE private key
 /// - `pk = (pkR1, pkR2)`: recipient's SD-APKE public key
 /// - `ad`: associated data
-/// - `info`: caller-supplied info (spec prepends `c2` internally: `info = c2 + info`)
+/// - `info_incl`: additional opaque bytes to include in info param, currently receiver's fetch key.
 /// # Errors
 /// Returns an error if ML-KEM encapsulation or HPKE sealing fails.
 let auth_enc
@@ -444,9 +444,10 @@ let auth_enc
       (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Rand_core.t_RngCore v_R)
       (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng v_R)
       (rng: v_R)
-      (sk: t_MessagePrivateKey)
+      (sk: t_MessageKeyPair)
       (pk: t_MessagePublicKey)
-      (m ad info: t_Slice u8)
+      (m ad: t_Slice u8)
+      (info_incl: Securedrop_protocol_minimal.Primitives.Ristretto255.t_DHPublicKey)
     : (v_R & Core_models.Result.t_Result t_MessageCiphertext Anyhow.t_Error) =
   let hpke:Hpke_rs.t_Hpke Hpke_rs_libcrux.t_HpkeLibcrux =
     Hpke_rs.impl_7__new #Hpke_rs_libcrux.t_HpkeLibcrux
@@ -523,7 +524,7 @@ let auth_enc
         #FStar.Tactics.Typeclasses.solve
         (Core_models.Clone.f_clone #Securedrop_protocol_minimal.Primitives.Dh_akem.t_DhAkemPrivateKey
             #FStar.Tactics.Typeclasses.solve
-            sk.f_dhakem
+            (impl_MessageKeyPair__private_key sk <: t_MessagePrivateKey).f_dhakem
           <:
           Securedrop_protocol_minimal.Primitives.Dh_akem.t_DhAkemPrivateKey)
     in
@@ -532,7 +533,25 @@ let auth_enc
       Alloc.Vec.impl_2__extend_from_slice #u8 #Alloc.Alloc.t_Global full_info (c2 <: t_Slice u8)
     in
     let full_info:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
-      Alloc.Vec.impl_2__extend_from_slice #u8 #Alloc.Alloc.t_Global full_info info
+      Alloc.Vec.impl_2__extend_from_slice #u8
+        #Alloc.Alloc.t_Global
+        full_info
+        (Securedrop_protocol_minimal.Primitives.Ristretto255.impl_DHPublicKey__into_bytes info_incl
+          <:
+          t_Slice u8)
+    in
+    let full_info:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
+      Alloc.Vec.impl_2__extend_from_slice #u8
+        #Alloc.Alloc.t_Global
+        full_info
+        (Alloc.Vec.impl_1__as_slice (impl_MessagePublicKey__as_bytes (impl_MessageKeyPair__public_key
+                    sk
+                  <:
+                  t_MessagePublicKey)
+              <:
+              Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+          <:
+          t_Slice u8)
     in
     let
     (tmp0: Hpke_rs.t_Hpke Hpke_rs_libcrux.t_HpkeLibcrux),
@@ -635,7 +654,8 @@ let auth_dec
       (sk: t_MessagePrivateKey)
       (pk: t_MessagePublicKey)
       (ct: t_MessageCiphertext)
-      (ad info: t_Slice u8)
+      (ad: t_Slice u8)
+      (info_incl: Securedrop_protocol_minimal.Primitives.Ristretto255.t_DHPublicKey)
     : Core_models.Result.t_Result (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) Anyhow.t_Error =
   let hpke:Hpke_rs.t_Hpke Hpke_rs_libcrux.t_HpkeLibcrux =
     Hpke_rs.impl_7__new #Hpke_rs_libcrux.t_HpkeLibcrux
@@ -716,7 +736,22 @@ let auth_dec
         (ct.f_c2 <: t_Slice u8)
     in
     let full_info:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
-      Alloc.Vec.impl_2__extend_from_slice #u8 #Alloc.Alloc.t_Global full_info info
+      Alloc.Vec.impl_2__extend_from_slice #u8
+        #Alloc.Alloc.t_Global
+        full_info
+        (Securedrop_protocol_minimal.Primitives.Ristretto255.impl_DHPublicKey__into_bytes info_incl
+          <:
+          t_Slice u8)
+    in
+    let full_info:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
+      Alloc.Vec.impl_2__extend_from_slice #u8
+        #Alloc.Alloc.t_Global
+        full_info
+        (Alloc.Vec.impl_1__as_slice (impl_MessagePublicKey__as_bytes pk
+              <:
+              Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
+          <:
+          t_Slice u8)
     in
     Core_models.Result.impl__map_err #(Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
       #Hpke_rs.t_HpkeError

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Message.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Message.fst
@@ -433,7 +433,7 @@ let deterministic_keygen (dh_seed: t_Array u8 (mk_usize 32)) (mlkem_seed: t_Arra
     Core_models.Result.Result_Err err <: Core_models.Result.t_Result t_MessageKeyPair Anyhow.t_Error
 
 /// SD-APKE.AuthEnc: encrypt message `m` from sender to recipient.
-/// - `sk = (skS1, skS2)`: sender's SD-APKE private key
+/// - `kp = ((skS1, skS2), (pkS1, pkS2))`: sender's SD-APKE keypair
 /// - `pk = (pkR1, pkR2)`: recipient's SD-APKE public key
 /// - `ad`: associated data
 /// - `info_incl`: additional opaque bytes to include in info param, currently receiver's fetch key.
@@ -444,7 +444,7 @@ let auth_enc
       (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Rand_core.t_RngCore v_R)
       (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Rand_core.t_CryptoRng v_R)
       (rng: v_R)
-      (sk: t_MessageKeyPair)
+      (kp: t_MessageKeyPair)
       (pk: t_MessagePublicKey)
       (m ad: t_Slice u8)
       (info_incl: Securedrop_protocol_minimal.Primitives.Ristretto255.t_DHPublicKey)
@@ -524,7 +524,7 @@ let auth_enc
         #FStar.Tactics.Typeclasses.solve
         (Core_models.Clone.f_clone #Securedrop_protocol_minimal.Primitives.Dh_akem.t_DhAkemPrivateKey
             #FStar.Tactics.Typeclasses.solve
-            (impl_MessageKeyPair__private_key sk <: t_MessagePrivateKey).f_dhakem
+            (impl_MessageKeyPair__private_key kp <: t_MessagePrivateKey).f_dhakem
           <:
           Securedrop_protocol_minimal.Primitives.Dh_akem.t_DhAkemPrivateKey)
     in
@@ -544,10 +544,7 @@ let auth_enc
       Alloc.Vec.impl_2__extend_from_slice #u8
         #Alloc.Alloc.t_Global
         full_info
-        (Alloc.Vec.impl_1__as_slice (impl_MessagePublicKey__as_bytes (impl_MessageKeyPair__public_key
-                    sk
-                  <:
-                  t_MessagePublicKey)
+        (Alloc.Vec.impl_1__as_slice (impl_MessagePublicKey__as_bytes kp.f_pk
               <:
               Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
           <:
@@ -647,7 +644,7 @@ let auth_enc
 /// - `sk = (skR1, skR2)`: recipient's SD-APKE private key
 /// - `pk = (pkS1, pkS2)`: sender's SD-APKE public key
 /// - `ad`: associated data
-/// - `info`: caller-supplied info (spec prepends `c2` internally: `info = c2 + info`)
+/// - `info_incl`: caller-supplied info (spec prepends `c2` internally: `info = c2 + info`)
 /// # Errors
 /// Returns an error if ML-KEM decapsulation or HPKE opening fails.
 let auth_dec

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Source.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Source.fst
@@ -169,24 +169,13 @@ let impl_2: Securedrop_protocol_minimal.Traits.t_UserSecret t_Source =
         <:
         (Securedrop_protocol_minimal.Primitives.Ristretto255.t_DHPrivateKey &
           Securedrop_protocol_minimal.Primitives.Ristretto255.t_DHPublicKey));
-    f_message_auth_key_pre = (fun (self: t_Source) -> true);
-    f_message_auth_key_post
+    f_message_auth_keypair_pre = (fun (self: t_Source) -> true);
+    f_message_auth_keypair_post
     =
-    (fun (self: t_Source) (out: Securedrop_protocol_minimal.Message.t_MessagePrivateKey) -> true);
-    f_message_auth_key
+    (fun (self: t_Source) (out: Securedrop_protocol_minimal.Message.t_MessageKeyPair) -> true);
+    f_message_auth_keypair
     =
-    (fun (self: t_Source) ->
-        Securedrop_protocol_minimal.Message.impl_MessageKeyPair__private_key self.f_message_keys
-            .Securedrop_protocol_minimal.Keys.f_apke);
-    f_own_message_auth_pk_pre = (fun (self: t_Source) -> true);
-    f_own_message_auth_pk_post
-    =
-    (fun (self: t_Source) (out: Securedrop_protocol_minimal.Message.t_MessagePublicKey) -> true);
-    f_own_message_auth_pk
-    =
-    (fun (self: t_Source) ->
-        Securedrop_protocol_minimal.Message.impl_MessageKeyPair__public_key self.f_message_keys
-            .Securedrop_protocol_minimal.Keys.f_apke);
+    (fun (self: t_Source) -> self.f_message_keys.Securedrop_protocol_minimal.Keys.f_apke);
     f_build_message_pre
     =
     (fun (self: t_Source) (message: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) -> true);

--- a/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Traits.fst
+++ b/securedrop-protocol/protocol-minimal/proofs/fstar/extraction/Securedrop_protocol_minimal.Traits.fst
@@ -139,19 +139,13 @@ class t_UserSecret (v_Self: Type0) = {
           Securedrop_protocol_minimal.Primitives.Ristretto255.t_DHPublicKey)
         (f_fetch_keypair_pre x0)
         (fun result -> f_fetch_keypair_post x0 result);
-  f_message_auth_key_pre:v_Self -> Type0;
-  f_message_auth_key_post:v_Self -> Securedrop_protocol_minimal.Message.t_MessagePrivateKey -> Type0;
-  f_message_auth_key:x0: v_Self
-    -> Prims.Pure Securedrop_protocol_minimal.Message.t_MessagePrivateKey
-        (f_message_auth_key_pre x0)
-        (fun result -> f_message_auth_key_post x0 result);
-  f_own_message_auth_pk_pre:v_Self -> Type0;
-  f_own_message_auth_pk_post:v_Self -> Securedrop_protocol_minimal.Message.t_MessagePublicKey
+  f_message_auth_keypair_pre:v_Self -> Type0;
+  f_message_auth_keypair_post:v_Self -> Securedrop_protocol_minimal.Message.t_MessageKeyPair
     -> Type0;
-  f_own_message_auth_pk:x0: v_Self
-    -> Prims.Pure Securedrop_protocol_minimal.Message.t_MessagePublicKey
-        (f_own_message_auth_pk_pre x0)
-        (fun result -> f_own_message_auth_pk_post x0 result);
+  f_message_auth_keypair:x0: v_Self
+    -> Prims.Pure Securedrop_protocol_minimal.Message.t_MessageKeyPair
+        (f_message_auth_keypair_pre x0)
+        (fun result -> f_message_auth_keypair_post x0 result);
   f_build_message_pre:v_Self -> Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global -> Type0;
   f_build_message_post:
       v_Self ->

--- a/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
+++ b/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
@@ -34,16 +34,23 @@ where
     Recipient: UserPublic + ?Sized,
 {
     // spec: sk_S^APKE - sender's long-term APKE private key
-    let sk_s = sender.message_auth_key();
+    let keypair_s = sender.message_auth_keypair();
+    let pk_s = sender.message_auth_keypair().public_key();
     // spec: pk_R^APKE - recipient's APKE public key
     let pk_r = recipient.message_enc_pk();
     // spec: pk_R^fetch
-    let pk_r_fetch = recipient.fetch_pk().into_bytes();
+    let pk_r_fetch = recipient.fetch_pk();
 
     // spec: ct^APKE = SD-APKE.AuthEnc(sk_S^APKE, pk_R^APKE, pt, NR, pk_R^fetch)
-    let ct_apke =
-        crate::message::auth_enc(rng, sk_s, pk_r, &plaintext.to_bytes(), NR_ID, &pk_r_fetch)
-            .expect("SD-APKE AuthEnc failed");
+    let ct_apke = crate::message::auth_enc(
+        rng,
+        keypair_s,
+        pk_r,
+        &plaintext.to_bytes(),
+        NR_ID,
+        &pk_r_fetch,
+    )
+    .expect("SD-APKE AuthEnc failed");
 
     // Hint (X, Z): X = g^x, Z = (pk_R^fetch)^x for a fresh ephemeral scalar x
     // spec: x (hint_esk), X (hint_epk)
@@ -56,7 +63,7 @@ where
     // TODO: Refactor to return Result<T, E> instead of panicking at failed metadata seal
     let ct_pke = metadata::encrypt(
         recipient.message_metadata_pk(),
-        &sender.own_message_auth_pk(),
+        &sender.message_auth_keypair().public_key(),
     )
     .expect("Valid Keybundle should allow metadata seal");
 
@@ -97,7 +104,7 @@ pub fn decrypt_with_sender<U: UserSecret + ?Sized>(
         .expect("Metadata must contain valid sender APKE key tuple");
 
     // spec: pk_R^fetch
-    let pk_r_fetch = receiver.fetch_keypair().1.into_bytes();
+    let pk_r_fetch = receiver.fetch_keypair().1;
 
     // spec: pt = SD-APKE.AuthDec(sk_R^APKE, pk_S^APKE, ct^APKE, NR, pk_R^fetch)
     let pt = crate::message::auth_dec(

--- a/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
+++ b/securedrop-protocol/protocol-minimal/src/encrypt_decrypt.rs
@@ -35,7 +35,6 @@ where
 {
     // spec: sk_S^APKE - sender's long-term APKE private key
     let keypair_s = sender.message_auth_keypair();
-    let pk_s = sender.message_auth_keypair().public_key();
     // spec: pk_R^APKE - recipient's APKE public key
     let pk_r = recipient.message_enc_pk();
     // spec: pk_R^fetch
@@ -48,7 +47,7 @@ where
         pk_r,
         &plaintext.to_bytes(),
         NR_ID,
-        &pk_r_fetch,
+        pk_r_fetch,
     )
     .expect("SD-APKE AuthEnc failed");
 
@@ -61,11 +60,8 @@ where
     // spec: pk_S^APKE - sender's long-term APKE public key
     // spec: ct^PKE = SD-PKE.Enc(pk_R^PKE, pk_S^APKE)
     // TODO: Refactor to return Result<T, E> instead of panicking at failed metadata seal
-    let ct_pke = metadata::encrypt(
-        recipient.message_metadata_pk(),
-        &sender.message_auth_keypair().public_key(),
-    )
-    .expect("Valid Keybundle should allow metadata seal");
+    let ct_pke = metadata::encrypt(recipient.message_metadata_pk(), &keypair_s.public_key())
+        .expect("Valid Keybundle should allow metadata seal");
 
     Envelope {
         ct_apke,                 // spec: ct^APKE
@@ -112,7 +108,7 @@ pub fn decrypt_with_sender<U: UserSecret + ?Sized>(
         &sender_pk,                // spec: pk_S^APKE
         &envelope.ct_apke,         // spec: ct^APKE
         NR_ID,                     // spec: NR
-        &pk_r_fetch,               // spec: pk_R^fetch
+        pk_r_fetch,                // spec: pk_R^fetch
     )
     .expect("SD-APKE AuthDec failed");
 

--- a/securedrop-protocol/protocol-minimal/src/journalist.rs
+++ b/securedrop-protocol/protocol-minimal/src/journalist.rs
@@ -149,12 +149,8 @@ impl UserSecret for Journalist {
         (&self.fetch_key.sk, &self.fetch_key.pk)
     }
 
-    fn message_auth_key(&self) -> &crate::message::MessagePrivateKey {
-        self.reply_apke.private_key()
-    }
-
-    fn own_message_auth_pk(&self) -> &MessagePublicKey {
-        self.reply_apke.public_key()
+    fn message_auth_keypair(&self) -> &MessageKeyPair {
+        &self.reply_apke
     }
 
     fn build_message(&self, message: Vec<u8>) -> Plaintext {

--- a/securedrop-protocol/protocol-minimal/src/message.rs
+++ b/securedrop-protocol/protocol-minimal/src/message.rs
@@ -288,9 +288,11 @@ pub fn auth_enc<R: RngCore + CryptoRng>(
     let pkr1: HpkePublicKey = pk.dhakem.clone().into();
     let sks1: HpkePrivateKey = sk.private_key().dhakem.clone().into();
 
+    // pskAPKE info param = c2 || pkR_fetch || pkS
     let mut full_info = Vec::new();
     full_info.extend_from_slice(&c2);
     full_info.extend_from_slice(&info_incl.into_bytes());
+    full_info.extend_from_slice(&sk.public_key().as_bytes());
 
     let (c1_vec, cp) = hpke
         .seal(
@@ -336,13 +338,15 @@ pub fn auth_dec(
     let k2 = MlKem768::decaps(&ct.c2, sk.mlkem.as_bytes())
         .map_err(|e| anyhow::anyhow!("ML-KEM decapsulation failed: {:?}", e))?;
 
-    // m = pskADec(pkS=pkS1, skR=skR1, psk=K2, c1=c1, cp=cp, ad=ad, info=c2+info)
+    // m = pskADec(pkS=pkS1, skR=skR1, psk=K2, c1=c1, cp=cp, ad=ad, info=c2+info+pkS)
     let skr1: HpkePrivateKey = sk.dhakem.clone().into();
     let pks1: HpkePublicKey = pk.dhakem.clone().into();
 
+    // c2 + info + pkS
     let mut full_info = Vec::new();
     full_info.extend_from_slice(&ct.c2);
     full_info.extend_from_slice(&info_incl.into_bytes());
+    full_info.extend_from_slice(&pk.as_bytes());
 
     hpke.open(
         &ct.c1,

--- a/securedrop-protocol/protocol-minimal/src/message.rs
+++ b/securedrop-protocol/protocol-minimal/src/message.rs
@@ -258,7 +258,7 @@ pub(crate) fn deterministic_keygen(
 
 /// SD-APKE.AuthEnc: encrypt message `m` from sender to recipient.
 ///
-/// - `sk = (skS1, skS2)`: sender's SD-APKE private key
+/// - `kp = ((skS1, skS2), (pkS1, pkS2))`: sender's SD-APKE keypair
 /// - `pk = (pkR1, pkR2)`: recipient's SD-APKE public key
 /// - `ad`: associated data
 /// - `info_incl`: additional opaque bytes to include in info param, currently receiver's fetch key.
@@ -268,7 +268,7 @@ pub(crate) fn deterministic_keygen(
 /// Returns an error if ML-KEM encapsulation or HPKE sealing fails.
 pub fn auth_enc<R: RngCore + CryptoRng>(
     rng: &mut R,
-    sk: &MessageKeyPair,   // (skS1, skS2)
+    kp: &MessageKeyPair,   // ((skS1, skS2), (pkS1, pkS2))
     pk: &MessagePublicKey, // (pkR1, pkR2)
     m: &[u8],
     ad: &[u8], // Todo: should always be empty
@@ -286,13 +286,13 @@ pub fn auth_enc<R: RngCore + CryptoRng>(
 
     // (c1, cp) = pskAEnc(skS=skS1, pkR=pkR1, psk=K2, m=m, ad=ad, info=c2+info)
     let pkr1: HpkePublicKey = pk.dhakem.clone().into();
-    let sks1: HpkePrivateKey = sk.private_key().dhakem.clone().into();
+    let sks1: HpkePrivateKey = kp.private_key().dhakem.clone().into();
 
     // pskAPKE info param = c2 || pkR_fetch || pkS
     let mut full_info = Vec::new();
     full_info.extend_from_slice(&c2);
     full_info.extend_from_slice(&info_incl.into_bytes());
-    full_info.extend_from_slice(&sk.public_key().as_bytes());
+    full_info.extend_from_slice(&kp.pk.as_bytes());
 
     let (c1_vec, cp) = hpke
         .seal(
@@ -320,7 +320,7 @@ pub fn auth_enc<R: RngCore + CryptoRng>(
 /// - `sk = (skR1, skR2)`: recipient's SD-APKE private key
 /// - `pk = (pkS1, pkS2)`: sender's SD-APKE public key
 /// - `ad`: associated data
-/// - `info`: caller-supplied info (spec prepends `c2` internally: `info = c2 + info`)
+/// - `info_incl`: caller-supplied info (spec prepends `c2` internally: `info = c2 + info`)
 ///
 /// # Errors
 ///
@@ -338,7 +338,7 @@ pub fn auth_dec(
     let k2 = MlKem768::decaps(&ct.c2, sk.mlkem.as_bytes())
         .map_err(|e| anyhow::anyhow!("ML-KEM decapsulation failed: {:?}", e))?;
 
-    // m = pskADec(pkS=pkS1, skR=skR1, psk=K2, c1=c1, cp=cp, ad=ad, info=c2+info+pkS)
+    // m = pskADec(pkS=pkS1, skR=skR1, psk=K2, c1=c1, cp=cp, ad=ad, info_incl=c2+info+pkS)
     let skr1: HpkePrivateKey = sk.dhakem.clone().into();
     let pks1: HpkePublicKey = pk.dhakem.clone().into();
 
@@ -409,7 +409,7 @@ mod tests {
         let mut rng = get_rng();
         let sender_kp = keygen(&mut rng).expect("KGen failed");
         let recipient_kp = keygen(&mut rng).expect("KGen failed");
-        let receipient_fetch = generate_dh_keypair(&mut rng).1;
+        let recipient_fetch = generate_dh_keypair(&mut rng).1;
         let wrong_kp = keygen(&mut rng).expect("KGen failed");
 
         let ct = auth_enc(
@@ -418,7 +418,7 @@ mod tests {
             recipient_kp.public_key(),
             b"secret",
             b"ad",
-            &receipient_fetch,
+            &recipient_fetch,
         )
         .expect("AuthEnc failed");
 
@@ -428,7 +428,7 @@ mod tests {
                 sender_kp.public_key(),
                 &ct,
                 b"ad",
-                &receipient_fetch,
+                &recipient_fetch,
             )
             .is_err()
         );

--- a/securedrop-protocol/protocol-minimal/src/message.rs
+++ b/securedrop-protocol/protocol-minimal/src/message.rs
@@ -26,6 +26,7 @@ use crate::primitives::provider::hpke_rs::{
 };
 use crate::primitives::provider::kem::MlKem768;
 use crate::primitives::provider::traits::OwnedKem as Kem;
+use crate::primitives::ristretto255::DHPublicKey;
 use alloc::string::String;
 use alloc::vec::Vec;
 use anyhow::Error;
@@ -260,18 +261,18 @@ pub(crate) fn deterministic_keygen(
 /// - `sk = (skS1, skS2)`: sender's SD-APKE private key
 /// - `pk = (pkR1, pkR2)`: recipient's SD-APKE public key
 /// - `ad`: associated data
-/// - `info`: caller-supplied info (spec prepends `c2` internally: `info = c2 + info`)
+/// - `info_incl`: additional opaque bytes to include in info param, currently receiver's fetch key.
 ///
 /// # Errors
 ///
 /// Returns an error if ML-KEM encapsulation or HPKE sealing fails.
 pub fn auth_enc<R: RngCore + CryptoRng>(
     rng: &mut R,
-    sk: &MessagePrivateKey, // (skS1, skS2)
-    pk: &MessagePublicKey,  // (pkR1, pkR2)
+    sk: &MessageKeyPair,   // (skS1, skS2)
+    pk: &MessagePublicKey, // (pkR1, pkR2)
     m: &[u8],
-    ad: &[u8],
-    info: &[u8],
+    ad: &[u8], // Todo: should always be empty
+    info_incl: &DHPublicKey,
 ) -> Result<MessageCiphertext, Error> {
     let mut hpke =
         Hpke::<HpkeLibcrux>::new(Mode::AuthPsk, DhKem25519, HkdfSha256, ChaCha20Poly1305);
@@ -285,11 +286,11 @@ pub fn auth_enc<R: RngCore + CryptoRng>(
 
     // (c1, cp) = pskAEnc(skS=skS1, pkR=pkR1, psk=K2, m=m, ad=ad, info=c2+info)
     let pkr1: HpkePublicKey = pk.dhakem.clone().into();
-    let sks1: HpkePrivateKey = sk.dhakem.clone().into();
+    let sks1: HpkePrivateKey = sk.private_key().dhakem.clone().into();
 
     let mut full_info = Vec::new();
     full_info.extend_from_slice(&c2);
-    full_info.extend_from_slice(info);
+    full_info.extend_from_slice(&info_incl.into_bytes());
 
     let (c1_vec, cp) = hpke
         .seal(
@@ -327,7 +328,7 @@ pub fn auth_dec(
     pk: &MessagePublicKey,  // (pkS1, pkS2)
     ct: &MessageCiphertext,
     ad: &[u8],
-    info: &[u8],
+    info_incl: &DHPublicKey,
 ) -> Result<Vec<u8>, Error> {
     let hpke = Hpke::<HpkeLibcrux>::new(Mode::AuthPsk, DhKem25519, HkdfSha256, ChaCha20Poly1305);
 
@@ -341,7 +342,7 @@ pub fn auth_dec(
 
     let mut full_info = Vec::new();
     full_info.extend_from_slice(&ct.c2);
-    full_info.extend_from_slice(info);
+    full_info.extend_from_slice(&info_incl.into_bytes());
 
     hpke.open(
         &ct.c1,
@@ -358,6 +359,8 @@ pub fn auth_dec(
 
 #[cfg(test)]
 mod tests {
+    use crate::primitives::ristretto255::generate_dh_keypair;
+
     use super::*;
     use proptest::prelude::*;
     use rand_chacha::ChaCha20Rng;
@@ -374,23 +377,23 @@ mod tests {
         fn test_auth_enc_dec_roundtrip(
             m in proptest::collection::vec(any::<u8>(), 0..200),
             ad in proptest::collection::vec(any::<u8>(), 0..64),
-            info in proptest::collection::vec(any::<u8>(), 0..64),
         ) {
             let mut rng = get_rng();
             let sender_kp = keygen(&mut rng).expect("KGen failed");
             let recipient_kp = keygen(&mut rng).expect("KGen failed");
+            let dh_fetch = generate_dh_keypair(&mut rng).1;
 
             let ct = auth_enc(
                 &mut rng,
-                sender_kp.private_key(),
+                &sender_kp,
                 recipient_kp.public_key(),
-                &m, &ad, &info,
+                &m, &ad, &dh_fetch,
             ).expect("AuthEnc failed");
 
             let decrypted = auth_dec(
                 recipient_kp.private_key(),
                 sender_kp.public_key(),
-                &ct, &ad, &info,
+                &ct, &ad, &dh_fetch,
             ).expect("AuthDec failed");
 
             prop_assert_eq!(m, decrypted);
@@ -402,15 +405,16 @@ mod tests {
         let mut rng = get_rng();
         let sender_kp = keygen(&mut rng).expect("KGen failed");
         let recipient_kp = keygen(&mut rng).expect("KGen failed");
+        let receipient_fetch = generate_dh_keypair(&mut rng).1;
         let wrong_kp = keygen(&mut rng).expect("KGen failed");
 
         let ct = auth_enc(
             &mut rng,
-            sender_kp.private_key(),
+            &sender_kp,
             recipient_kp.public_key(),
             b"secret",
             b"ad",
-            b"info",
+            &receipient_fetch,
         )
         .expect("AuthEnc failed");
 
@@ -420,7 +424,7 @@ mod tests {
                 sender_kp.public_key(),
                 &ct,
                 b"ad",
-                b"info",
+                &receipient_fetch,
             )
             .is_err()
         );

--- a/securedrop-protocol/protocol-minimal/src/source.rs
+++ b/securedrop-protocol/protocol-minimal/src/source.rs
@@ -95,12 +95,8 @@ impl UserSecret for Source {
         (&self.fetch_key.sk, &self.fetch_key.pk)
     }
 
-    fn message_auth_key(&self) -> &crate::message::MessagePrivateKey {
-        self.message_keys.apke.private_key()
-    }
-
-    fn own_message_auth_pk(&self) -> &crate::message::MessagePublicKey {
-        self.message_keys.apke.public_key()
+    fn message_auth_keypair(&self) -> &crate::message::MessageKeyPair {
+        &self.message_keys.apke
     }
 
     fn build_message(&self, message: Vec<u8>) -> Plaintext {

--- a/securedrop-protocol/protocol-minimal/src/traits.rs
+++ b/securedrop-protocol/protocol-minimal/src/traits.rs
@@ -83,7 +83,7 @@ pub trait UserSecret: sealed::Sealed {
 pub trait UserSecret {
     fn num_bundles(&self) -> usize;
     fn fetch_keypair(&self) -> (&DHPrivateKey, &DHPublicKey);
-    /// The long-term SD-APKE keypair (`sk^APKE`, `pk&APKE`).
+    /// The long-term SD-APKE keypair (`sk^APKE`, `pk^APKE`).
     fn message_auth_keypair(&self) -> &MessageKeyPair;
     fn build_message(&self, message: Vec<u8>) -> Plaintext;
     fn keybundles(&self) -> Vec<&MessageKeyBundle>;

--- a/securedrop-protocol/protocol-minimal/src/traits.rs
+++ b/securedrop-protocol/protocol-minimal/src/traits.rs
@@ -1,5 +1,6 @@
 use crate::VerifyingKey;
-use crate::message::{MessagePrivateKey, MessagePublicKey};
+use crate::message::MessageKeyPair;
+use crate::message::MessagePublicKey;
 use crate::metadata::MetadataPublicKey;
 use crate::primitives::ristretto255::DHPrivateKey;
 use crate::primitives::ristretto255::DHPublicKey;
@@ -72,10 +73,8 @@ pub trait Enrollable {
 pub trait UserSecret: sealed::Sealed {
     fn num_bundles(&self) -> usize;
     fn fetch_keypair(&self) -> (&DHPrivateKey, &DHPublicKey);
-    /// The long-term SD-APKE private key `sk^APKE`.
-    fn message_auth_key(&self) -> &MessagePrivateKey;
-    /// The holder's own long-term SD-APKE public key `pk^APKE`.
-    fn own_message_auth_pk(&self) -> &MessagePublicKey;
+    /// The long-term SD-APKE keypair (`sk^APKE`, `pk^APKE`)
+    fn message_auth_keypair(&self) -> &MessageKeyPair;
     fn build_message(&self, message: Vec<u8>) -> Plaintext;
     fn keybundles(&self) -> Vec<&MessageKeyBundle>;
 }
@@ -84,10 +83,8 @@ pub trait UserSecret: sealed::Sealed {
 pub trait UserSecret {
     fn num_bundles(&self) -> usize;
     fn fetch_keypair(&self) -> (&DHPrivateKey, &DHPublicKey);
-    /// The long-term SD-APKE private key `sk^APKE`.
-    fn message_auth_key(&self) -> &MessagePrivateKey;
-    /// The holder's own long-term SD-APKE public key `pk^APKE`.
-    fn own_message_auth_pk(&self) -> &MessagePublicKey;
+    /// The long-term SD-APKE keypair (`sk^APKE`, `pk&APKE`).
+    fn message_auth_keypair(&self) -> &MessageKeyPair;
     fn build_message(&self, message: Vec<u8>) -> Plaintext;
     fn keybundles(&self) -> Vec<&MessageKeyBundle>;
 }

--- a/securedrop-protocol/protocol-minimal/tests/core.rs
+++ b/securedrop-protocol/protocol-minimal/tests/core.rs
@@ -118,7 +118,7 @@ fn protocol_step_5_source_fetch_keys() {
     // Verify the journalist's message (APKE) key matches our expectation
     assert_eq!(
         journalist_view.message_auth_pk().as_bytes(),
-        journalist.own_message_auth_pk().as_bytes()
+        journalist.message_auth_keypair().public_key().as_bytes()
     );
 
     // Verify that ephemeral keys were consumed (deleted from server storage)


### PR DESCRIPTION
Closes #246 
Refs #331 

-  (refactor) Return MessageKeyPair instead of two separate UserSecret methods for pubkey and private key, then adjust `message::auth_enc` to take sender &MessageKeyPair instead of just the private key
- (refactor) specify DHPublicKey instead of &[u8] for info_incl param in `message::auth_enc`. (As in that pr, this param has also been renamed to match #331 and disambiguate it from the final `info` param that is passed to hpke sealauthpsk) 
-  Commit to full sender apke pubkey in `auth_enc` 
- Update hax extraction

# Test Plan
- Visual review
- Changes match spec 
- CI(+ hax ci) passing