### PR TITLE
CI: Reduce hax workflow runs: daily or relevant changes

### DIFF
--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -1,6 +1,19 @@
 name: hax
 
-on: [push, pull_request]
+# Schedule this workflow once a day or when there are changes to relevant files
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  push:
+    paths:
+      - securedrop-protocol/Cargo.lock
+      - securedrop-protocol/protocol-minimal/proofs/**
+      - securedrop-protocol/protocol-minimal/src/**
+  pull_request:
+    paths:
+      - securedrop-protocol/Cargo.lock
+      - securedrop-protocol/protocol-minimal/proofs/**
+      - securedrop-protocol/protocol-minimal/src/**
 
 permissions:
   contents: read


### PR DESCRIPTION
GHA: run hax workflow once every 24h, or on push/pr changes to protocol-minimal crate or entire workspace Cargo.toml. The latter still means more runs than we probably need, but without getting too fancy this should save some runs when unrelated parts of the code change.

Closes #322 

### Test plan
- Visual Review
- CI 
- Compare this GHA run (no hax workflow) with the run for this temporary branch (https://github.com/freedomofpress/securedrop-protocol/compare/DNM-ci-optimization-see-hax-run?expand=1), which has changes to the protocol-minimal/proofs directory (just a flag) and therefore triggers the hax github actions as well: [GHA run is here](https://github.com/freedomofpress/securedrop-protocol/actions/runs/31815968366/job/94817604405)