### PR TITLE
CI: separate wasm benchmarks workflow, run as-needed

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,7 @@ name: Rust CI
 
 on: [push, pull_request]
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
   check:
@@ -23,8 +21,8 @@ jobs:
       # Swatinem/rust-cache@v2.8.0
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
         with:
-          # wasm-bindgen-cli version change should invalidate cache too
-          prefix-key: ${{ hashFiles('securedrop-protocol/bench/Makefile') }}
+          prefix-key: "native"
+          add-job-id-key: false
       # dtolnay/rust-toolchain@30dc51db75d080812bc4a28ba3f342840b2e7dd7
       - run: cargo check
         working-directory: securedrop-protocol
@@ -44,7 +42,8 @@ jobs:
       # Swatinem/rust-cache@v2.8.0
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
         with:
-          prefix-key: ${{ hashFiles('securedrop-protocol/bench/Makefile') }}
+          prefix-key: "native"
+          add-job-id-key: false
       # dtolnay/rust-toolchain@30dc51db75d080812bc4a28ba3f342840b2e7dd7
       - run: cargo test --all-features
         working-directory: securedrop-protocol
@@ -69,7 +68,8 @@ jobs:
       # Swatinem/rust-cache@v2.8.0
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
         with:
-          prefix-key: ${{ hashFiles('securedrop-protocol/bench/Makefile') }}
+          prefix-key: "native"
+          add-job-id-key: false
       # dtolnay/rust-toolchain@30dc51db75d080812bc4a28ba3f342840b2e7dd7
       - run: cargo fmt --all --check
         working-directory: securedrop-protocol
@@ -90,41 +90,13 @@ jobs:
       # Swatinem/rust-cache@v2.8.0
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
         with:
-          prefix-key: ${{ hashFiles('securedrop-protocol/bench/Makefile') }}
+          prefix-key: "native"
+          add-job-id-key: false
       - run: make clippy
 
-  check_wasm_bindgen:
-    name: Pin same version of wasm-bindgen and wasm-bindgen-cli
+  protocol_minimal_wasm32:
+    name: Compile core crate for wasm32-unknown-unknown
     runs-on: ubuntu-latest
-    steps:
-      # actions/checkout@4.1.1
-      - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
-        with:
-          persist-credentials: false
-      - name: Compare Makefile wasm-bindgen-cli and Cargo.toml wasm-bindgen versions
-        run: |
-          set -euo pipefail
-
-          CARGO_VERSION=$(grep -E '^wasm-bindgen\s*=' securedrop-protocol/Cargo.toml \
-            | sed -E 's/.*"=?([^"]+)".*/\1/')
-
-          MAKEFILE_VERSION=$(grep -E '^WASM_BINDGEN_CLI_VERSION\s*:=' securedrop-protocol/bench/Makefile \
-            | awk '{print $3}')
-
-          echo "wasm-bindgen crate version: $CARGO_VERSION"
-          echo "wasm-bindgen CLI version:   $MAKEFILE_VERSION"
-
-          if [ "$CARGO_VERSION" != "$MAKEFILE_VERSION" ]; then
-            echo "Error: wasm-bindgen version mismatch."
-            echo "Cargo.toml uses wasm-bindgen = \"$CARGO_VERSION\""
-            echo "Makefile uses WASM_BINDGEN_CLI_VERSION := $MAKEFILE_VERSION"
-            exit 1
-          fi
-
-  build_wasm:
-    name: wasm build
-    runs-on: ubuntu-latest
-    needs: [check_wasm_bindgen]
     steps:
       # actions/checkout@4.1.1
       - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
@@ -135,73 +107,12 @@ jobs:
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown
-      # Swatinem/rust-cache@v2.8.0
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
         with:
-          # wasm-bindgen-cli version change should invalidate cache too
-          prefix-key: ${{ hashFiles('securedrop-protocol/bench/Makefile') }}
-      # dtolnay/rust-toolchain@30dc51db75d080812bc4a28ba3f342840b2e7dd7
-      - name: Cache node and selenium dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            securedrop-protocol/bench/.selenium-cache
-            securedrop-protocol/bench/node_modules
-          key: node-${{ runner.os }}-${{ hashFiles('securedrop-protocol/bench/package-lock.json') }}-${{ github.run_id }}
-          restore-keys: node-${{ runner.os }}-${{ hashFiles('securedrop-protocol/bench/package-lock.json') }}-
-      - name: Cache wasm and Rust artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            securedrop-protocol/target
-            securedrop-protocol/bench/pkg
-          key: wasm-rust-target-${{ runner.os }}-${{ github.run_id }}
-          restore-keys: wasm-rust-target-${{ runner.os }}-${{ github.run_id }}
-      - name: Ensure wasm-bindgen is available
-        run: make rust-target
-        working-directory: securedrop-protocol/bench
-      - name: Compile protocol-minimal wasm32-unknown-unknown
-        run: make core-wasm
-      - name: Build wasm32-unknown-unknown benchmark crate and wasm artifacts
-        run: make build
-        working-directory: securedrop-protocol/bench
-
-  quick_bench:
-    name: Run native and browser benchmarks (quick-bench)
-    runs-on: ubuntu-latest
-    needs: [build_wasm, check_wasm_bindgen]
-    steps:
-      - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
-        with:
-          persist-credentials: false
-      - name: Setup Node
-        # action v6.3.0, most recent with passing CI suite
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
-        with:
-          node-version-file: securedrop-protocol/bench/.nvmrc
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@30dc51db75d080812bc4a28ba3f342840b2e7dd7
-        with:
-          toolchain: stable
-      - name: Restore node and selenium artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            securedrop-protocol/bench/node_modules
-            securedrop-protocol/bench/.selenium-cache
-          key: node-${{ runner.os }}-${{ hashFiles('securedrop-protocol/bench/package-lock.json') }}-${{ github.run_id }}
-          restore-keys: node-${{ runner.os }}-${{ hashFiles('securedrop-protocol/bench/package-lock.json') }}-
-      - name: Restore wasm and Rust artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            securedrop-protocol/target
-            securedrop-protocol/bench/pkg
-          key: wasm-rust-target-${{ runner.os }}-${{ github.run_id }}
-          restore-keys: wasm-rust-target-${{ runner.os }}-${{ github.run_id }}
-      - name: Install wasm-bindgen + target
-        run: make rust-target
-        working-directory: securedrop-protocol/bench
-      - name: Run quick bench
-        run: make quick-bench
-        working-directory: securedrop-protocol/bench
+          # Use these keys to reuse cache in other workflows, such as wasm.yml
+          prefix-key: wasm
+          # wasm-bindgen-cli version change in Makefile should invalidate cache
+          key: ${{ hashFiles('securedrop-protocol/bench/Makefile') }}
+          add-job-id-key: false
+      - run: |
+          make core-wasm

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,137 @@
+name: WASM Build and benchmarks
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # daily
+  push:
+    paths:
+      - securedrop-protocol/Cargo.toml
+      - securedrop-protocol/bench/**
+  pull_request:
+    paths:
+      - securedrop-protocol/Cargo.toml
+      - securedrop-protocol/bench/**
+
+permissions: {}
+
+jobs:
+  check_wasm_bindgen:
+    name: Pin same version of wasm-bindgen and wasm-bindgen-cli
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@4.1.1
+      - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
+        with:
+          persist-credentials: false
+      - name: Compare Makefile wasm-bindgen-cli and Cargo.toml wasm-bindgen versions
+        run: |
+          set -euo pipefail
+
+          CARGO_VERSION=$(grep -E '^wasm-bindgen\s*=' securedrop-protocol/Cargo.toml \
+            | sed -E 's/.*"=?([^"]+)".*/\1/')
+
+          MAKEFILE_VERSION=$(grep -E '^WASM_BINDGEN_CLI_VERSION\s*:=' securedrop-protocol/bench/Makefile \
+            | awk '{print $3}')
+
+          echo "wasm-bindgen crate version: $CARGO_VERSION"
+          echo "wasm-bindgen CLI version:   $MAKEFILE_VERSION"
+
+          if [ "$CARGO_VERSION" != "$MAKEFILE_VERSION" ]; then
+            echo "Error: wasm-bindgen version mismatch."
+            echo "Cargo.toml uses wasm-bindgen = \"$CARGO_VERSION\""
+            echo "Makefile uses WASM_BINDGEN_CLI_VERSION := $MAKEFILE_VERSION"
+            exit 1
+          fi
+
+  build_wasm:
+    name: wasm build
+    runs-on: ubuntu-latest
+    needs: [check_wasm_bindgen]
+    steps:
+      # actions/checkout@4.1.1
+      - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
+        with:
+          persist-credentials: false
+      # dtolnay/rust-toolchain@30dc51db75d080812bc4a28ba3f342840b2e7dd7
+      - uses: dtolnay/rust-toolchain@30dc51db75d080812bc4a28ba3f342840b2e7dd7
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+      # Swatinem/rust-cache@v2.8.0
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
+        with:
+          # Note: keep key consistent with rust.yml protocol_minimal_wasm32 cache
+          prefix-key: wasm
+          key: ${{ hashFiles('securedrop-protocol/bench/Makefile') }}
+          add-job-id-key: false
+          # Don't race to create the cache
+          save-if: false
+      # dtolnay/rust-toolchain@30dc51db75d080812bc4a28ba3f342840b2e7dd7
+      - name: Cache node and selenium dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            securedrop-protocol/bench/.selenium-cache
+            securedrop-protocol/bench/node_modules
+          key: node-${{ runner.os }}-${{ hashFiles('securedrop-protocol/bench/package-lock.json') }}-${{ github.run_id }}
+          restore-keys: node-${{ runner.os }}-${{ hashFiles('securedrop-protocol/bench/package-lock.json') }}-
+      - name: Cache wasm artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            securedrop-protocol/bench/pkg
+          key: wasm-rust-target-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: wasm-rust-target-${{ runner.os }}-${{ github.run_id }}
+      - name: Ensure wasm-bindgen is available
+        run: make rust-target
+        working-directory: securedrop-protocol/bench
+      - name: Compile protocol-minimal wasm32-unknown-unknown
+        run: make core-wasm
+      - name: Build wasm32-unknown-unknown benchmark crate and wasm artifacts
+        run: make build
+        working-directory: securedrop-protocol/bench
+
+  quick_bench:
+    name: Run native and browser benchmarks (quick-bench)
+    runs-on: ubuntu-latest
+    needs: [build_wasm, check_wasm_bindgen]
+    steps:
+      - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
+        with:
+          persist-credentials: false
+      - name: Setup Node
+        # action v6.3.0, most recent with passing CI suite
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: securedrop-protocol/bench/.nvmrc
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@30dc51db75d080812bc4a28ba3f342840b2e7dd7
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
+        with:
+          prefix-key: wasm
+          key: ${{ hashFiles('project-protocol/bench/Makefile') }}
+          add-job-id-key: false
+          save-if: false
+      - name: Restore node and selenium artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            securedrop-protocol/bench/node_modules
+            securedrop-protocol/bench/.selenium-cache
+          key: node-${{ runner.os }}-${{ hashFiles('securedrop-protocol/bench/package-lock.json') }}-${{ github.run_id }}
+          restore-keys: node-${{ runner.os }}-${{ hashFiles('securedrop-protocol/bench/package-lock.json') }}-
+      - name: Restore wasm artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            securedrop-protocol/bench/pkg
+          key: wasm-rust-target-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: wasm-rust-target-${{ runner.os }}-${{ github.run_id }}
+      - name: Install wasm-bindgen + target
+        run: make rust-target
+        working-directory: securedrop-protocol/bench
+      - name: Run quick bench
+        run: make quick-bench
+        working-directory: securedrop-protocol/bench


### PR DESCRIPTION
- Add wasm32-unknown-unknown compilation for main protocol crate in rust.yml, then move all other wasm benchmarks ci to wasm.yml file and run it only as needed (currently: if bench crate changes, if workspace dependencies change, and once every 24h. See #340 for similar schedule for hax workflow).  
- Improve GHA caching behaviour: cache wasm32 and native builds separately, cache across workflow runs unless dependencies or other configuration changes. 
- Remove unneeded read permissions on workflow

TODO: (infra or GH owner permissions required): `build_wasm` is configured as a required workflow; that should be renamed to `protocol_minimal_wasm32` ("Compile the core securedrop-protocol-minimal crate for wasm32-unknown-unknown") in rust.yml.

### Test plan 
- Visual review
- CI passing
- Inspect test branch (has a flag designed to trigger wasm bench workflow), see that wasm.yml workflow is run and it succeeds https://github.com/freedomofpress/securedrop-protocol/compare/DNM-ci-optimization-wasm-workflow-triggered?expand=1 , [GHA wasm run is here](https://github.com/freedomofpress/securedrop-protocol/actions/runs/31878474655)