### PR TITLE
docs: recommend LLM spell/type-checking before substantive review

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -11,6 +11,9 @@
 - Names of schemes, algorithms, etc. can just be ordinary nouns: "the SD-APKE
   ciphertext", "a journalist's fetching key", HPKE, ML-KEM-768, etc.
 
+NB. LLM (e.g. Copilot) code review is recommended as a kind of
+spell-check/type-check before substantive review of changes.
+
 -->
 
 # SecureDrop Protocol specification


### PR DESCRIPTION
I've found LLMs (both locally and in GitHub's Copilot code review) to be very helpful in both "spell-checking" (Is that what I meant?) and "type-checking" (Have I contradicted something else here?) the protocol specification, especially across different idioms and styles of notation.

I'm suggesting this recommendation here because I think of this much like static analysis and other linting for code: It's better to do before changes get merged; it's better to do so before spending time reviewing the substance of changes; and (in contrast to substantive review) it's pretty painful to do manually in GitHub.  But this may not be the approach we want to take or recommend, for any of a host of reasons.